### PR TITLE
Add caching to lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,14 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    # Set up cache for Python packages
+    - name: Cache Python dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.venv/ci-venv
+        key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-venv-
     - name: Install dependencies
       run: |
         python -m venv ~/.venv/ci-venv

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     # Set up cache for Python packages
     - name: Cache Python dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.venv/ci-venv
         key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}


### PR DESCRIPTION
* Updates lint.yml to cache venv

Most of our lint.yml build time is spent in dependency installation. This PR caches the virtual env, so that unless requirements change, the venv will be served from cache rather than installing from scratch 