### PR TITLE
Improve INSTALL.md; remove apt update from install-apt.sh

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         source .initialize_conda_env.sh
+        pip install -r **/requirements-dev.txt
     - name: Build Bystro using Maturin
       run: |
         maturin build

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,6 +1,6 @@
 name: conda-build
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -11,33 +11,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-      with:
-        # Explicitly set the fetch-depth to 0 to fetch all history
-        fetch-depth: 0
-
-    - name: Set up remote for head branch
-      run: |
-        # Set up the remote repository for the head branch
-        git remote add head-repo https://github.com/${{ github.head_repo }}.git
-        git fetch head-repo ${{ github.head_ref }} --depth=1
-      env:
-        GITHUB_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-
-    - name: Check modified files
-      id: file-check
-      run: |
-        # Get the list of modified files in the pull request
-        MODIFIED_FILES=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }})
-      
-        # Check if any modified file has a non-Perl file extension
-        if echo "$MODIFIED_FILES" | grep -E -q '.*\.(?!pl|pm$)[^.]+$'; then
-          echo "At least one non-Perl file modified. Continuing with the workflow."
-        else
-          echo "No non-Perl files modified. Exiting the workflow."
-          exit 78  # Exit with a neutral status code (78) to indicate a skipped workflow
-        fi
-      shell: bash
-
     - name: Build Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -45,13 +18,11 @@ jobs:
           auto-activate-base: true
           activate-environment: true
           python-version: ${{ matrix.python-version }}   
-  
     - name: Build Bystro using Maturin
       run: |
         . .initialize_conda_env.sh
         make build
       shell: bash
-
     - name: Verify Bystro wheel exists
       run: |
         if [[ ! -f "python/target/wheels/bystro-1.0.0-cp310-cp310-manylinux_2_34_x86_64.whl" ]]; then

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -10,8 +10,9 @@ jobs:
         python-version: ["3.10.11"]
     steps:
     - uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
-        with:
+    - name: Build Miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
           auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -16,14 +16,12 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           activate-environment: true
-          python-version: ${{ matrix.python-version }}      
-    - name: Install dependencies
-      run: |
-        source .initialize_conda_env.sh
-        pip install -r **/requirements-dev.txt
+          python-version: ${{ matrix.python-version }}   
     - name: Build Bystro using Maturin
       run: |
+        . .initialize_conda_env.sh
         maturin build
+      shell: bash
     - name: Verify Bystro wheel exists
       run: |
         if [[ ! -f "python/target/wheels/bystro-1.0.0-cp310-cp310-manylinux_2_34_x86_64.whl" ]]; then

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -10,6 +10,20 @@ jobs:
         python-version: ["3.10.11"]
     steps:
     - uses: actions/checkout@v3
+    - name: Check modified files
+      id: file-check
+      run: |
+        # Get the list of modified files in the pull request
+        MODIFIED_FILES=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }})
+      
+        # Check if any modified file has a non-Perl file extension
+        if echo "$MODIFIED_FILES" | grep -E -q '.*\.(?!pl|pm$)[^.]+$'; then
+          echo "At least one non-Perl file modified. Continuing with the workflow."
+        else
+          echo "No non-Perl files modified. Exiting the workflow."
+          exit 78  # Exit with a neutral status code (78) to indicate a skipped workflow
+        fi
+      shell: bash
     - name: Build Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build Bystro using Maturin
       run: |
         . .initialize_conda_env.sh
-        maturin build
+        make build
       shell: bash
     - name: Verify Bystro wheel exists
       run: |

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -15,7 +15,7 @@ jobs:
       with:
           auto-update-conda: true
           auto-activate-base: true
-          activate-environment: ""
+          activate-environment: true
           python-version: ${{ matrix.python-version }}      
     - name: Install dependencies
       run: |

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -9,7 +9,20 @@ jobs:
       matrix:
         python-version: ["3.10.11"]
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        # Explicitly set the fetch-depth to 0 to fetch all history
+        fetch-depth: 0
+
+    - name: Set up remote for head branch
+      run: |
+        # Set up the remote repository for the head branch
+        git remote add head-repo https://github.com/${{ github.head_repo }}.git
+        git fetch head-repo ${{ github.head_ref }} --depth=1
+      env:
+        GITHUB_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+
     - name: Check modified files
       id: file-check
       run: |
@@ -24,6 +37,7 @@ jobs:
           exit 78  # Exit with a neutral status code (78) to indicate a skipped workflow
         fi
       shell: bash
+
     - name: Build Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -31,11 +45,13 @@ jobs:
           auto-activate-base: true
           activate-environment: true
           python-version: ${{ matrix.python-version }}   
+  
     - name: Build Bystro using Maturin
       run: |
         . .initialize_conda_env.sh
         make build
       shell: bash
+
     - name: Verify Bystro wheel exists
       run: |
         if [[ ! -f "python/target/wheels/bystro-1.0.0-cp310-cp310-manylinux_2_34_x86_64.whl" ]]; then

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,0 +1,31 @@
+name: conda-build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          activate-environment: ""
+          python-version: ${{ matrix.python-version }}      
+    - name: Install dependencies
+      run: |
+        source .initialize_conda_env.sh
+    - name: Build Bystro using Maturin
+      run: |
+        maturin build
+    - name: Verify Bystro wheel exists
+      run: |
+        if [[ ! -f "python/target/wheels/bystro-1.0.0-cp310-cp310-manylinux_2_34_x86_64.whl" ]]; then
+          echo "Expected Bystro wheel not found!"
+          exit 1
+        fi
+        echo "Bystro wheel found! Build succeeded."

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,8 @@
-# Bystro installation
-
 For most users, we recommend not installing the software, and using https://bystro.io, where the software is hosted
 
-The web app provides full functionality for any size experiment (up to 890GB uncompressed/129GB compressed tested), a convenient search interface, and excellent performance
+The web app provides full functionality for any size experiment, a convenient search interface, and excellent performance
 
-## Docker
+# Installing Bystro using Docker
 
 ###### The recommended way to use Bystro on the command line
 
@@ -19,29 +17,54 @@ docker run bystro bystro-annotate.pl #Annotate
 docker run bystro bystro-build.pl #Build
 ```
 
-## Installation on RPM-based distros
+# Direct (non-Docker) installation
 
-###### (Fedora, Redhat, Centos, openSUSE, Mandriva)
+There are 2 components to Bystro:
+ 1. The Bystro annotator: a Perl program accessed through the command line (via bin/bystro-*)
+ 2. The Bystro Python package: where the rest of Bystro's functionality lives (statistics, proteomics, etc).
+
+## Installing the Bystro annotator (Perl/cli)
+
+##### (Fedora, Redhat, Centos, openSUSE, Mandriva)
 
 1.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-rpm.sh`
 
-## Installation on MacOS
-
-###### (tested on HighSierra, interactive)
+##### MacOS (tested on HighSierra, interactive)
 
 1.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-mac.sh`
 
-## Installation on Debian systems
+##### Ubuntu
+1.  Ensure that packages are up to date (`sudo apt update`), or that you are satisified with the state of package versions.
+2.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-apt.sh`
+    - Please note that this installation script requires root priveleges, in order to install system dependencies
 
-###### (Ubuntu)
+## Installing the Bystro Python libraries and cli tools
 
-1.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-apt.sh`
+We recommend using Miniconda to manage Bystro Python dependencies: https://docs.conda.io/projects/miniconda/en/latest/
 
-## Example of installation on RPM-based Amazon AMI (any 'yum'-capable Amazon AMI)
+Once Bystro annotator installation is complete, and assuming Conda/Miniconda has been installed, run :
 
-Run the script found @ https://github.com/akotlar/bystro-aws
+```sh
+# Install Rust
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+echo -e "\n### Bystro: Done installing Rust! Now sourcing .cargo/env for use in the current shell ###\n"
+source "$HOME/.cargo/env"
+# Create or activate Bystro conda environment and install all dependencies
+# This assumes you are in the bystro folder
+source .initialize_conda_env.sh;
+```
 
-## Configuring Bystro for annotation
+to install the Python package dependencies. Then, run:
+```
+# Build the Python package for local use
+make build
+```
+
+to intall the Bystro Python library.
+
+Follow the instructions below to install the Bystro annotator:
+
+## Configuring the Bystro annotator
 
 Once Bystro is installed, it needs to be configured. The easiest step is choosing the species/assemblies to annotate.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ Make sure you have [Docker installed](https://store.docker.com/search?type=editi
 #### Building the latest version of Bystro in Docker
 
 ```
-git clone https://github.com/akotlar/bystro.git && cd bystro
+git clone https://github.com/bystrogenomics/bystro.git && cd bystro
 docker build -t bystro .
 docker run bystro bystro-annotate.pl #Annotate
 docker run bystro bystro-build.pl #Build
@@ -27,15 +27,15 @@ There are 2 components to Bystro:
 
 ##### (Fedora, Redhat, Centos, openSUSE, Mandriva)
 
-1.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-rpm.sh`
+1.  `git clone https://github.com/bystrogenomics/bystro.git && cd bystro && source ./install-rpm.sh`
 
 ##### MacOS (tested on HighSierra, interactive)
 
-1.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-mac.sh`
+1.  `git clone https://github.com/bystrogenomics/bystro.git && cd bystro && source ./install-mac.sh`
 
 ##### Ubuntu
 1.  Ensure that packages are up to date (`sudo apt update`), or that you are satisified with the state of package versions.
-2.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-apt.sh`
+2.  `git clone https://github.com/bystrogenomics/bystro.git && cd bystro && source ./install-apt.sh`
     - Please not that this installation script will ask you for the root password in order to install system dependencies
 
 ## Installing the Bystro Python libraries and cli tools

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ There are 2 components to Bystro:
 ##### Ubuntu
 1.  Ensure that packages are up to date (`sudo apt update`), or that you are satisified with the state of package versions.
 2.  `git clone https://github.com/akotlar/bystro.git && cd bystro && source ./install-apt.sh`
-    - Please note that this installation script requires root priveleges, in order to install system dependencies
+    - Please not that this installation script will ask you for the root password in order to install system dependencies
 
 ## Installing the Bystro Python libraries and cli tools
 

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ develop:
 # Ray must be started with make serve-dev
 # without ray start, make serve-dev will succeed, but the handlers that rely on Ray will fail to start
 serve-dev: develop
-        ray stop && ray start --head
+	ray stop && ray start --head
 	pm2 delete all 2> /dev/null || true && pm2 start startup.yml

--- a/install/install-apt-deps.sh
+++ b/install/install-apt-deps.sh
@@ -2,7 +2,6 @@
 
 echo -e "\n\nInstalling Ubuntu/Debian (apt-get) dependencies\n";
 
-sudo apt update;
 # Installs gcc, and more; may be too much
 sudo apt install -y build-essential;
 

--- a/install/install-apt-deps.sh
+++ b/install/install-apt-deps.sh
@@ -31,4 +31,6 @@ sudo apt install -y npm;
 sudo npm install -g pm2;
 
 sudo apt install -y awscli;
+
+# pkg-config is required for building the wheel
 sudo apt install -y pkg-config;

--- a/install/install-apt-deps.sh
+++ b/install/install-apt-deps.sh
@@ -31,3 +31,4 @@ sudo apt install -y npm;
 sudo npm install -g pm2;
 
 sudo apt install -y awscli;
+sudo apt install -y pkg-config;

--- a/install/install-mac-deps.sh
+++ b/install/install-mac-deps.sh
@@ -21,3 +21,4 @@ brew install nodejs;
 sudo npm install -g pm2;
 
 brew install awscli;
+brew install pkg-config;

--- a/install/install-mac-deps.sh
+++ b/install/install-mac-deps.sh
@@ -21,4 +21,6 @@ brew install nodejs;
 sudo npm install -g pm2;
 
 brew install awscli;
+
+# pkg-config is required for building the wheel
 brew install pkg-config;

--- a/install/install-rpm-deps.sh
+++ b/install/install-rpm-deps.sh
@@ -32,4 +32,6 @@ sudo yum install nodejs -y;
 sudo npm install -g pm2;
 
 sudo yum install awscli -y;
+
+# pkg-config is required for building the wheel
 sudo yum install -y pkg-config;

--- a/install/install-rpm-deps.sh
+++ b/install/install-rpm-deps.sh
@@ -32,3 +32,4 @@ sudo yum install nodejs -y;
 sudo npm install -g pm2;
 
 sudo yum install awscli -y;
+sudo yum install -y pkg-config;


### PR DESCRIPTION
* Remove apt update from install-apt.sh, and instead indicate in installation manual that packages should be updated at the discretion of the user.
* Cleaned up installation instructions

This was motivated by attempting to set up Bystro on a new Ubuntu server. I realized that users will not want Bystro to force package updates, and that the installation of the Python libraries is not spelled out in INSTALL.md

Future PRs will strip out sudo from the install scripts, this is a gentle first step.