### PR TITLE
Bugfix/indexing

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -18,8 +18,6 @@ sort:
   dbSNP.alleleFreqs: min
   refSeq.codonNumber: avg
   refSeq.codonPosition: avg
-booleanFields:
-  - discordant
 post_index_settings:
   index:
     refresh_interval: 15s
@@ -29,8 +27,6 @@ index_settings:
     refresh_interval: -1
     number_of_replicas: 0
     codec: best_compression
-    mapping:
-      single_type: true
   analysis:
     normalizer:
       lowercase_normalizer:

--- a/lib/Seq/Output/Delimiters.pm
+++ b/lib/Seq/Output/Delimiters.pm
@@ -37,7 +37,6 @@ has globalReplaceChar => (is => 'ro', isa => 'Str', default => ',');
 has cleanDelims => (is => 'ro', init_arg => undef, lazy => 1, default => sub {
   my $self = shift;
 
-  # my $aD = $self->alleleDelimiter;
   my $vD = $self->valueDelimiter;
   my $pD = $self->positionDelimiter;
   my $oD = $self->overlapDelimiter;

--- a/python/python/bystro/beanstalkd/worker.py
+++ b/python/python/bystro/beanstalkd/worker.py
@@ -112,7 +112,7 @@ def listen(
                     f"""
                             Job {job_id} JSON does not have the data expected.
                             Expected {job_data_type.keys_with_types()}.
-                            Decoding `{str(job.job_data)}`, failed with: `{err}`"""
+                            Decoding failed with: `{err}`"""
                 )
                 traceback.print_exc()
                 client.put_job(json.encode(failed_msg_fn(job_data, job_id, ValueError(msg))))

--- a/python/python/bystro/search/index/bystro_file.pyx
+++ b/python/python/bystro/search/index/bystro_file.pyx
@@ -30,7 +30,6 @@ cdef class ReadAnnotationTarball:
         str index_name
         int chunk_size
         str field_separator
-        str allele_delimiter
         str position_delimiter
         str overlap_delimiter
         str value_delimiter
@@ -45,7 +44,6 @@ cdef class ReadAnnotationTarball:
         self.index_name = index_name
         self.chunk_size = chunk_size
         self.field_separator = delimiters['field']
-        self.allele_delimiter = delimiters['allele']
         self.position_delimiter = delimiters['position']
         self.overlap_delimiter = delimiters['overlap']
         self.value_delimiter = delimiters['value']

--- a/python/python/bystro/search/index/handler.py
+++ b/python/python/bystro/search/index/handler.py
@@ -88,7 +88,6 @@ async def go(
     client = AsyncOpenSearch(**search_client_args)
 
     post_index_settings = mapping_conf["post_index_settings"]
-    boolean_map: dict[str, bool] = {x: True for x in mapping_conf["booleanFields"]}
 
     index_body: dict[str, dict] = {
         "settings": mapping_conf["index_settings"],
@@ -107,7 +106,6 @@ async def go(
     data = read_annotation_tarball(
         index_name=index_name,
         tar_path=tar_path,
-        boolean_map=boolean_map,
         delimiters=get_delimiters(),
         chunk_size=paralleleism_chunk_size,
     )

--- a/python/python/bystro/search/save/handler.py
+++ b/python/python/bystro/search/save/handler.py
@@ -58,11 +58,14 @@ def _get_header(field_names):
 
 
 def _populate_data(field_path, data_for_end_of_path):
-    if not isinstance(field_path, list):
+    if not isinstance(field_path, list) or data_for_end_of_path is None:
         return data_for_end_of_path
 
     for child_field in field_path:
-        data_for_end_of_path = data_for_end_of_path[child_field]
+        data_for_end_of_path = data_for_end_of_path.get(child_field)
+
+        if data_for_end_of_path is None:
+            return data_for_end_of_path
 
     return data_for_end_of_path
 
@@ -140,7 +143,7 @@ def _process_query(
     for doc in resp["hits"]["hits"]:
         row = np.empty(len(field_names), dtype=object)
         for y in range(len(field_names)):
-            row[y] = _populate_data(child_fields[y], doc["_source"][parent_fields[y]])
+            row[y] = _populate_data(child_fields[y], doc["_source"].get(parent_fields[y]))
 
         if row[discordant_idx][0][0] is False:
             row[discordant_idx][0][0] = 0

--- a/python/python/bystro/search/utils/annotation.py
+++ b/python/python/bystro/search/utils/annotation.py
@@ -39,7 +39,6 @@ class AnnotationOutputs(Struct, frozen=True):
             statistics: Optional[StatisticsOutputs]
                 Basenames of the statistics files, inside the archive
     """
-    output_dir: str
     archived: str
     annotation: str
     sampleList: str
@@ -81,7 +80,6 @@ class AnnotationOutputs(Struct, frozen=True):
             )
 
         return AnnotationOutputs(
-            output_dir=output_dir,
             annotation=annotation,
             sampleList=sampleList,
             statistics=statistics,

--- a/python/python/bystro/search/utils/annotation.py
+++ b/python/python/bystro/search/utils/annotation.py
@@ -92,7 +92,6 @@ class AnnotationOutputs(Struct, frozen=True):
 
 _default_delimiters = {
     "field": "\t",
-    "allele": "/",
     "position": "|",
     "overlap": chr(31),
     "value": ";",


### PR DESCRIPTION
CHANGELOG:
* Brings annotation file parsing (during indexing) up to date with master branch's lib/SeqFromQuery.pm

Will add tests in a future PR, can be tested manually from annotation instance by:

```
make develop
f=/seqant/user-data/<omitted>/<omitted>/output/gnomad_genomes_r2_1_1_sites_22_10klines_vcf.tar
python python/python/bystro/search/index/handler.py --tar $f --mapping_conf config/hg38.mapping.yml --search_conf config/opensearch.yml --index_name <your_index_name>
```
[gnomad_genomes_r2_1_1_sites_22_10klines_vcf-3.tar.zip](https://github.com/bystrogenomics/bystro/files/11953926/gnomad_genomes_r2_1_1_sites_22_10klines_vcf-3.tar.zip)
