### PR TITLE
Remove vcf_dir logic from ancestry listener

### DIFF
--- a/python/python/bystro/ancestry/listener.py
+++ b/python/python/bystro/ancestry/listener.py
@@ -1,7 +1,6 @@
 """Provide a worker for the ancestry model."""
 import argparse
 import logging
-import os
 from collections.abc import Callable, Collection
 from pathlib import Path
 
@@ -27,19 +26,6 @@ ANCESTRY_TUBE = "ancestry"
 ANCESTRY_BUCKET = "bystro-ancestry"
 PCA_FILE = "pca.csv"
 RFC_FILE = "rfc.skop"
-
-
-def _check_vcf_dir_access(vcf_dir: str) -> None:
-    try:
-        os.listdir(vcf_dir)
-    except FileNotFoundError as err:
-        err_msg = (
-            f"Couldn't access VCF dir {vcf_dir}, "
-            "will not be able to read VCFs in order to report ancestry results. "
-            "Check whether EFS is mounted correctly?"
-        )
-        raise FileNotFoundError(err_msg) from err
-    logger.info("Successfully checked EFS on %s", vcf_dir)
 
 
 def _get_model_from_s3(
@@ -152,16 +138,8 @@ if __name__ == "__main__":
         help="Path to the beanstalkd queue config yaml file (e.g beanstalk1.yml)",
         required=True,
     )
-    parser.add_argument(
-        "--vcf_dir",
-        type=Path,
-        help="Path to the beanstalkd queue config yaml file (e.g beanstalk1.yml)",
-        required=True,
-    )
-
     args = parser.parse_args()
 
-    _check_vcf_dir_access(args.vcf_dir)
     s3_client = boto3.client("s3")
     ancestry_model = _get_model_from_s3(s3_client)
     queue_conf = _load_queue_conf(args.queue_conf)

--- a/python/python/bystro/ancestry/tests/test_listener.py
+++ b/python/python/bystro/ancestry/tests/test_listener.py
@@ -8,7 +8,6 @@ import pytest
 from bystro.ancestry.ancestry_types import AncestrySubmission
 from bystro.ancestry.listener import (
     AncestryJobData,
-    _check_vcf_dir_access,
     completed_msg_fn,
     handler_fn_factory,
     submit_msg_fn,
@@ -95,13 +94,6 @@ def test_completed_msg_fn_rejects_nonmatching_vcf_paths():
     # end instantiating another ancestry response with the wrong vcf...
 
     with pytest.raises(
-        ValueError, match="Ancestry submission filename .*\.vcf doesn't match response filename .*\.vcf"
+        ValueError, match="Ancestry submission filename .*\\.vcf doesn't match response filename .*\\.vcf"
     ):
         _ancestry_job_complete_message = completed_msg_fn(ancestry_job_data, wrong_ancestry_response)
-
-
-def test__check_vcf_dir_access():
-    with pytest.raises(
-        FileNotFoundError, match="will not be able to read VCFs in order to report ancestry results"
-    ):
-        _check_vcf_dir_access(Path("my_fake_vcf_dir"))

--- a/python/python/bystro/ancestry/tests/test_listener.py
+++ b/python/python/bystro/ancestry/tests/test_listener.py
@@ -94,6 +94,7 @@ def test_completed_msg_fn_rejects_nonmatching_vcf_paths():
     # end instantiating another ancestry response with the wrong vcf...
 
     with pytest.raises(
-        ValueError, match="Ancestry submission filename .*\\.vcf doesn't match response filename .*\\.vcf"
+        ValueError,
+        match="Ancestry submission filename .*\\.vcf doesn't match response filename .*\\.vcf",
     ):
         _ancestry_job_complete_message = completed_msg_fn(ancestry_job_data, wrong_ancestry_response)


### PR DESCRIPTION
Now ancestry listener expects an absolute filepath and does not explicitly check for EFS access.