### PR TITLE
fix bug in ancestry listener error reporting

### DIFF
--- a/python/python/bystro/ancestry/listener.py
+++ b/python/python/bystro/ancestry/listener.py
@@ -119,7 +119,7 @@ def completed_msg_fn(
     if ancestry_submission.vcf_path != ancestry_response.vcf_path:
         err_msg = (
             f"Ancestry submission filename {ancestry_submission.vcf_path} "
-            "doesn't match response filename {ancestry_response.vcf_path}: this is a bug."
+            f"doesn't match response filename {ancestry_response.vcf_path}: this is a bug."
         )
         raise ValueError(err_msg)
     logger.debug("completed ancestry inference for: %s", ancestry_response)

--- a/python/python/bystro/ancestry/tests/test_listener.py
+++ b/python/python/bystro/ancestry/tests/test_listener.py
@@ -95,7 +95,7 @@ def test_completed_msg_fn_rejects_nonmatching_vcf_paths():
     # end instantiating another ancestry response with the wrong vcf...
 
     with pytest.raises(
-        ValueError, match="Ancestry submission filename .* doesn't match response filename"
+        ValueError, match="Ancestry submission filename .*\.vcf doesn't match response filename .*\.vcf"
     ):
         _ancestry_job_complete_message = completed_msg_fn(ancestry_job_data, wrong_ancestry_response)
 


### PR DESCRIPTION
Fix an unformatted f-string that was failing to render correctly, and fix the test that should have caught it.