### PR TITLE
Make ancestry tests eager

### DIFF
--- a/python/python/bystro/ancestry/tests/test_listener.py
+++ b/python/python/bystro/ancestry/tests/test_listener.py
@@ -8,8 +8,6 @@ from bystro.ancestry.listener import AncestryJobData, completed_msg_fn, handler_
 from bystro.beanstalkd.messages import ProgressMessage
 from bystro.beanstalkd.worker import ProgressPublisher
 
-pytest_plugins = ("pytest_asyncio",)
-
 
 def test_handler_fn_happy_path():
     progress_message = ProgressMessage(submissionID="my_submission_id")

--- a/python/python/bystro/ancestry/tests/test_listener.py
+++ b/python/python/bystro/ancestry/tests/test_listener.py
@@ -11,8 +11,7 @@ from bystro.beanstalkd.worker import ProgressPublisher
 pytest_plugins = ("pytest_asyncio",)
 
 
-@pytest.mark.asyncio()
-async def test_handler_fn_happy_path():
+def test_handler_fn_happy_path():
     progress_message = ProgressMessage(submissionID="my_submission_id")
     publisher = ProgressPublisher(
         host="127.0.0.1", port=1234, queue="my_queue", message=progress_message
@@ -21,7 +20,7 @@ async def test_handler_fn_happy_path():
     ancestry_job_data = AncestryJobData(
         submissionID="my_submission_id2", ancestry_submission=ancestry_submission
     )
-    ancestry_response = await handler_fn(publisher, ancestry_job_data)
+    ancestry_response = handler_fn(publisher, ancestry_job_data)
     assert ancestry_submission.vcf_path == ancestry_response.vcf_path
 
 
@@ -34,8 +33,7 @@ def test_submit_msg_fn_happy_path():
     assert submitted_job_message.submissionID == ancestry_job_data.submissionID
 
 
-@pytest.mark.asyncio()
-async def test_completed_msg_fn_happy_path():
+def test_completed_msg_fn_happy_path():
     progress_message = ProgressMessage(submissionID="my_submission_id")
     publisher = ProgressPublisher(
         host="127.0.0.1", port=1234, queue="my_queue", message=progress_message
@@ -46,15 +44,14 @@ async def test_completed_msg_fn_happy_path():
         submissionID="my_submission_id", ancestry_submission=ancestry_submission
     )
 
-    ancestry_response = await handler_fn(publisher, ancestry_job_data)
+    ancestry_response = handler_fn(publisher, ancestry_job_data)
     ancestry_job_complete_message = completed_msg_fn(ancestry_job_data, ancestry_response)
 
     assert ancestry_job_complete_message.submissionID == ancestry_job_data.submissionID
     assert ancestry_job_complete_message.results == ancestry_response
 
 
-@pytest.mark.asyncio()
-async def test_completed_msg_fn_rejects_nonmatching_vcf_paths():
+def test_completed_msg_fn_rejects_nonmatching_vcf_paths():
     progress_message = ProgressMessage(submissionID="my_submission_id")
     publisher = ProgressPublisher(
         host="127.0.0.1", port=1234, queue="my_queue", message=progress_message
@@ -65,7 +62,7 @@ async def test_completed_msg_fn_rejects_nonmatching_vcf_paths():
         submissionID="my_submission_id", ancestry_submission=ancestry_submission
     )
 
-    _correct_but_unused_ancestry_response = await handler_fn(publisher, ancestry_job_data)
+    _correct_but_unused_ancestry_response = handler_fn(publisher, ancestry_job_data)
 
     progress_message = ProgressMessage(submissionID="my_submission_id")
     publisher = ProgressPublisher(
@@ -78,7 +75,7 @@ async def test_completed_msg_fn_rejects_nonmatching_vcf_paths():
         submissionID="my_submission_id", ancestry_submission=wrong_ancestry_submission
     )
 
-    wrong_ancestry_response = await handler_fn(publisher, wrong_ancestry_job_data)
+    wrong_ancestry_response = handler_fn(publisher, wrong_ancestry_job_data)
     # end instantiating another ancestry response with the wrong vcf...
 
     with pytest.raises(

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -3,6 +3,5 @@ mypy==1.3.0
 pandas-stubs==2.0.2.230605
 pytest==7.3.1
 pytest-cov==4.1.0
-pytest-asyncio==0.21.0
 ruff==0.0.270
 types-tqdm==4.65.0.1


### PR DESCRIPTION
Previously, some ancestry tests were async in order to test async beanstalk functionality.  This functionality is now eager, so update the tests accordingly.  Additionally, remove the now-unnecessary pytest-asyncio plugin from requirements-dev.txt.