### PR TITLE
Enforce CI checks for forked pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: lint
 
-on: [push]
+on: [push, pull_request_target]
 
 jobs:
   build:


### PR DESCRIPTION
Previously the lint job was only configured to run for pushes to the main repo, and not for PRs submitted from a forked copy of the repo.  Enforce CI for these PRs as well.

Closes #178 