### PR TITLE
Add project-level config utilities

### DIFF
--- a/python/python/bystro/utils/__init__.py
+++ b/python/python/bystro/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Provide various project-wide utilities."""

--- a/python/python/bystro/utils/config.py
+++ b/python/python/bystro/utils/config.py
@@ -19,9 +19,9 @@ def get_bystro_project_root() -> Path:
     # find project root by walking up the tree until we get to top level bystro directory.
     # The bystro top level is assumed to be the unique directory containing a startup.yml file.
     path = Path().absolute()
-    ROOT = Path("/")
+    FILESYSTEM_ROOT = Path("/")
     found_startup_file = False
-    while path != ROOT:
+    while path != FILESYSTEM_ROOT:
         if any(path.glob("startup.yml")):
             found_startup_file = True
             break

--- a/python/python/bystro/utils/config.py
+++ b/python/python/bystro/utils/config.py
@@ -14,7 +14,7 @@ ConfigDict = Dict[str, Union["ConfigDictValue", list["ConfigDictValue"]]]
 ConfigDictValue = Union[str, int, float, "ConfigDict"]
 
 
-def get_bystro_project_root() -> Path:
+def _get_bystro_project_root() -> Path:
     """Return Path of bystro project root."""
     # find project root by walking up the tree until we get to top level bystro directory.
     # The bystro top level is assumed to be the unique directory containing a startup.yml file.
@@ -32,10 +32,12 @@ def get_bystro_project_root() -> Path:
     return path
 
 
+BYSTRO_PROJECT_ROOT = _get_bystro_project_root()
+
+
 def get_opensearch_config() -> ConfigDict:
     """Read opensearch config and return parsed YAML."""
-    BYSTRO_ROOT = get_bystro_project_root()
-    opensearch_config_filepath = BYSTRO_ROOT / "config/opensearch.yml"
+    opensearch_config_filepath = BYSTRO_PROJECT_ROOT / "config/opensearch.yml"
     with opensearch_config_filepath.open() as search_config_file:
         config_dict: ConfigDict = YAML(typ="safe").load(search_config_file)
     return config_dict

--- a/python/python/bystro/utils/config.py
+++ b/python/python/bystro/utils/config.py
@@ -1,0 +1,41 @@
+"""Utility functions for accessing project-level configuration files."""
+from pathlib import Path
+from typing import Dict, Union
+
+from ruamel.yaml import YAML
+
+# A ConfigDict has string keys and values of type ConfigDictValue, or
+# a list of ConfigDictValues.  A ConfigDictValue is a str, int, float,
+# or (nested) ConfigDict.  ConfigDictValue can be extended with
+# additional primitive types if necessary.
+
+
+ConfigDict = Dict[str, Union["ConfigDictValue", list["ConfigDictValue"]]]
+ConfigDictValue = Union[str, int, float, "ConfigDict"]
+
+
+def get_bystro_project_root() -> Path:
+    """Return Path of bystro project root."""
+    # find project root by walking up the tree until we get to top level bystro directory.
+    # The bystro top level is assumed to be the unique directory containing a startup.yml file.
+    path = Path().absolute()
+    ROOT = Path("/")
+    found_startup_file = False
+    while path != ROOT:
+        if any(path.glob("startup.yml")):
+            found_startup_file = True
+            break
+        path = path.parent
+    if not found_startup_file:
+        msg = "Recursed to filesystem root without finding startup.yml file: this is a bug."
+        raise FileNotFoundError(msg)
+    return path
+
+
+def get_opensearch_config() -> ConfigDict:
+    """Read opensearch config and return parsed YAML."""
+    BYSTRO_ROOT = get_bystro_project_root()
+    opensearch_config_filepath = BYSTRO_ROOT / "config/opensearch.yml"
+    with opensearch_config_filepath.open() as search_config_file:
+        config_dict: ConfigDict = YAML(typ="safe").load(search_config_file)
+    return config_dict

--- a/python/python/bystro/utils/tests/test_config.py
+++ b/python/python/bystro/utils/tests/test_config.py
@@ -11,7 +11,7 @@ def test_get_bystro_project_root():
 
 @patch("pathlib.Path.glob", return_value=[])
 def test_get_bystro_project_root_error_case(mocked_glob):  # noqa: ARG001  (arg is actually necessary)
-    """Test case where Path.glob never returns startup.yml."""
+    """Test case where Path.glob never finds startup.yml in any directory it searches."""
     with pytest.raises(FileNotFoundError, match="this is a bug"):
         get_bystro_project_root()
 

--- a/python/python/bystro/utils/tests/test_config.py
+++ b/python/python/bystro/utils/tests/test_config.py
@@ -1,19 +1,19 @@
 from unittest.mock import patch
 
 import pytest
-from bystro.utils.config import get_bystro_project_root, get_opensearch_config
+from bystro.utils.config import BYSTRO_PROJECT_ROOT, get_opensearch_config, _get_bystro_project_root
 
 
 def test_get_bystro_project_root():
-    bystro_project_root = get_bystro_project_root()
-    assert "bystro" in str(bystro_project_root)
+    expected_startup_yml_path = BYSTRO_PROJECT_ROOT / "startup.yml"
+    assert expected_startup_yml_path.exists()
 
 
 @patch("pathlib.Path.glob", return_value=[])
 def test_get_bystro_project_root_error_case(mocked_glob):  # noqa: ARG001  (arg is actually necessary)
     """Test case where Path.glob never finds startup.yml in any directory it searches."""
     with pytest.raises(FileNotFoundError, match="this is a bug"):
-        get_bystro_project_root()
+        _get_bystro_project_root()
 
 
 def test_get_opensearch_config():

--- a/python/python/bystro/utils/tests/test_config.py
+++ b/python/python/bystro/utils/tests/test_config.py
@@ -1,0 +1,12 @@
+from bystro.utils.config import get_bystro_project_root, get_opensearch_config
+
+
+def test_get_bystro_project_root():
+    bystro_project_root = get_bystro_project_root()
+    assert "bystro" in str(bystro_project_root)
+
+
+def test_get_opensearch_config():
+    opensearch_config = get_opensearch_config()
+    expected_keys = set(["connection", "auth"])
+    assert expected_keys == set(opensearch_config.keys())

--- a/python/python/bystro/utils/tests/test_config.py
+++ b/python/python/bystro/utils/tests/test_config.py
@@ -1,8 +1,7 @@
-import pathlib
-import pytest
-
-from bystro.utils.config import get_bystro_project_root, get_opensearch_config
 from unittest.mock import patch
+
+import pytest
+from bystro.utils.config import get_bystro_project_root, get_opensearch_config
 
 
 def test_get_bystro_project_root():
@@ -11,13 +10,13 @@ def test_get_bystro_project_root():
 
 
 @patch("pathlib.Path.glob", return_value=[])
-def test_get_bystro_project_root_error_case(mocked_glob):
+def test_get_bystro_project_root_error_case(mocked_glob):  # noqa: ARG001  (arg is actually necessary)
     """Test case where Path.glob never returns startup.yml."""
     with pytest.raises(FileNotFoundError, match="this is a bug"):
-        bystro_project_root = get_bystro_project_root()
+        get_bystro_project_root()
 
 
 def test_get_opensearch_config():
     opensearch_config = get_opensearch_config()
-    expected_keys = set(["connection", "auth"])
+    expected_keys = {"connection", "auth"}
     assert expected_keys == set(opensearch_config.keys())

--- a/python/python/bystro/utils/tests/test_config.py
+++ b/python/python/bystro/utils/tests/test_config.py
@@ -1,9 +1,20 @@
+import pathlib
+import pytest
+
 from bystro.utils.config import get_bystro_project_root, get_opensearch_config
+from unittest.mock import patch
 
 
 def test_get_bystro_project_root():
     bystro_project_root = get_bystro_project_root()
     assert "bystro" in str(bystro_project_root)
+
+
+@patch("pathlib.Path.glob", return_value=[])
+def test_get_bystro_project_root_error_case(mocked_glob):
+    """Test case where Path.glob never returns startup.yml."""
+    with pytest.raises(FileNotFoundError, match="this is a bug"):
+        bystro_project_root = get_bystro_project_root()
 
 
 def test_get_opensearch_config():


### PR DESCRIPTION
Provide utility functions for loading the opensearch config and finding the bystro project root directory.