### PR TITLE
optimize unit test suite

### DIFF
--- a/python/python/bystro/supervised_ppca/tests/test_generative_pt.py
+++ b/python/python/bystro/supervised_ppca/tests/test_generative_pt.py
@@ -70,7 +70,7 @@ def generate_data_factorAnalysis():
 
 def test_ppca():
     W, sigma, X, S_train = generate_data_ppca()
-    model = PPCA(4, training_options={"n_iterations": 100})
+    model = PPCA(n_components=4, training_options={"n_iterations": 25})
     model.fit(X)
     cov_est = model.get_covariance()
     cov_emp = np.dot(X.T, X) / X.shape[0]

--- a/python/python/bystro/tada_mixture/tests/test_em.py
+++ b/python/python/bystro/tada_mixture/tests/test_em.py
@@ -26,8 +26,8 @@ def test_fit():
         zerod_out = rng.binomial(1, Alphas[idx])
         X[i, zerod_out == 1] = 0
 
-    model = MVTadaZipEM(K=K)
+    model = MVTadaZipEM(K=K, training_options={"n_iterations": 2})
     model.fit(X)
 
-    model = MVTadaPoissonEM(K=K)
+    model = MVTadaPoissonEM(K=K, training_options={"n_iterations": 2})
     model.fit(X)

--- a/python/python/bystro/tada_mixture/tests/test_em.py
+++ b/python/python/bystro/tada_mixture/tests/test_em.py
@@ -26,8 +26,8 @@ def test_fit():
         zerod_out = rng.binomial(1, Alphas[idx])
         X[i, zerod_out == 1] = 0
 
-    model = MVTadaZipEM(K=K, training_options={"n_iterations": 2})
+    model = MVTadaZipEM(K=K, training_options={"n_iterations": 5})
     model.fit(X)
 
-    model = MVTadaPoissonEM(K=K, training_options={"n_iterations": 2})
+    model = MVTadaPoissonEM(K=K, training_options={"n_iterations": 5})
     model.fit(X)

--- a/python/python/bystro/tada_mixture/tests/test_marginal.py
+++ b/python/python/bystro/tada_mixture/tests/test_marginal.py
@@ -23,5 +23,5 @@ def test_fit():
         idx = int(Z_true[i])
         X[i] = rng.poisson(Lambda[idx])
 
-    model = MVTadaPoissonML(K=K)
+    model = MVTadaPoissonML(K=K, training_options={"n_iterations": 2})
     model.fit(X)

--- a/python/python/bystro/tada_mixture/tests/test_marginal.py
+++ b/python/python/bystro/tada_mixture/tests/test_marginal.py
@@ -23,5 +23,5 @@ def test_fit():
         idx = int(Z_true[i])
         X[i] = rng.poisson(Lambda[idx])
 
-    model = MVTadaPoissonML(K=K, training_options={"n_iterations": 2})
+    model = MVTadaPoissonML(K=K, training_options={"n_iterations": 5})
     model.fit(X)


### PR DESCRIPTION
Optimize unit test suite performance by setting `n_iterations` training parameter to lower values that maintain test invariants.

This results in a 6x speedup, bringing local unit testing wall time from ~70s to ~12s.