### PR TITLE
use zstd for all mapping codecs

### DIFF
--- a/config/dm6.mapping.yml
+++ b/config/dm6.mapping.yml
@@ -15,7 +15,7 @@ sort:
       refresh_interval: -1
       number_of_replicas: 0
       number_of_shards: 6
-      codec: best_compression
+      codec: zstd
     analysis:
       normalizer:
         lowercase_normalizer:

--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -26,7 +26,7 @@ index_settings:
   index:
     refresh_interval: -1
     number_of_replicas: 0
-    codec: best_compression
+    codec: zstd
   analysis:
     normalizer:
       lowercase_normalizer:

--- a/config/hg19_ensembl.mapping.yml
+++ b/config/hg19_ensembl.mapping.yml
@@ -30,7 +30,7 @@ index_settings:
         refresh_interval: -1
         number_of_replicas: 0
         number_of_shards: 12
-        codec: best_compression
+        codec: zstd
     analysis:
         normalizer:
             lowercase_normalizer:

--- a/config/sacCer3.mapping.yml
+++ b/config/sacCer3.mapping.yml
@@ -24,7 +24,7 @@ index_settings:
       refresh_interval: -1
       number_of_replicas: 0
       number_of_shards: 9
-      codec: best_compression
+      codec: zstd
   analysis:
       normalizer:
           lowercase_normalizer:


### PR DESCRIPTION
* Uses the same zest compression algorithm for all mapping configs

ZSTD brings throughput benefits vs "best_compression" https://opensearch.org/docs/latest/im-plugin/index-codecs/

