### PR TITLE
relax ruff to allow named expressions before returns

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -75,6 +75,7 @@ ignore = [
 "N803",  # upercase variable names are often ok in scientific programming 
 "N806",  # upercase function names are often ok in scientific programming(ditto)
 "N815",  # ignore camelCase for now (remove this eventually)
+"RET504",  # allow variable assignments before return values
 "S311", # it's fine to use standard pseudo-random generators
 "SIM300",  # ignore yoda conditions, too many false positives
 ]


### PR DESCRIPTION
This rule interferes with readability, so let's get rid of it.

closes #157 