### PR TITLE
[annotation] uniquefy Bystro outputs

### DIFF
--- a/config/hg19.clean.yml
+++ b/config/hg19.clean.yml
@@ -129,8 +129,8 @@
       build_date: 2019-09-22T04:22:00
       dist: true
       features:
-      - name2
       - name
+      - name2
       from: txStart
       local_files:
       - hg19.kgXref.chr*.with_dbnsfp.gz
@@ -142,8 +142,8 @@
       build_date: 2019-09-22T04:22:00
       dist: true
       features:
-      - name2
       - name
+      - name2
       from: txStart
       local_files:
       - hg19.kgXref.chr*.with_dbnsfp.gz

--- a/config/hg38.clean.yml
+++ b/config/hg38.clean.yml
@@ -107,8 +107,8 @@
       build_date: 2018-09-07T19:32:00
       dist: true
       features:
-      - name2
       - name
+      - name2
       from: txStart
       local_files:
       - hg38.kgXref.chr*.with_dbnsfp.gz
@@ -120,8 +120,8 @@
       build_date: 2018-09-07T19:32:00
       dist: true
       features:
-      - name2
       - name
+      - name2
       from: txStart
       local_files:
       - hg38.kgXref.chr*.with_dbnsfp.gz

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -168,23 +168,16 @@ sub annotateFile {
   ###### Processes pre-processor output passed from file reader/producer #######
   my $refTrackOutIdx = $outIndicesMap->{ $refTrackGetter->name };
 
+  #Accessors are amazingly slow; it takes as long to call ->name as track->get
+  #after accounting for the nubmer of calls to ->name
   my %wantedChromosomes = %{ $refTrackGetter->chromosomes };
   my $maxDel            = $self->maxDel;
 
-  #Accessors are amazingly slow; it takes as long to call ->name as track->get
-  #after accounting for the nubmer of calls to ->name
-  # my @trackNames = map { $_->name } @{$self->_tracks};
-
   my $outJson = $self->outputJson;
-
-  # TODO: don't annotate MT (GRCh37) if MT not explicitly specified
-  # to avoid issues between GRCh37 and hg19 chrM vs MT
-  # my %normalizedNames = %{$self->normalizedWantedChrs};
 
   mce_loop_f {
     #my ($mce, $slurp_ref, $chunk_id) = @_;
     #    $_[0], $_[1],     $_[2]
-    #open my $MEM_FH, '<', $slurp_ref; binmode $MEM_FH, ':raw';
     open my $MEM_FH, '<', $_[1];
     binmode $MEM_FH, ':raw';
 
@@ -244,7 +237,6 @@ sub annotateFile {
             # Note that position_1_based - (negativeDelLength + 2) == position_0_based + (delLength - 1)
             if ( $fields[4] < $maxDel ) {
               @indelDbData = ( $fields[1] .. $fields[1] - ( $maxDel + 2 ) );
-              # $self->log('info', "$fields[0]:$fields[1]: long deletion. Annotating up to $maxDel");
             }
             else {
               @indelDbData = ( $fields[1] .. $fields[1] - ( $fields[4] + 2 ) );

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -1,6 +1,7 @@
 use 5.10.0;
 use strict;
 use warnings;
+
 package Seq;
 
 our $VERSION = '0.001';
@@ -156,8 +157,13 @@ sub annotateFile {
   # Are the features that come from our database
   # Meaning, we can skip anything forwarded from the pre-processor
 
-  my $outputter =
-    Seq::Output->new( { header => $finalHeader, trackOutIndices => \@allOutIndices, refTrackName => $refTrackGetter->name } );
+  my $outputter = Seq::Output->new(
+    {
+      header          => $finalHeader,
+      trackOutIndices => \@allOutIndices,
+      refTrackName    => $refTrackGetter->name
+    }
+  );
   # my $outputFn;
   # if($self->outputJson) {
   #   $outputFn = \&encode_json;

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -164,13 +164,6 @@ sub annotateFile {
       refTrackName    => $refTrackGetter->name
     }
   );
-  # my $outputFn;
-  # if($self->outputJson) {
-  #   $outputFn = \&encode_json;
-  # } else {
-  #   my $outputter = Seq::Output->new({header => $finalHeader, trackOutIndices => \@allOutIndices});
-  #   $outputFn = \$outputter->makeOutputString;
-  # }
 
   ###### Processes pre-processor output passed from file reader/producer #######
   my $refTrackOutIdx = $outIndicesMap->{ $refTrackGetter->name };

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -1,7 +1,6 @@
 use 5.10.0;
 use strict;
 use warnings;
-
 package Seq;
 
 our $VERSION = '0.001';
@@ -158,7 +157,7 @@ sub annotateFile {
   # Meaning, we can skip anything forwarded from the pre-processor
 
   my $outputter =
-    Seq::Output->new( { header => $finalHeader, trackOutIndices => \@allOutIndices } );
+    Seq::Output->new( { header => $finalHeader, trackOutIndices => \@allOutIndices, refTrackName => $refTrackGetter->name } );
   # my $outputFn;
   # if($self->outputJson) {
   #   $outputFn = \&encode_json;

--- a/perl/lib/Seq/Output.pm
+++ b/perl/lib/Seq/Output.pm
@@ -76,8 +76,8 @@ sub uniqueify {
   my %count;
   my $undefCount = 0;
 
-  if (!@{ $_[0] }) {
-    return []
+  if ( !@{ $_[0] } ) {
+    return $_[0];
   }
 
   foreach my $value ( @{ $_[0] } ) {
@@ -182,12 +182,14 @@ sub makeOutputString {
         # It's an array, for instance, CADD scores are
         $row->[$oIdx] = join(
           $posDelim,
-          uniqueify(
-            [
-              map { !defined $_ ? $missChar : ref $_ ? $self->mungeRow($_) : $_ }
-                @{ $row->[$oIdx] }
-            ]
-          )
+          @{
+            uniqueify(
+              [
+                map { !defined $_ ? $missChar : ref $_ ? $self->mungeRow($_) : $_ }
+                  @{ $row->[$oIdx] }
+              ]
+            )
+          }
         );
 
         next;

--- a/perl/lib/Seq/Output.pm
+++ b/perl/lib/Seq/Output.pm
@@ -76,6 +76,10 @@ sub uniqueify {
   my %count;
   my $undefCount = 0;
 
+  if (!@{ $_[0] }) {
+    return []
+  }
+
   foreach my $value ( @{ $_[0] } ) {
     if ( !defined $value ) {
       $undefCount++;
@@ -85,7 +89,11 @@ sub uniqueify {
     }
   }
 
-  if ( $undefCount == @{ $_[0] } || scalar keys %count == 1 ) {
+  if ( $undefCount == @{ $_[0] } ) {
+    return [ $_[0]->[0] ];
+  }
+
+  if ( $undefCount == 0 && scalar keys %count == 1 ) {
     return [ $_[0]->[0] ];
   }
 

--- a/perl/lib/Seq/Output.pm
+++ b/perl/lib/Seq/Output.pm
@@ -24,8 +24,8 @@ has delimiters => (
 );
 
 has refTrackName => (
-  is      => 'ro',
-  isa     => 'Str',
+  is  => 'ro',
+  isa => 'Str',
 );
 
 sub BUILD {
@@ -56,7 +56,7 @@ sub BUILD {
 
     push @{ $self->{_trackOutIndices} }, $outIdx;
 
-    if($trackName eq $self->refTrackName) {
+    if ( $trackName eq $self->refTrackName ) {
       $self->{_refTrackIdx} = $outIdx;
       next;
     }
@@ -71,22 +71,23 @@ sub BUILD {
 }
 
 sub uniqueify {
-    my %count;
-    my $undefCount = 0;
+  my %count;
+  my $undefCount = 0;
 
-    foreach my $value (@{$_[0]}) {
-      if(!defined $value) {
-        $undefCount++;
-      } else {
-        $count{$value} = 1;
-      }
+  foreach my $value ( @{ $_[0] } ) {
+    if ( !defined $value ) {
+      $undefCount++;
     }
-
-    if($undefCount == @{$_[0]} || scalar keys %count == 1) {
-        return [$_[0]->[0]];
+    else {
+      $count{$value} = 1;
     }
+  }
 
-    return $_[0];
+  if ( $undefCount == @{ $_[0] } || scalar keys %count == 1 ) {
+    return [ $_[0]->[0] ];
+  }
+
+  return $_[0];
 }
 
 # ABSTRACT: Knows how to make an output string
@@ -113,8 +114,8 @@ sub makeOutputString {
     # info = [$outIdx, $numFeatures, $missingValue]
     # if $numFeatures == 0, this track has no features
     TRACK_LOOP: for my $oIdx ( @{ $self->{_trackOutIndices} } ) {
-      if($oIdx == $self->{_refTrackIdx}) {
-        $row->[$oIdx] = join '', @{$row->[$oIdx]};
+      if ( $oIdx == $self->{_refTrackIdx} ) {
+        $row->[$oIdx] = join '', @{ $row->[$oIdx] };
         next;
       }
 
@@ -137,7 +138,7 @@ sub makeOutputString {
           }
 
           if ( ref $row->[$oIdx][0] ) {
-            $row->[$oIdx] = join( $valDelim, @{uniqueify($row->[$oIdx][0])} );
+            $row->[$oIdx] = join( $valDelim, @{ uniqueify( $row->[$oIdx][0] ) } );
             next;
           }
 
@@ -160,13 +161,13 @@ sub makeOutputString {
               ref $_
               ?
                 # at this position this feature has multiple values
-                join( $valDelim, map { defined $_ ? $_ : $missChar } @{uniqueify($_)} )
+                join( $valDelim, map { defined $_ ? $_ : $missChar } @{ uniqueify($_) } )
               :
                 # at this position this feature has 1 value
                 $_
               )
               : $missChar
-          } @{ uniqueify($row->[$oIdx]) }
+          } @{ uniqueify( $row->[$oIdx] ) }
         );
 
         next;
@@ -199,25 +200,31 @@ sub makeOutputString {
 
           $row->[$oIdx][$featIdx] = join(
             $valDelim,
-            @{ uniqueify([map {
-              defined $_
-                ? (
-                ref $_
-                ?
-                  # at this position this feature has multiple values
-                  join( $overlapDelim, map { defined $_ ? $_ : $missChar } @{uniqueify($_)} )
-                :
-                  # at this position this feature has 1 value
-                  $_
-                )
-                : $missChar
-            } @{ $row->[$oIdx][$featIdx][0] } ]) }
+            @{
+              uniqueify(
+                [
+                  map {
+                    defined $_
+                      ? (
+                      ref $_
+                      ?
+                        # at this position this feature has multiple values
+                        join( $overlapDelim, map { defined $_ ? $_ : $missChar } @{ uniqueify($_) } )
+                      :
+                        # at this position this feature has 1 value
+                        $_
+                      )
+                      : $missChar
+                  } @{ $row->[$oIdx][$featIdx][0] }
+                ]
+              )
+            }
           );
 
           next;
         }
 
-        for my $posData ( @{ $row->[$oIdx][$featIdx]} ) {
+        for my $posData ( @{ $row->[$oIdx][$featIdx] } ) {
           if ( !defined $posData ) {
             $posData = $missChar;
 
@@ -239,23 +246,30 @@ sub makeOutputString {
           # t1;t2 \t t1_name1\\t1_name2;t2_onlyName
           $posData = join(
             $valDelim,
-            @{ uniqueify([ map {
-              defined $_
-                ? (
-                ref $_
-                ?
-                  # at this position this feature has multiple values
-                  join( $overlapDelim, map { defined $_ ? $_ : $missChar } @{uniqueify($_)} )
-                :
-                  # at this position this feature has 1 value
-                  $_
-                )
-                : $missChar
-            } @{ $posData } ]) }
+            @{
+              uniqueify(
+                [
+                  map {
+                    defined $_
+                      ? (
+                      ref $_
+                      ?
+                        # at this position this feature has multiple values
+                        join( $overlapDelim, map { defined $_ ? $_ : $missChar } @{ uniqueify($_) } )
+                      :
+                        # at this position this feature has 1 value
+                        $_
+                      )
+                      : $missChar
+                  } @{$posData}
+                ]
+              )
+            }
           );
         }
 
-        $row->[$oIdx][$featIdx] = join( $posDelim, @{ uniqueify($row->[$oIdx][$featIdx]) } );
+        $row->[$oIdx][$featIdx] =
+          join( $posDelim, @{ uniqueify( $row->[$oIdx][$featIdx] ) } );
       }
 
       # Fields are separated by something like tab

--- a/perl/t/output.t
+++ b/perl/t/output.t
@@ -13,29 +13,29 @@ my $head = Seq::Headers->new();
 $head->addFeaturesToHeader('preProcessorHeader1');
 $head->addFeaturesToHeader( [ 'c1a', 'c1b', 'c1c' ], 'withFeaturesTrack1' );
 $head->addFeaturesToHeader('scalarTrack2');
-$head->addFeaturesToHeader( [ 'c2a', 'c2b', 'c2c_overlapped_vals' ],
-  'withFeaturesTrack2' );
+$head->addFeaturesToHeader( [ 'c2a', 'c2b', 'c2c_overlapped_vals' ], 'withFeaturesTrack3' );
+$head->addFeaturesToHeader( 'ref' );
 
 # trackOutIndices simply tracks Seq features apart from those passed in by
 # a pre-processor
 # this allows us to skip iterating over very long feature arrays on which we do no work
 my $outputter =
-  Seq::Output->new( { header => $head, trackOutIndices => [ 1, 2, 3 ] } );
+  Seq::Output->new( { header => $head, trackOutIndices => [ 1, 2, 3, 4 ], refTrackName => 'ref' } );
 
 my $delims = Seq::Output::Delimiters->new();
-
 my $header = $head->getOrderedHeader();
 
-ok( @$header == 4,          "Output header matches # of tracks" );
+ok( @$header == 5,          "Output header matches # of tracks" );
 ok( @{ $header->[1] } == 3, "First package-defined track has 3 features" );
-ok( !ref $header->[2],      "Second track has 1 feature" );
+ok( !ref $header->[2],      "Second track has no features, is itself a feature" );
 ok( @{ $header->[3] } == 3, "Third track has 2 features" );
+ok( !ref $header->[4], "Fourth track has no features, is itself a feature" );
 
 my $hStr = $head->getString();
 
 my @headFields = split( $delims->fieldSeparator, $hStr );
 
-ok( @headFields == 8,
+ok( @headFields == 9,
   "String header contains all expected fields, including those from pre-processor" );
 
 # Everything is output as an array
@@ -80,7 +80,7 @@ $expected .= $delims->fieldSeparator . $valTrack2;
 
 # Separate delimiters so that one can clearly see that track3_feat3_*
 # have a relationship with track3_feat3_val1
-my @valsTrack2 = (
+my @valsTrack3 = (
   'track3_feat1',
   'track3_feat2',
   [
@@ -88,16 +88,24 @@ my @valsTrack2 = (
   ]
 );
 
-$row[3][0][$posIdx] = $valsTrack2[0];
-$row[3][1][$posIdx] = $valsTrack2[1];
-$row[3][2][$posIdx] = $valsTrack2[2];
+$row[3][0][$posIdx] = $valsTrack3[0];
+$row[3][1][$posIdx] = $valsTrack3[1];
+$row[3][2][$posIdx] = $valsTrack3[2];
 
-my $nestedVals = join( $delims->overlapDelimiter, @{ $valsTrack2[2][1] } );
+# Add the reference
+# Scalar tracks by definition have no features, and so in Bystro
+# they are always 1 nested less deep
+$row[4][0] = 'C';
+
+my $nestedVals = join( $delims->overlapDelimiter, @{ $valsTrack3[2][1] } );
 my $track3field3val =
-  join( $delims->valueDelimiter, $valsTrack2[2][0], $nestedVals );
+  join( $delims->valueDelimiter, $valsTrack3[2][0], $nestedVals );
 
 $expected .= $delims->fieldSeparator
-  . join( $delims->fieldSeparator, @valsTrack2[ 0 .. 1 ], $track3field3val ) . "\n";
+  . join( $delims->fieldSeparator, @valsTrack3[ 0 .. 1 ], $track3field3val );
+
+# Add ref
+$expected .= $delims->fieldSeparator . "C" . "\n";
 
 my @rows = ( \@row );
 
@@ -110,6 +118,50 @@ my @rowFields = split( $delims->fieldSeparator, $str );
 
 ok( @headFields == @rowFields,
   "Output string length matches flattened header length" );
+
+# Test all values duplicate
+@row = ( "somePreProcessorVal", [], [], [], []);
+$expected = "somePreProcessorVal" . $delims->fieldSeparator;
+
+# Test all values duplicate
+$row[1][0][0] = [ "t1_1a", "t1_1a" ];
+# When both values are duplicate in an inner array, we expect a single value, with no overlap delimiter
+$row[1][1][0] = [ [ "t1_2aa", "t1_2aa" ], [ "t1_2ba", "t1_2ba" ] ];
+# If all values are duplicate across delimiters, we expect a single value, with no overlap delimiter or value delimiter
+$row[1][2][0] = [ [ "t1_3aa", "t1_3aa"  ], [ "t1_3aa", "t1_3aa", "t1_3aa", "t1_3aa" ] ];
+
+# Track 1 values
+$expected .= "t1_1a" .  $delims->fieldSeparator; #$row[1][0][0]
+$expected .= "t1_2aa" . $delims->valueDelimiter . "t1_2ba" . $delims->fieldSeparator; #$row[1][1][0]
+$expected .= "t1_3aa" . $delims->fieldSeparator; #$row[1][1][0]
+
+# We still handle scalar values just fine
+$row[2][0] = "blah";
+
+$expected .= "blah" . $delims->fieldSeparator;
+
+# If not all values deuplicated, we won't deduplcate anything
+$row[3][0][0] = [ "t3_1a", "t3_1a",  "t3_1b"];
+# When not all values duplicated in inner array, we will not deduplicate
+$row[3][1][0] = [ [ "t3_2aa", 't3_2aa', 't3_2ab' ], [ "t3_2ba", 't3_2ba' ] ];
+# We will deduplicate values across position delimiters too
+$row[3][2][0] = "t3_3a";
+$row[3][2][1] = "t3_3a";
+
+#$row[2][0][0]
+$expected .= join($delims->valueDelimiter, ("t3_1a", "t3_1a",  "t3_1b")) . $delims->fieldSeparator;
+#$row[2][1][0]
+$expected .= join($delims->overlapDelimiter, ("t3_2aa", 't3_2aa', 't3_2ab')) . $delims->valueDelimiter . "t3_2ba" . $delims->fieldSeparator;
+#$row[2][2][0] & $row[2][2][1] are collapsed into a single value since they are the same
+$expected .= "t3_3a" . $delims->fieldSeparator;
+
+$row[4][0] = "T";
+
+$expected .= "T" . "\n";
+
+$str = $outputter->makeOutputString( [\@row] );
+
+ok( $str eq $expected, "De-duplicates values" );
 
 done_testing();
 1;

--- a/perl/t/output.t
+++ b/perl/t/output.t
@@ -119,7 +119,7 @@ my @rowFields = split( $delims->fieldSeparator, $str );
 ok( @headFields == @rowFields,
   "Output string length matches flattened header length" );
 
-# Test all values duplicate
+########## Test value deduplication in makeOutputString ##########
 @row = ( "somePreProcessorVal", [], [], [], []);
 $expected = "somePreProcessorVal" . $delims->fieldSeparator;
 
@@ -162,6 +162,27 @@ $expected .= "T" . "\n";
 $str = $outputter->makeOutputString( [\@row] );
 
 ok( $str eq $expected, "De-duplicates values" );
+
+######### Test uniquefy  ##########
+# Test 1: All identical defined values
+my $result1 = Seq::Output::uniqueify( ['a', 'a', 'a'] );
+is_deeply($result1, ['a'], "All identical values");
+
+# Test 2: All undefined values
+my $result2 = Seq::Output::uniqueify( [undef, undef, undef] );
+is_deeply($result2, [undef], "All undefined values");
+
+# Test 3: Mix of undefined and defined values
+my $result3 = Seq::Output::uniqueify( ['b', undef, 'b'] );
+is_deeply($result3, ['b', undef, 'b'], "Mix of undefined and defined values");
+
+# Test 4: Multiple distinct defined values
+my $result4 = Seq::Output::uniqueify( ['c', 'd'] );
+is_deeply($result4, ['c', 'd'], "Multiple distinct values");
+
+# Test 5: Empty array
+my $result5 = Seq::Output::uniqueify( [] );
+is_deeply($result5, [], "Empty array");
 
 done_testing();
 1;

--- a/perl/t/output.t
+++ b/perl/t/output.t
@@ -13,14 +13,16 @@ my $head = Seq::Headers->new();
 $head->addFeaturesToHeader('preProcessorHeader1');
 $head->addFeaturesToHeader( [ 'c1a', 'c1b', 'c1c' ], 'withFeaturesTrack1' );
 $head->addFeaturesToHeader('scalarTrack2');
-$head->addFeaturesToHeader( [ 'c2a', 'c2b', 'c2c_overlapped_vals' ], 'withFeaturesTrack3' );
-$head->addFeaturesToHeader( 'ref' );
+$head->addFeaturesToHeader( [ 'c2a', 'c2b', 'c2c_overlapped_vals' ],
+  'withFeaturesTrack3' );
+$head->addFeaturesToHeader('ref');
 
 # trackOutIndices simply tracks Seq features apart from those passed in by
 # a pre-processor
 # this allows us to skip iterating over very long feature arrays on which we do no work
 my $outputter =
-  Seq::Output->new( { header => $head, trackOutIndices => [ 1, 2, 3, 4 ], refTrackName => 'ref' } );
+  Seq::Output->new(
+  { header => $head, trackOutIndices => [ 1, 2, 3, 4 ], refTrackName => 'ref' } );
 
 my $delims = Seq::Output::Delimiters->new();
 my $header = $head->getOrderedHeader();
@@ -29,7 +31,7 @@ ok( @$header == 5,          "Output header matches # of tracks" );
 ok( @{ $header->[1] } == 3, "First package-defined track has 3 features" );
 ok( !ref $header->[2],      "Second track has no features, is itself a feature" );
 ok( @{ $header->[3] } == 3, "Third track has 2 features" );
-ok( !ref $header->[4], "Fourth track has no features, is itself a feature" );
+ok( !ref $header->[4],      "Fourth track has no features, is itself a feature" );
 
 my $hStr = $head->getString();
 
@@ -120,7 +122,7 @@ ok( @headFields == @rowFields,
   "Output string length matches flattened header length" );
 
 ########## Test value deduplication in makeOutputString ##########
-@row = ( "somePreProcessorVal", [], [], [], []);
+@row      = ( "somePreProcessorVal", [], [], [], [] );
 $expected = "somePreProcessorVal" . $delims->fieldSeparator;
 
 # Test all values duplicate
@@ -128,20 +130,25 @@ $row[1][0][0] = [ "t1_1a", "t1_1a" ];
 # When both values are duplicate in an inner array, we expect a single value, with no overlap delimiter
 $row[1][1][0] = [ [ "t1_2aa", "t1_2aa" ], [ "t1_2ba", "t1_2ba" ] ];
 # If all values are duplicate across delimiters, we expect a single value, with no overlap delimiter or value delimiter
-$row[1][2][0] = [ [ "t1_3aa", "t1_3aa"  ], [ "t1_3aa", "t1_3aa", "t1_3aa", "t1_3aa" ] ];
+$row[1][2][0] =
+  [ [ "t1_3aa", "t1_3aa" ], [ "t1_3aa", "t1_3aa", "t1_3aa", "t1_3aa" ] ];
 
 # Track 1 values
-$expected .= "t1_1a" .  $delims->fieldSeparator; #$row[1][0][0]
-$expected .= "t1_2aa" . $delims->valueDelimiter . "t1_2ba" . $delims->fieldSeparator; #$row[1][1][0]
+$expected .= "t1_1a" . $delims->fieldSeparator; #$row[1][0][0]
+$expected .=
+    "t1_2aa"
+  . $delims->valueDelimiter
+  . "t1_2ba"
+  . $delims->fieldSeparator;                    #$row[1][1][0]
 $expected .= "t1_3aa" . $delims->fieldSeparator; #$row[1][1][0]
 
 # We still handle scalar values just fine
-$row[2][0] = "blah";
+$row[2][0] = [ "blah", "blah", "blah" ];
 
 $expected .= "blah" . $delims->fieldSeparator;
 
 # If not all values deuplicated, we won't deduplcate anything
-$row[3][0][0] = [ "t3_1a", "t3_1a",  "t3_1b"];
+$row[3][0][0] = [ "t3_1a", "t3_1a", "t3_1b" ];
 # When not all values duplicated in inner array, we will not deduplicate
 $row[3][1][0] = [ [ "t3_2aa", 't3_2aa', 't3_2ab' ], [ "t3_2ba", 't3_2ba' ] ];
 # We will deduplicate values across position delimiters too
@@ -149,9 +156,14 @@ $row[3][2][0] = "t3_3a";
 $row[3][2][1] = "t3_3a";
 
 #$row[2][0][0]
-$expected .= join($delims->valueDelimiter, ("t3_1a", "t3_1a",  "t3_1b")) . $delims->fieldSeparator;
+$expected .= join( $delims->valueDelimiter, ( "t3_1a", "t3_1a", "t3_1b" ) )
+  . $delims->fieldSeparator;
 #$row[2][1][0]
-$expected .= join($delims->overlapDelimiter, ("t3_2aa", 't3_2aa', 't3_2ab')) . $delims->valueDelimiter . "t3_2ba" . $delims->fieldSeparator;
+$expected .=
+    join( $delims->overlapDelimiter, ( "t3_2aa", 't3_2aa', 't3_2ab' ) )
+  . $delims->valueDelimiter
+  . "t3_2ba"
+  . $delims->fieldSeparator;
 #$row[2][2][0] & $row[2][2][1] are collapsed into a single value since they are the same
 $expected .= "t3_3a" . $delims->fieldSeparator;
 
@@ -159,30 +171,30 @@ $row[4][0] = "T";
 
 $expected .= "T" . "\n";
 
-$str = $outputter->makeOutputString( [\@row] );
+$str = $outputter->makeOutputString( [ \@row ] );
 
 ok( $str eq $expected, "De-duplicates values" );
 
 ######### Test uniquefy  ##########
 # Test 1: All identical defined values
-my $result1 = Seq::Output::uniqueify( ['a', 'a', 'a'] );
-is_deeply($result1, ['a'], "All identical values");
+my $result1 = Seq::Output::uniqueify( [ 'a', 'a', 'a' ] );
+is_deeply( $result1, ['a'], "All identical values" );
 
 # Test 2: All undefined values
-my $result2 = Seq::Output::uniqueify( [undef, undef, undef] );
-is_deeply($result2, [undef], "All undefined values");
+my $result2 = Seq::Output::uniqueify( [ undef, undef, undef ] );
+is_deeply( $result2, [undef], "All undefined values" );
 
 # Test 3: Mix of undefined and defined values
-my $result3 = Seq::Output::uniqueify( ['b', undef, 'b'] );
-is_deeply($result3, ['b', undef, 'b'], "Mix of undefined and defined values");
+my $result3 = Seq::Output::uniqueify( [ 'b', undef, 'b' ] );
+is_deeply( $result3, [ 'b', undef, 'b' ], "Mix of undefined and defined values" );
 
 # Test 4: Multiple distinct defined values
-my $result4 = Seq::Output::uniqueify( ['c', 'd'] );
-is_deeply($result4, ['c', 'd'], "Multiple distinct values");
+my $result4 = Seq::Output::uniqueify( [ 'c', 'd' ] );
+is_deeply( $result4, [ 'c', 'd' ], "Multiple distinct values" );
 
 # Test 5: Empty array
 my $result5 = Seq::Output::uniqueify( [] );
-is_deeply($result5, [], "Empty array");
+is_deeply( $result5, [], "Empty array" );
 
 done_testing();
 1;


### PR DESCRIPTION
* If all delimited outputs are duplicates, output only the single unique value
* Join ref on '', converting A|C|G|T => ACGT in the del case, or A|C => AC in the ins case. SNV are unaffected


Needs tests, but worth a look anyway. Live on bystro-dev.emory.edu

This is motivated by Pat's feedback and agreed upon with Dave (going to have him double check the output of a test case just in case)

Attached before & after annotations:
[before_trio_trim_vep_vcf.annotation.tsv.zip](https://github.com/bystrogenomics/bystro/files/13161175/before_trio_trim_vep_vcf.annotation.tsv.zip)
[after_trio_trim_vep_vcf.annotation.tsv.gz](https://github.com/bystrogenomics/bystro/files/13172838/after_trio_trim_vep_vcf.annotation.tsv.gz)

