### PR TITLE
 Add utility functions to get name of GNU tar executable in OS-agnostic manner

### DIFF
--- a/install/install-mac-deps.sh
+++ b/install/install-mac-deps.sh
@@ -24,3 +24,5 @@ brew install awscli;
 
 # pkg-config is required for building the wheel
 brew install pkg-config;
+
+brew install gnu-tar

--- a/python/python/bystro/utils/tar.py
+++ b/python/python/bystro/utils/tar.py
@@ -33,8 +33,9 @@ def _determine_os() -> OperatingSystem:
             check=True,
         )
     except FileNotFoundError as file_not_found_error:
-        err_msg = "Couldn't run `uname -a` in shell to determine OS: "
-        err_msg += "only linux and macosx are supported."
+        err_msg = (
+            "Couldn't run `uname -a` in shell to determine OS: only linux and macosx are supported."
+        )
         raise AssertionError(err_msg) from file_not_found_error
     downcased_uname_output = result.stdout.lower()
     if "darwin" in downcased_uname_output:

--- a/python/python/bystro/utils/tar.py
+++ b/python/python/bystro/utils/tar.py
@@ -54,11 +54,10 @@ def _get_gnu_tar_executable_name() -> str:
     operating_system = _determine_os()
     if operating_system is OperatingSystem.linux:
         return GNU_TAR_LINUX
-    elif operating_system is OperatingSystem.macosx:
+    if operating_system is OperatingSystem.macosx:
         _assert_gtar_installed_on_macosx()
         return GNU_TAR_MACOSX
-    else:
-        return assert_never(operating_system)
+    return assert_never(operating_system)
 
 
 def _assert_gtar_installed_on_macosx() -> None:

--- a/python/python/bystro/utils/tar.py
+++ b/python/python/bystro/utils/tar.py
@@ -19,7 +19,11 @@ class OperatingSystem(Enum):
 def _get_executable_name(name: str) -> str:
     try:
         result = subprocess.run(
-            ["which", name], capture_output=True, text=True, check=True, shell=False  # noqa: S603, S607
+            ["/usr/bin/which", name],
+            capture_output=True,
+            text=True,
+            check=True,
+            shell=False,  # noqa: S603 (input is safe)
         )
     except CalledProcessError as err:
         err_msg = f"executable `{name}` not found on system, is it installed?"
@@ -37,7 +41,7 @@ def _determine_os() -> OperatingSystem:
     """Determine whether we're running on Linux or MacOSX by inspecting uname output."""
     try:
         result = subprocess.run(
-            ["/usr/bin/uname", "-a"],  # noqa: S603
+            ["/usr/bin/uname", "-a"],  # noqa: S603 (input is safe)
             capture_output=True,
             text=True,
             check=True,

--- a/python/python/bystro/utils/tar.py
+++ b/python/python/bystro/utils/tar.py
@@ -1,0 +1,77 @@
+"""Utility functions for safely invoking tar in cross-OS manner."""
+
+import subprocess
+from enum import Enum
+from typing import NoReturn
+
+
+class OperatingSystem(Enum):
+    """Represent the operating system on which the current Python process is running."""
+
+    linux = "linux"
+    macosx = "macosx"
+
+
+# here and throughout, fully qualify executable names to avoid privilege escalation
+GNU_TAR_LINUX = "/usr/bin/tar"
+GNU_TAR_MACOSX = "/opt/homebrew/bin/gtar"
+
+
+def assert_never(value: NoReturn) -> NoReturn:
+    """Raise error for mypy if code is proven reachable."""
+    msg = f"Unhandled value: {value} ({type(value).__name__})"
+    raise AssertionError(msg)
+
+
+def _determine_os() -> OperatingSystem:
+    """Determine whether we're running on Linux or MacOSX by inspecting uname output."""
+    try:
+        result = subprocess.run(
+            ["/usr/bin/uname", "-a"],  # noqa: S603 (this input is safe)
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as file_not_found_error:
+        err_msg = "Couldn't run `uname -a` in shell to determine OS: "
+        err_msg += "only linux and macosx are supported."
+        raise AssertionError(err_msg) from file_not_found_error
+    downcased_uname_output = result.stdout.lower()
+    if "darwin" in downcased_uname_output:
+        return OperatingSystem.macosx
+    if "linux" in downcased_uname_output:
+        return OperatingSystem.linux
+    err_msg = f"Could not determine OS from `uname -a` output: `{result.stdout}`"
+    raise OSError(err_msg)
+
+
+def _get_gnu_tar_executable_name() -> str:
+    """Find the name of the GNU tar executable on user's instance."""
+    # Macs use bsdtar by default.  bsdtar is not fully compatible with
+    # GNU tar, the implementation we use.  So if we're on a mac, we'll
+    # want to use 'gtar' instead of 'tar'.
+    operating_system = _determine_os()
+    if operating_system is OperatingSystem.linux:
+        return GNU_TAR_LINUX
+    elif operating_system is OperatingSystem.macosx:
+        _assert_gtar_installed_on_macosx()
+        return GNU_TAR_MACOSX
+    else:
+        return assert_never(operating_system)
+
+
+def _assert_gtar_installed_on_macosx() -> None:
+    """Check that gtar is installed, raising RuntimeError if not."""
+    try:
+        subprocess.run(
+            [GNU_TAR_MACOSX, "--version"],  # noqa: S603 (this input is safe)
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as file_not_found_error:
+        err_msg = "Could not detect GNU tar on system, try: `brew install gnu-tar`"
+        raise RuntimeError(err_msg) from file_not_found_error
+
+
+GNU_TAR_EXECUTABLE_NAME = _get_gnu_tar_executable_name()

--- a/python/python/bystro/utils/tar.py
+++ b/python/python/bystro/utils/tar.py
@@ -1,34 +1,21 @@
 """Utility functions for safely invoking tar in cross-OS manner."""
-
+import sys
+import shutil
 import subprocess
 from enum import Enum
 from subprocess import CalledProcessError
 from typing import NoReturn
 
 
-class OperatingSystem(Enum):
-    """Represent the operating system on which the current Python process is running."""
-
-    linux = "linux"
-    macosx = "macosx"
-
-
 # here and throughout, fully qualify executable names to avoid privilege escalation
 
 
 def _get_executable_name(name: str) -> str:
-    try:
-        result = subprocess.run(
-            ["/usr/bin/which", name],
-            capture_output=True,
-            text=True,
-            check=True,
-            shell=False,  # noqa: S603 (input is safe)
-        )
-    except CalledProcessError as err:
-        err_msg = f"executable `{name}` not found on system, is it installed?"
-        raise OSError(err_msg) from err
-    return result.stdout.strip()
+    executable_name = shutil.which(name)
+    if executable_name is None:
+        err_msg = f"executable `{name}` not found on system"
+        raise OSError(err_msg)
+    return executable_name
 
 
 def assert_never(value: NoReturn) -> NoReturn:
@@ -37,40 +24,17 @@ def assert_never(value: NoReturn) -> NoReturn:
     raise AssertionError(msg)
 
 
-def _determine_os() -> OperatingSystem:
-    """Determine whether we're running on Linux or MacOSX by inspecting uname output."""
-    try:
-        result = subprocess.run(
-            ["/usr/bin/uname", "-a"],  # noqa: S603 (input is safe)
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except FileNotFoundError as file_not_found_error:
-        err_msg = (
-            "Couldn't run `uname -a` in shell to determine OS: only linux and macosx are supported."
-        )
-        raise OSError(err_msg) from file_not_found_error
-    downcased_uname_output = result.stdout.lower()
-    if "darwin" in downcased_uname_output:
-        return OperatingSystem.macosx
-    if "linux" in downcased_uname_output:
-        return OperatingSystem.linux
-    err_msg = f"Could not determine OS from `uname -a` output: `{result.stdout}`"
-    raise OSError(err_msg)
-
-
 def _get_gnu_tar_executable_name() -> str:
     """Find the name of the GNU tar executable on user's instance."""
     # Macs use bsdtar by default.  bsdtar is not fully compatible with
     # GNU tar, the implementation we use.  So if we're on a mac, we'll
     # want to use 'gtar' instead of 'tar'.
-    operating_system = _determine_os()
-    if operating_system is OperatingSystem.linux:
+    if sys.platform == "linux":
         return _get_executable_name("tar")
-    if operating_system is OperatingSystem.macosx:
+    if sys.platform == "darwin":
         return _get_executable_name("gtar")
-    return assert_never(operating_system)
+    err_msg = f"Operating system must be linux or macosx, got {sys.platform} instead."
+    raise OSError(err_msg)
 
 
 GNU_TAR_EXECUTABLE_NAME = _get_gnu_tar_executable_name()

--- a/python/python/bystro/utils/tar.py
+++ b/python/python/bystro/utils/tar.py
@@ -1,13 +1,6 @@
 """Utility functions for safely invoking tar in cross-OS manner."""
-import sys
 import shutil
-import subprocess
-from enum import Enum
-from subprocess import CalledProcessError
-from typing import NoReturn
-
-
-# here and throughout, fully qualify executable names to avoid privilege escalation
+import sys
 
 
 def _get_executable_name(name: str) -> str:
@@ -16,12 +9,6 @@ def _get_executable_name(name: str) -> str:
         err_msg = f"executable `{name}` not found on system"
         raise OSError(err_msg)
     return executable_name
-
-
-def assert_never(value: NoReturn) -> NoReturn:
-    """Raise error for mypy if code is proven reachable."""
-    msg = f"Unhandled value: {value} ({type(value).__name__})"
-    raise AssertionError(msg)
 
 
 def _get_gnu_tar_executable_name() -> str:

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -27,7 +27,7 @@ def test_GNU_TAR_EXECUTABLE_NAME():
 
 
 def _mock_subprocess(response_table: dict[tuple[str], (str | Exception)]) -> Mock:
-    """Simulate subprocess.run."""
+    """Mock subprocess.run, given dictionary of inputs and outputs."""
 
     def generate_subprocess_mock(args: list[str], **_kwargs: dict[str, Any]):
         response = response_table.get(tuple(args))

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -42,7 +42,7 @@ def _mock_subprocess(stdout_string: str) -> Callable[[Any, Any], Mock]:
 def test_get_gnu_tar_executable_macosx_gnu_tar_installed(monkeypatch):
     monkeypatch.setattr(subprocess, "run", _mock_subprocess("/opt/homebrew/bin/gtar\n"))
     monkeypatch.setattr(sys, "platform", "darwin")
-    monkeypatch.setattr(shutil, "which", "/opt/homebrew/bin/gtar")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/opt/homebrew/bin/gtar")
     assert "/opt/homebrew/bin/gtar" == _get_gnu_tar_executable_name()
 
 
@@ -60,7 +60,7 @@ def test_get_gnu_tar_executable_macosx_gnu_tar_not_installed(monkeypatch):
 def test_get_gnu_tar_executable_linux(monkeypatch):
     monkeypatch.setattr(subprocess, "run", _mock_subprocess("/usr/bin/tar\n"))
     monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(shutil, "which", "/usr/bin/tar")
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/tar")
     assert "/usr/bin/tar" == _get_gnu_tar_executable_name()
 
 

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -40,9 +40,8 @@ def _mock_subprocess(stdout_string: str) -> Callable[[Any, Any], Mock]:
 
 
 def test_get_gnu_tar_executable_macosx_gnu_tar_installed(monkeypatch):
-    mock = Mock()
-    mock.stdout = "/opt/homebrew/bin/gtar\n"
     monkeypatch.setattr(subprocess, "run", _mock_subprocess("/opt/homebrew/bin/gtar\n"))
+    monkeypatch.setattr(sys, "platform", "darwin")
     assert "/opt/homebrew/bin/gtar" == _get_gnu_tar_executable_name()
 
 
@@ -52,6 +51,7 @@ def test_get_gnu_tar_executable_macosx_gnu_tar_not_installed(monkeypatch):
         raise CalledProcessError(cmd=["which", "gtar"], returncode=1)
 
     monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setattr(sys, "platform", "darwin")
     with pytest.raises(OSError, match="executable `gtar` not found on system"):
         _get_gnu_tar_executable_name()
 

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -28,7 +28,7 @@ def test_GNU_TAR_EXECUTABLE_NAME():
 
 
 def _mock_subprocess(stdout_string: str) -> Callable[[Any, Any], Mock]:
-    """Mock subprocess.run, given dictionary of inputs and outputs."""
+    """Create a subprocess.run mock that returns stdout_string."""
     mock = Mock()
     mock.stdout = stdout_string
 

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -1,0 +1,94 @@
+"""Test functions for utils module."""
+
+import subprocess
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from bystro.utils.tar import (
+    GNU_TAR_EXECUTABLE_NAME,
+    GNU_TAR_LINUX,
+    GNU_TAR_MACOSX,
+    _get_gnu_tar_executable_name,
+)
+
+
+# These tests check that we correctly infer the name of the GNU tar
+# executable regardless of the operating system we find ourselves
+# running on, or that we raise an appropriate error if we can't
+# determine the correct executable.
+def test_GNU_TAR_EXECUTABLE_NAME():
+    assert GNU_TAR_EXECUTABLE_NAME in ["/usr/bin/tar", "/opt/homebrew/bin/gtar"]
+
+
+def _mock_subprocess_run_macosx_gnu_tar_installed(args: list[str], **_kwargs: dict[str, Any]) -> Mock:
+    """Simulate subprocess runs on macosx if GNU tar installed."""
+    if args == ["/usr/bin/uname", "-a"]:
+        mock = Mock()
+        mock.stdout = "some uname output string with Darwin in it"
+    elif args == ["/opt/homebrew/bin/gtar", "--version"]:
+        mock = Mock()
+        mock.stdout = "some string with tar in it"
+    else:
+        err_msg = f"Couldn't interpret args: {args} correctly, this is an error in the test."
+        raise AssertionError(err_msg)
+    return mock
+
+
+def test_get_gnu_tar_executable_macosx_gnu_tar_installed(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _mock_subprocess_run_macosx_gnu_tar_installed)
+    assert GNU_TAR_MACOSX == _get_gnu_tar_executable_name()
+
+
+def _mock_subprocess_run_macosx_gnu_tar_not_installed(
+    args: list[str], **_kwargs: dict[str, Any]
+) -> Mock:
+    """Simulate subprocess runs on macosx if GNU tar not installed."""
+    if args == ["/usr/bin/uname", "-a"]:
+        mock = Mock()
+        mock.stdout = "some uname output string with Darwin in it"
+    elif args == ["/opt/homebrew/bin/gtar", "--version"]:
+        raise FileNotFoundError
+    else:
+        err_msg = f"Couldn't interpret args: {args} correctly, this is an error in the test."
+        raise AssertionError(err_msg)
+    return mock
+
+
+def test_get_gnu_tar_executable_macosx_gnu_tar_not_installed(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _mock_subprocess_run_macosx_gnu_tar_not_installed)
+    with pytest.raises(RuntimeError):
+        _get_gnu_tar_executable_name()
+
+
+def _mock_subprocess_run_linux(args: list[str], **_kwargs: dict[str, Any]) -> Mock:
+    """Simulate subprocess runs on linux."""
+    if args == ["/usr/bin/uname", "-a"]:
+        mock = Mock()
+        mock.stdout = "some uname output string with Linux in it"
+    else:
+        err_msg = f"Couldn't interpret args: {args} correctly, this is an error in the test."
+        raise AssertionError(err_msg)
+    return mock
+
+
+def test_get_gnu_tar_executable_linux(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _mock_subprocess_run_linux)
+    assert GNU_TAR_LINUX == _get_gnu_tar_executable_name()
+
+
+def _mock_subprocess_run_unknown_os(args: list[str], **_kwargs: dict[str, Any]) -> Mock:
+    """Simulate subprocess runs some arbitrary unrecognized OS."""
+    if args == ["/usr/bin/uname", "-a"]:
+        mock = Mock()
+        mock.stdout = "some uname output string from unrecognized OS"
+    else:
+        err_msg = f"Couldn't interpret args: {args} correctly, this is an error in the test."
+        raise AssertionError(err_msg)
+    return mock
+
+
+def test_get_gnu_tar_executable_unknown_os(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _mock_subprocess_run_unknown_os)
+    with pytest.raises(OSError, match="Could not determine OS"):
+        _get_gnu_tar_executable_name()

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -42,6 +42,7 @@ def _mock_subprocess(stdout_string: str) -> Callable[[Any, Any], Mock]:
 def test_get_gnu_tar_executable_macosx_gnu_tar_installed(monkeypatch):
     monkeypatch.setattr(subprocess, "run", _mock_subprocess("/opt/homebrew/bin/gtar\n"))
     monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(shutil, "which", "/opt/homebrew/bin/gtar")
     assert "/opt/homebrew/bin/gtar" == _get_gnu_tar_executable_name()
 
 
@@ -59,6 +60,7 @@ def test_get_gnu_tar_executable_macosx_gnu_tar_not_installed(monkeypatch):
 def test_get_gnu_tar_executable_linux(monkeypatch):
     monkeypatch.setattr(subprocess, "run", _mock_subprocess("/usr/bin/tar\n"))
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(shutil, "which", "/usr/bin/tar")
     assert "/usr/bin/tar" == _get_gnu_tar_executable_name()
 
 

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -46,7 +46,7 @@ def _mock_subprocess(response_table: dict[tuple[str], (str | Exception)]) -> Moc
 def test_get_gnu_tar_executable_macosx_gnu_tar_installed(monkeypatch):
     subprocess_response_table = {
         ("/usr/bin/uname", "-a"): "some uname output string with Darwin in it",
-        ("which", "gtar"): "/opt/homebrew/bin/gtar\n",
+        ("/usr/bin/which", "gtar"): "/opt/homebrew/bin/gtar\n",
     }
     monkeypatch.setattr(subprocess, "run", _mock_subprocess(subprocess_response_table))
     assert "/opt/homebrew/bin/gtar" == _get_gnu_tar_executable_name()
@@ -55,7 +55,7 @@ def test_get_gnu_tar_executable_macosx_gnu_tar_installed(monkeypatch):
 def test_get_gnu_tar_executable_macosx_gnu_tar_not_installed(monkeypatch):
     subprocess_responses = {
         ("/usr/bin/uname", "-a"): "some string with Darwin in it",
-        ("which", "gtar"): CalledProcessError(cmd=["which", "gtar"], returncode=1),
+        ("/usr/bin/which", "gtar"): CalledProcessError(cmd=["which", "gtar"], returncode=1),
     }
 
     monkeypatch.setattr(subprocess, "run", _mock_subprocess(subprocess_responses))
@@ -66,7 +66,7 @@ def test_get_gnu_tar_executable_macosx_gnu_tar_not_installed(monkeypatch):
 def test_get_gnu_tar_executable_linux(monkeypatch):
     subprocess_response_table = {
         ("/usr/bin/uname", "-a"): "some uname output string with Linux in it",
-        ("which", "tar"): "/usr/bin/tar\n",
+        ("/usr/bin/which", "tar"): "/usr/bin/tar\n",
     }
     monkeypatch.setattr(subprocess, "run", _mock_subprocess(subprocess_response_table))
     assert "/usr/bin/tar" == _get_gnu_tar_executable_name()

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -13,12 +13,18 @@ from bystro.utils.tar import (
 )
 
 
+def test_GNU_TAR_EXECUTABLE_NAME():
+    assert GNU_TAR_EXECUTABLE_NAME in ["/usr/bin/tar", "/opt/homebrew/bin/gtar"]
+
+
 # These tests check that we correctly infer the name of the GNU tar
 # executable regardless of the operating system we find ourselves
 # running on, or that we raise an appropriate error if we can't
-# determine the correct executable.
-def test_GNU_TAR_EXECUTABLE_NAME():
-    assert GNU_TAR_EXECUTABLE_NAME in ["/usr/bin/tar", "/opt/homebrew/bin/gtar"]
+# determine the correct executable.  The
+# _mock_subprocess_run_... methods mocks all interaction with
+# subprocess.run under various OS scenarios and the tests ensure that
+# we return the correct GNU tar executable name or raise the appropriate
+# exception.
 
 
 def _mock_subprocess_run_macosx_gnu_tar_installed(args: list[str], **_kwargs: dict[str, Any]) -> Mock:

--- a/python/python/bystro/utils/tests/test_tar.py
+++ b/python/python/bystro/utils/tests/test_tar.py
@@ -1,9 +1,9 @@
 """Test functions for utils module."""
 import shutil
-import sys
 import subprocess
+import sys
 from subprocess import CalledProcessError
-from typing import Any
+from typing import Any, Callable, NoReturn
 from unittest.mock import Mock
 
 import pytest
@@ -27,12 +27,13 @@ def test_GNU_TAR_EXECUTABLE_NAME():
 # exception.
 
 
-def _mock_subprocess(stdout_string: str) -> Mock:
+def _mock_subprocess(stdout_string: str) -> Callable[[Any, Any], Mock]:
     """Mock subprocess.run, given dictionary of inputs and outputs."""
-    mock = Mock
+    mock = Mock()
     mock.stdout = stdout_string
 
-    def f(*args, **kwargs):
+    def f(*args: list[str], **kwargs: dict[str, Any]) -> Mock:
+        del args, kwargs
         return mock
 
     return f
@@ -46,10 +47,11 @@ def test_get_gnu_tar_executable_macosx_gnu_tar_installed(monkeypatch):
 
 
 def test_get_gnu_tar_executable_macosx_gnu_tar_not_installed(monkeypatch):
-    def raise_error(*args, **kwargs):
+    def raise_error(args: list[str], kwargs: dict[str, Any]) -> NoReturn:
+        del args, kwargs
         raise CalledProcessError(cmd=["which", "gtar"], returncode=1)
 
-    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
     with pytest.raises(OSError, match="executable `gtar` not found on system"):
         _get_gnu_tar_executable_name()
 


### PR DESCRIPTION
At various points in annotation file processing we rely on tar to compress or decompress files. In particular, we use GNU tar and use certain features that are specific to that implementation. On linux, GNU tar is the default. On MacOSX, however, the default implementation is bsdtar, which is not fully compatible with GNU tar. If we end up calling bsdtar when we mean GNU tar, subtle bugs can result.

So, in order to run tar correctly we need to know which OS we're running it on and specify the correct executable name for GNU tar (or raise an error if it isn't installed). This commit defines a utils module that provides a runtime constant GNU_TAR_EXECUTABLE_NAME valid under linux or MacOSX.

Closes #277 