### PR TITLE
[annotator] Add CaddIndel -> VCF script

### DIFF
--- a/perl/lib/Utils/scripts/cadd_indel_to_vcf.sh
+++ b/perl/lib/Utils/scripts/cadd_indel_to_vcf.sh
@@ -1,36 +1,76 @@
-#!/bin/bash
+#!/bin/env bash
 
-# Check for the input file
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 input_file"
+# Function to show help
+show_help() {
+    echo "Usage: $0 [OPTION]..."
+    echo "Convert a custom file format to VCF."
+    echo "Reads from standard input if '-' is provided as an argument, or use --input to specify a file."
+    echo
+    echo "  -h, --help    Display this help and exit"
+    echo "  --input FILE  Specify the input file to be converted"
+}
+
+# No arguments provided (not even a dash)
+if [ "$#" -eq 0 ]; then
+    show_help
     exit 1
 fi
 
-input_file=$1
+# Variables
+input_file=""
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --input)
+            if [[ -n $input_file ]]; then
+                echo "Error: Cannot use --input with '-' argument."
+                exit 1
+            fi
+            input_file="$2"
+            shift # Remove argument name from processing
+            shift # Remove argument value from processing
+            ;;
+        -)
+            if [[ -n $input_file ]]; then
+                echo "Error: Cannot use '-' with --input argument."
+                exit 1
+            fi
+            input_file="-" # Indicate that we should read from stdin
+            shift
+            ;;
+        *)
+            # Unknown option
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
 
 # VCF Header
-echo "##fileformat=VCFv4.2"
-echo "##source=CADD_GRCh37-v1.6"
-echo "##reference=GRCh37"
-echo '##INFO=<ID=RawScore,Number=1,Type=Float,Description="Raw CADD score">'
-echo '##INFO=<ID=PHRED,Number=1,Type=Float,Description="CADD PHRED-like score">'
-echo -e "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
+cat <<EOF
+##fileformat=VCFv4.2
+##source=CADD_GRCh37-v1.6
+##reference=GRCh37
+##INFO=<ID=RawScore,Number=1,Type=Float,Description="Raw CADD score">
+##INFO=<ID=PHRED,Number=1,Type=Float,Description="CADD PHRED-like score">
+#CHROM POS ID REF ALT QUAL FILTER INFO
+EOF
 
-# Process the input file and convert it to VCF format
-tail -n +3 "$input_file" | while read -r line; do
-    # Read the columns into variables
-    read -a fields <<< "$line"
-    chrom=${fields[0]}
-    pos=${fields[1]}
-    ref=${fields[2]}
-    alt=${fields[3]}
-    rawscore=${fields[4]}
-    phred=${fields[5]}
-
-    # Create the INFO field content
-    info="RawScore=${rawscore};PHRED=${phred}"
-
-    # VCF columns: CHROM POS ID REF ALT QUAL FILTER INFO
-    echo -e "${chrom}\t${pos}\t.\t${ref}\t${alt}\t.\t.\t${info}"
-
-done
+# Process the file or stdin and convert it to VCF format using awk
+if [[ $input_file == "-" ]]; then
+    # Read from stdin
+    awk 'FNR > 2 { printf("%s\t%s\t.\t%s\t%s\t.\t.\tRawScore=%s;PHRED=%s\n", $1, $2, $3, $4, $5, $6) }'
+else
+    # Check if the file exists
+    if [[ ! -f $input_file ]]; then
+        echo "Error: File does not exist."
+        exit 1
+    fi
+    awk 'FNR > 2 { printf("%s\t%s\t.\t%s\t%s\t.\t.\tRawScore=%s;PHRED=%s\n", $1, $2, $3, $4, $5, $6) }' "$input_file"
+fi

--- a/perl/lib/Utils/scripts/cadd_indel_to_vcf.sh
+++ b/perl/lib/Utils/scripts/cadd_indel_to_vcf.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Check for the input file
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 input_file"
+    exit 1
+fi
+
+input_file=$1
+
+# VCF Header
+echo "##fileformat=VCFv4.2"
+echo "##source=CADD_GRCh37-v1.6"
+echo "##reference=GRCh37"
+echo '##INFO=<ID=RawScore,Number=1,Type=Float,Description="Raw CADD score">'
+echo '##INFO=<ID=PHRED,Number=1,Type=Float,Description="CADD PHRED-like score">'
+echo -e "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
+
+# Process the input file and convert it to VCF format
+tail -n +3 "$input_file" | while read -r line; do
+    # Read the columns into variables
+    read -a fields <<< "$line"
+    chrom=${fields[0]}
+    pos=${fields[1]}
+    ref=${fields[2]}
+    alt=${fields[3]}
+    rawscore=${fields[4]}
+    phred=${fields[5]}
+
+    # Create the INFO field content
+    info="RawScore=${rawscore};PHRED=${phred}"
+
+    # VCF columns: CHROM POS ID REF ALT QUAL FILTER INFO
+    echo -e "${chrom}\t${pos}\t.\t${ref}\t${alt}\t.\t.\t${info}"
+
+done

--- a/perl/lib/Utils/scripts/cadd_indel_to_vcf.sh
+++ b/perl/lib/Utils/scripts/cadd_indel_to_vcf.sh
@@ -59,8 +59,8 @@ cat <<EOF
 ##reference=GRCh37
 ##INFO=<ID=RawScore,Number=1,Type=Float,Description="Raw CADD score">
 ##INFO=<ID=PHRED,Number=1,Type=Float,Description="CADD PHRED-like score">
-#CHROM POS ID REF ALT QUAL FILTER INFO
 EOF
+echo -e "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
 
 # Process the file or stdin and convert it to VCF format using awk
 if [[ $input_file == "-" ]]; then


### PR DESCRIPTION
* Adds script to convert CaddIndel format, which is something they came up with, for VCF, which is standard. This allows us to re-use our VCF builder to build CaddIndel scores.

Input:
```
## CADD GRCh37-v1.6 (c) University of Washington, Hudson-Alpha Institute for Biotechnology and Berlin Institute of Health 2013-2020. All rights reserved.
#Chrom  Pos     Ref     Alt     RawScore        PHRED
1       10001   T       TC      -0.115832       1.266
1       10009   A       AC      -0.115586       1.268
1       10012   C       CT      -0.116324       1.261
1       10013   T       TA      -0.116117       1.263
1       10015   A       AC      -0.115701       1.267
1       10021   A       AC      -0.117355       1.253
1       10027   A       AC      -0.114670       1.275
1       10033   A       AC      -0.098175       1.423
1       10039   A       AC      -0.098341       1.422
1       10045   A       AC      -0.098460       1.421
1       10049   TA      T       -0.106227       1.349
1       10054   C       CTT     -0.102631       1.382
```

Output:
```
##fileformat=VCFv4.2
##source=CADD_GRCh37-v1.6
##reference=GRCh37
##INFO=<ID=RawScore,Number=1,Type=Float,Description="Raw CADD score">
##INFO=<ID=PHRED,Number=1,Type=Float,Description="CADD PHRED-like score">
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
1       10001   .       T       TC      .       .       RawScore=-0.115832;PHRED=1.266
1       10009   .       A       AC      .       .       RawScore=-0.115586;PHRED=1.268
1       10012   .       C       CT      .       .       RawScore=-0.116324;PHRED=1.261
1       10013   .       T       TA      .       .       RawScore=-0.116117;PHRED=1.263
1       10015   .       A       AC      .       .       RawScore=-0.115701;PHRED=1.267
1       10021   .       A       AC      .       .       RawScore=-0.117355;PHRED=1.253
1       10027   .       A       AC      .       .       RawScore=-0.114670;PHRED=1.275
1       10033   .       A       AC      .       .       RawScore=-0.098175;PHRED=1.423
1       10039   .       A       AC      .       .       RawScore=-0.098341;PHRED=1.422
1       10045   .       A       AC      .       .       RawScore=-0.098460;PHRED=1.421
1       10049   .       TA      T       .       .       RawScore=-0.106227;PHRED=1.349
1       10054   .       C       CTT     .       .       RawScore=-0.102631;PHRED=1.382
```

The script also validates the CADD Indel header, extracts genome and version, and if an unexpected header found, errors as follows:

```sh
Error: Invalid header line or reference genome and CADD version not found.
Error: Unable to extract reference genome and CADD version.
```