### PR TITLE
Remove apt update from install-apt.sh

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,10 @@ docker run bystro bystro-build.pl #Build
 
 ###### (Ubuntu)
 
-1.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-apt.sh`
+
+1.  Ensure that packages are up to date (`sudo apt update`), or that you are satisified with the state of package versions.
+2.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-apt.sh`
+    - Please note that this installation script requires root priveleges, in order to install system dependencies
 
 ## Example of installation on RPM-based Amazon AMI (any 'yum'-capable Amazon AMI)
 

--- a/install/install-apt-deps.sh
+++ b/install/install-apt-deps.sh
@@ -2,7 +2,6 @@
 
 echo -e "\n\nInstalling Ubuntu/Debian (apt-get) dependencies\n";
 
-sudo apt update;
 # Installs gcc, and more; may be too much
 sudo apt install -y build-essential;
 


### PR DESCRIPTION
- Remove apt update from install-apt.sh, and instead indicate in installation manual that packages should be updated at the discretion of the user.