### PR TITLE
Improve indexing to avoid creating unnecessary inner overlap delimiter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: lint
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -41,5 +41,6 @@ jobs:
       run: |
         source ~/.venv/ci-venv/bin/activate
         cd python
-        maturin develop        
+        maturin develop
+        ray start --head
         pytest

--- a/python/python/bystro/search/index/bystro_file.pyx
+++ b/python/python/bystro/search/index/bystro_file.pyx
@@ -95,10 +95,7 @@ cdef class ReadAnnotationTarball:
 
                             overlap_values.append(overlap_value)
 
-                        if len(overlap_values) == 1:
-                            values.append(overlap_values[0])
-                        else:
-                            values.append(overlap_values)
+                        values.append(overlap_values)
 
                     position_values.append(values)
 

--- a/python/python/bystro/search/index/bystro_file.pyx
+++ b/python/python/bystro/search/index/bystro_file.pyx
@@ -95,12 +95,12 @@ cdef class ReadAnnotationTarball:
 
                             overlap_values.append(overlap_value)
 
-                        values.append(overlap_values)
+                        if len(overlap_values) == 1:
+                            values.append(overlap_values[0])
+                        else:
+                            values.append(overlap_values)
 
-                    if len(values_raw) > 1:
-                        position_values.append(values)
-                    else:
-                        position_values.append(values[0])
+                    position_values.append(values)
 
                 populate_hash_path(_source, self.paths[i], position_values)
 

--- a/python/python/bystro/search/index/tests/test_bystro_file.py
+++ b/python/python/bystro/search/index/tests/test_bystro_file.py
@@ -37,8 +37,9 @@ def test_read_annotation_tarball():
     field1val = f"value1a{dv}value1b{dp}value2aa{do}value2ab{dv}value2b{df}"
     field2val = f"value3a{dv}value3b{df}"
     field3val = f"value4a{dp}value4b\n"
+
     annotation_content = header + field1val + field2val + field3val
-    print(annotation_content)
+
     mock_tarball_path = create_mock_tarball(annotation_content)
 
     reader = read_annotation_tarball(
@@ -73,7 +74,6 @@ def test_read_annotation_tarball():
     ]
 
     result_data = next(reader)
-    print(result_data)
     assert result_data == expected_data
 
     # Test the end of the data

--- a/python/python/bystro/search/index/tests/test_bystro_file.py
+++ b/python/python/bystro/search/index/tests/test_bystro_file.py
@@ -1,0 +1,88 @@
+import pytest
+import tarfile
+import io
+import gzip
+import tempfile
+from bystro.search.index.bystro_file import (  # type: ignore # pylint: disable=no-name-in-module,import-error  # noqa: E501
+    read_annotation_tarball,
+)
+from bystro.search.utils.annotation import get_delimiters
+
+
+def create_mock_tarball(annotation_content):
+    # Create a compressed annotation file
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb") as f:
+        f.write(annotation_content.encode())
+
+    # Create a temporary tar file
+    temp_tar_file = tempfile.NamedTemporaryFile(delete=False)
+    with tarfile.open(fileobj=temp_tar_file, mode="w") as t:
+        tarinfo = tarfile.TarInfo(name="annotation.tsv.gz")
+        tarinfo.size = len(buffer.getvalue())
+        buffer.seek(0)
+        t.addfile(tarinfo, buffer)
+
+    return temp_tar_file.name
+
+
+def test_read_annotation_tarball():
+    delims = get_delimiters()
+    dv = delims["value"]  # e.g. ;
+    df = delims["field"]  # e.g. \t
+    do = delims["overlap"]  # e.g. chr(31)
+    dp = delims["position"]  # e.g. |
+
+    header = f"field1{df}field2{df}field3\n"
+    field1val = f"value1a{dv}value1b{dp}value2aa{do}value2ab{dv}value2b{df}"
+    field2val = f"value3a{dv}value3b{df}"
+    field3val = f"value4a{dp}value4b\n"
+    annotation_content = header + field1val + field2val + field3val
+    print(annotation_content)
+    mock_tarball_path = create_mock_tarball(annotation_content)
+
+    reader = read_annotation_tarball(
+        index_name="test_index",
+        tar_path=mock_tarball_path,
+        delimiters=delims,
+        chunk_size=1,
+    )
+
+    # Expected data based on the given annotation_content
+    expected_data = [
+        {
+            "_index": "test_index",
+            "_id": 1,
+            "_source": {
+                "field1": [  # position values
+                    ["value1a", "value1b"],
+                    [  # value values
+                        ["value2aa", "value2ab"],  # overlap values
+                        "value2b",
+                    ],
+                ],
+                "field2": [["value3a", "value3b"]],  # position values  # value values
+                "field3": [  # position values
+                    [
+                        "value4a",
+                    ],
+                    ["value4b"],  # value values
+                ],
+            },
+        }
+    ]
+
+    result_data = next(reader)
+    print(result_data)
+    assert result_data == expected_data
+
+    # Test the end of the data
+    with pytest.raises(StopIteration):
+        next(reader)
+
+    # Test header fields
+    assert reader.get_header_fields() == ["field1", "field2", "field3"]
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/python/python/bystro/search/index/tests/test_bystro_file.py
+++ b/python/python/bystro/search/index/tests/test_bystro_file.py
@@ -28,15 +28,15 @@ def create_mock_tarball(annotation_content):
 
 def test_read_annotation_tarball():
     delims = get_delimiters()
-    dv = delims["value"]  # e.g. ;
-    df = delims["field"]  # e.g. \t
-    do = delims["overlap"]  # e.g. chr(31)
-    dp = delims["position"]  # e.g. |
+    delim_v = delims["value"]  # e.g. ;
+    delim_f = delims["field"]  # e.g. \t
+    delim_o = delims["overlap"]  # e.g. chr(31)
+    delim_p = delims["position"]  # e.g. |
 
-    header = f"field1{df}field2{df}field3\n"
-    field1val = f"value1a{dv}value1b{dp}value2aa{do}value2ab{dv}value2b{df}"
-    field2val = f"value3a{dv}value3b{df}"
-    field3val = f"value4a{dp}value4b\n"
+    header = f"field1{delim_f}field2{delim_f}field3\n"
+    field1val = f"value1a{delim_v}value1b{delim_p}value2aa{delim_o}value2ab{delim_v}value2b{delim_f}"
+    field2val = f"value3a{delim_v}value3b{delim_f}"
+    field3val = f"value4a{delim_p}value4b\n"
 
     annotation_content = header + field1val + field2val + field3val
 

--- a/python/python/bystro/search/index/tests/test_bystro_file.py
+++ b/python/python/bystro/search/index/tests/test_bystro_file.py
@@ -49,25 +49,21 @@ def test_read_annotation_tarball():
         chunk_size=1,
     )
 
-    # Expected data based on the given annotation_content
     expected_data = [
         {
             "_index": "test_index",
             "_id": 1,
             "_source": {
-                "field1": [  # position values
-                    ["value1a", "value1b"],
-                    [  # value values
-                        ["value2aa", "value2ab"],  # overlap values
-                        "value2b",
-                    ],
+                "field1": [
+                    # value1a;value1b|value2aa/value2ab;value2b
+                    [["value1a"], ["value1b"]], # value1a;value1b
+                    [["value2aa","value2ab"], ["value2b"]], # value2aa/value2ab;value2b
                 ],
-                "field2": [["value3a", "value3b"]],  # position values  # value values
-                "field3": [  # position values
-                    [
-                        "value4a",
-                    ],
-                    ["value4b"],  # value values
+                "field2": [
+                    [["value3a"], ["value3b"]]  #value3a;value3B
+                ],
+                "field3": [
+                    [["value4a"]], [["value4b"]],  #value4a|value4B
                 ],
             },
         }

--- a/python/python/bystro/search/index/tests/test_bystro_file.py
+++ b/python/python/bystro/search/index/tests/test_bystro_file.py
@@ -49,6 +49,8 @@ def test_read_annotation_tarball():
         chunk_size=1,
     )
 
+    # In the expected data commented explanations that follow
+    # the overlap delimiter is considered to be "/"
     expected_data = [
         {
             "_index": "test_index",

--- a/python/python/bystro/search/save/handler.py
+++ b/python/python/bystro/search/save/handler.py
@@ -99,16 +99,16 @@ def _make_output_string(rows: list, delims: dict):
 
                         if isinstance(sub, list):
                             inner_values.append(
-                                delims["value"].join(
+                                delims["overlap"].join(
                                     map(lambda x: str(x) if x is not None else empty_field_char, sub)
                                 )
                             )
                         else:
                             inner_values.append(str(sub))
 
-                    column[j] = delims["position"].join(inner_values)
+                    column[j] = delims["value"].join(inner_values)
 
-            row[i] = delims["overlap"].join(column)
+            row[i] = delims["position"].join(column)
 
         rows[row_idx] = delims["field"].join(row)
 

--- a/python/python/bystro/search/save/tests/test_make_output_string.py
+++ b/python/python/bystro/search/save/tests/test_make_output_string.py
@@ -32,7 +32,8 @@ def test_basic_functionality():
         # row2
         [
             # column1
-            [
+            [   
+                # Retain backwards compat with scalar values in 2nd dimension
                 [
                     "row2_scalar"
                 ]

--- a/python/python/bystro/search/save/tests/test_make_output_string.py
+++ b/python/python/bystro/search/save/tests/test_make_output_string.py
@@ -17,7 +17,7 @@ def test_basic_functionality():
                 [  # value values
                     ["gene1_mrna1", None, "gene1_mrna2"], # overlap values
                     # gene1 has 3 transcripts, 1 of which is non-coding and doens't have an mrna record
-                    "gene1",
+                    ["gene1"]
                 ],
                 # 2 value delimited values at the next position in the indel
                 ["position2a", "position2b"],
@@ -25,7 +25,7 @@ def test_basic_functionality():
             # column 2
             [  # position values
                 [
-                    "col2_scalar",
+                    ["col2_scalar"],
                 ]
             ],
         ],

--- a/python/python/bystro/search/save/tests/test_make_output_string.py
+++ b/python/python/bystro/search/save/tests/test_make_output_string.py
@@ -1,0 +1,52 @@
+from bystro.search.save.handler import _make_output_string
+
+delims = {
+    "empty_field": "!",
+    "overlap": "/",
+    "value": ";",
+    "position": "|",
+    "field": "\t",
+}
+
+def test_basic_functionality():
+    rows = [
+        # row 1
+        [
+            # column1
+            [  # position values
+                [  # value values
+                    ["gene1_mrna1", None, "gene1_mrna2"], # overlap values
+                    # gene1 has 3 transcripts, 1 of which is non-coding and doens't have an mrna record
+                    "gene1",
+                ],
+                # 2 value delimited values at the next position in the indel
+                ["position2a", "position2b"],
+            ],
+            # column 2
+            [  # position values
+                [
+                    "col2_scalar",
+                ]
+            ],
+        ],
+        # row2
+        [
+            # column1
+            [
+                [
+                    "row2_scalar"
+                ]
+            ]
+        ]
+    ]
+
+    expected = (
+        b"gene1_mrna1/!/gene1_mrna2;gene1|position2a;position2b\tcol2_scalar\nrow2_scalar\n"
+    )
+
+    assert _make_output_string(rows, delims) == expected
+
+def test_empty_list():
+    rows = []
+    expected = b"\n"
+    assert _make_output_string(rows, delims) == expected


### PR DESCRIPTION
* Simplifies indexing
* Fixes saving parsing regression
* Adds index string -> search _source parsing test

The aim of this PR is to simplify the source structure in indexed documents, and fix a saving regression. We do this by ensuring that if there are no overlap delimited values (the innermost dimension) the innermost value is a scalar.

Briefly, this will ensure that:

het1;het2 will shown as **[ [het1, het2] ]** and not [ [ [het1], [het2] ] ]
and
het1 as **[ [ het1 ] ]**

which will make parsing more straightforward.

Still a bit more work on this one, especially in the need save handler test demonstrating parsing from source document

cc @poneill 

