### PR TITLE
[annotator] Use NA as the emptyField

### DIFF
--- a/FIELDS.md
+++ b/FIELDS.md
@@ -4,13 +4,13 @@
 <br/>
 
 ### General output information:
-<p style="margin-left: 40px"> Missing data in the annotation is marked by <strong>'!'</strong>  </p>
+<p style="margin-left: 40px"> Missing data in the annotation is marked by <strong>'NA'</strong>  </p>
 <p style="margin-left: 40px"> Multiple values for a single annotated position are separated by <strong>';'</strong> </p>
 <p style="margin-left: 40px"> Multiple positions on a single annotation line (occurs with indels only) are separated by <strong>'|'</strong> </p>
 <p style="margin-left: 40px"> Annotated output data is ordered in the same way as the original file. </p>
 
 Reserved characters:
-  - "!" ";" "|" "/"
+  - ";" "|" "/"
   - "/" Will be used in a future release to denote overlapping data from a single track
     - For instance if 2 different dbSNP records overlap, which often occurs with indels, or when two refSeq transcripts overlap at the same position
     - Currently such sites are compressed to ";", but this loses information when a 1:1 relationship does not exist between a track's fields

--- a/config/ce11.clean.yml
+++ b/config/ce11.clean.yml
@@ -23,10 +23,10 @@ statistics:
 temp_dir: "~"
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --keepId --keepPos
+    args: --emptyField NA --keepId --keepPos
     program: bystro-vcf
 tracks:
   - name: ref

--- a/config/danRer10.clean.yml
+++ b/config/danRer10.clean.yml
@@ -1,6 +1,6 @@
 ---
-  assembly: danRer10
-  chromosomes:
+assembly: danRer10
+chromosomes:
   - chr1
   - chr2
   - chr3
@@ -27,38 +27,38 @@
   - chr24
   - chr25
   - chrM
-  database_dir: '~'
-  files: '~'
-  files_dir: ~
-  statistics:
-    dbSNPnameField: ~
-    exonicAlleleFunctionField: refSeq.exonicAlleleFunction
-    outputExtensions:
-      json: .statistics.json
-      qc: .statistics.qc.tab
-      tab: .statistics.tab
-    refTrackField: ref
-    siteTypeField: refSeq.siteType
-    programPath: bystro-stats
-  temp_dir: '~'
-  fileProcessors:
-    snp:
-      args: --emptyField ! --minGq .95
-      program: bystro-snp
-    vcf:
-      args: --emptyField ! --keepId --keepPos
-      program: bystro-vcf
-  tracks:
+database_dir: "~"
+files: "~"
+files_dir: ~
+statistics:
+  dbSNPnameField: ~
+  exonicAlleleFunctionField: refSeq.exonicAlleleFunction
+  outputExtensions:
+    json: .statistics.json
+    qc: .statistics.qc.tab
+    tab: .statistics.tab
+  refTrackField: ref
+  siteTypeField: refSeq.siteType
+  programPath: bystro-stats
+temp_dir: "~"
+fileProcessors:
+  snp:
+    args: --emptyField NA --minGq .95
+    program: bystro-snp
+  vcf:
+    args: --emptyField NA --keepId --keepPos
+    program: bystro-vcf
+tracks:
   - local_files:
-    - danRer10.fa.gz
+      - danRer10.fa.gz
     name: ref
     remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/danRer10/bigZips/
     remote_files:
-    - danRer10.fa.gz
+      - danRer10.fa.gz
     type: reference
   - features:
-    - name
-    - name2
+      - name
+      - name2
     name: refSeq
     sql_statement: SELECT * FROM danRer10.refGene
     type: gene

--- a/config/dm6.clean.yml
+++ b/config/dm6.clean.yml
@@ -24,10 +24,10 @@ statistics:
 temp_dir: "~"
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --keepId --keepPos
+    args: --emptyField NA --keepId --keepPos
     program: bystro-vcf
 tracks:
   - build_author: ec2-user

--- a/config/hg19.clean.yml
+++ b/config/hg19.clean.yml
@@ -1,811 +1,123 @@
 ---
-  assembly: hg19
-  build_author: ec2-user
-  build_date: 2019-09-22T04:22:00
-  chromosomes:
+assembly: hg19
+build_author: alexkotlar
+build_date: 2023-11-08T00:03:00
+chromosomes:
   - chr1
-  - chr2
-  - chr3
-  - chr4
-  - chr5
-  - chr6
-  - chr7
-  - chr8
-  - chr9
-  - chr10
-  - chr11
-  - chr12
-  - chr13
-  - chr14
-  - chr15
-  - chr16
-  - chr17
-  - chr18
-  - chr19
-  - chr20
-  - chr21
-  - chr22
-  - chrM
-  - chrX
-  - chrY
-  database_dir: '~'
-  fileProcessors:
-    snp:
-      args: --emptyField ! --minGq .95
-      program: bystro-snp
-    vcf:
-      args: --emptyField ! --sample %sampleList% --keepPos --keepId
-      program: bystro-vcf
-  files_dir: '~'
-  statistics:
-    dbSNPnameField: dbSNP.name
-    exonicAlleleFunctionField: refSeq.exonicAlleleFunction
-    outputExtensions:
-      json: .statistics.json
-      qc: .statistics.qc.tsv
-      tab: .statistics.tsv
-    programPath: bystro-stats
-    refTrackField: ref
-    siteTypeField: refSeq.siteType
-  temp_dir: '~'
-  tracks:
-    outputOrder:
+database_dir: "~"
+fileProcessors:
+  snp:
+    args: --emptyField NA --minGq .95
+    program: bystro-snp
+  vcf:
+    args: --emptyField NA --sample %sampleList% --keepPos --keepId
+    program: bystro-vcf
+files_dir: "~"
+statistics:
+  dbSNPnameField: dbSNP.name
+  exonicAlleleFunctionField: refSeq.exonicAlleleFunction
+  outputExtensions:
+    json: .statistics.json
+    qc: .statistics.qc.tsv
+    tab: .statistics.tsv
+  programPath: bystro-stats
+  refTrackField: ref
+  siteTypeField: refSeq.siteType
+temp_dir: "~"
+tracks:
+  outputOrder:
     - ref
-    - refSeq
-    - refSeq.gene
-    - nearest.refSeq
-    - nearestTss.refSeq
-    - phastCons
-    - phyloP
-    - cadd
-    - gnomad.genomes
-    - gnomad.exomes
-    - dbSNP
-    - clinvar
-    tracks:
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
+    - clinvar2
+  tracks:
+    - build_author: alexkotlar
+      build_date: 2023-11-05T22:11:00
       local_files:
-      - chr1.fa.gz
-      - chr2.fa.gz
-      - chr3.fa.gz
-      - chr4.fa.gz
-      - chr5.fa.gz
-      - chr6.fa.gz
-      - chr7.fa.gz
-      - chr8.fa.gz
-      - chr9.fa.gz
-      - chr10.fa.gz
-      - chr11.fa.gz
-      - chr12.fa.gz
-      - chr13.fa.gz
-      - chr14.fa.gz
-      - chr15.fa.gz
-      - chr16.fa.gz
-      - chr17.fa.gz
-      - chr18.fa.gz
-      - chr19.fa.gz
-      - chr20.fa.gz
-      - chr21.fa.gz
-      - chr22.fa.gz
-      - chrM.fa.gz
-      - chrX.fa.gz
-      - chrY.fa.gz
+        - chr1.fa.gz
+        - chr2.fa.gz
+        - chr3.fa.gz
+        - chr4.fa.gz
+        - chr5.fa.gz
+        - chr6.fa.gz
+        - chr7.fa.gz
+        - chr8.fa.gz
+        - chr9.fa.gz
+        - chr10.fa.gz
+        - chr11.fa.gz
+        - chr12.fa.gz
+        - chr13.fa.gz
+        - chr14.fa.gz
+        - chr15.fa.gz
+        - chr16.fa.gz
+        - chr17.fa.gz
+        - chr18.fa.gz
+        - chr19.fa.gz
+        - chr20.fa.gz
+        - chr21.fa.gz
+        - chr22.fa.gz
+        - chrM.fa.gz
+        - chrX.fa.gz
+        - chrY.fa.gz
       name: ref
       type: reference
       utils:
-      - args:
-          remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/chromosomes/
-          remoteFiles:
-          - chr1.fa.gz
-          - chr2.fa.gz
-          - chr3.fa.gz
-          - chr4.fa.gz
-          - chr5.fa.gz
-          - chr6.fa.gz
-          - chr7.fa.gz
-          - chr8.fa.gz
-          - chr9.fa.gz
-          - chr10.fa.gz
-          - chr11.fa.gz
-          - chr12.fa.gz
-          - chr13.fa.gz
-          - chr14.fa.gz
-          - chr15.fa.gz
-          - chr16.fa.gz
-          - chr17.fa.gz
-          - chr18.fa.gz
-          - chr19.fa.gz
-          - chr20.fa.gz
-          - chr21.fa.gz
-          - chr22.fa.gz
-          - chrM.fa.gz
-          - chrX.fa.gz
-          - chrY.fa.gz
-        completed: 2019-09-21T20:17:00
-        name: fetch
-      version: 29
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
-      dist: true
-      features:
-      - name
-      - name2
-      from: txStart
-      local_files:
-      - hg19.kgXref.chr*.with_dbnsfp.gz
-      name: nearest.refSeq
-      to: txEnd
-      type: nearest
-      version: 3
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
-      dist: true
-      features:
-      - name
-      - name2
-      from: txStart
-      local_files:
-      - hg19.kgXref.chr*.with_dbnsfp.gz
-      name: nearestTss.refSeq
-      type: nearest
-      version: 20
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
-      local_files:
-      - chr1.phastCons100way.wigFix.gz
-      - chr2.phastCons100way.wigFix.gz
-      - chr3.phastCons100way.wigFix.gz
-      - chr4.phastCons100way.wigFix.gz
-      - chr5.phastCons100way.wigFix.gz
-      - chr6.phastCons100way.wigFix.gz
-      - chr7.phastCons100way.wigFix.gz
-      - chr8.phastCons100way.wigFix.gz
-      - chr9.phastCons100way.wigFix.gz
-      - chr10.phastCons100way.wigFix.gz
-      - chr11.phastCons100way.wigFix.gz
-      - chr12.phastCons100way.wigFix.gz
-      - chr13.phastCons100way.wigFix.gz
-      - chr14.phastCons100way.wigFix.gz
-      - chr15.phastCons100way.wigFix.gz
-      - chr16.phastCons100way.wigFix.gz
-      - chr17.phastCons100way.wigFix.gz
-      - chr18.phastCons100way.wigFix.gz
-      - chr19.phastCons100way.wigFix.gz
-      - chr20.phastCons100way.wigFix.gz
-      - chr21.phastCons100way.wigFix.gz
-      - chr22.phastCons100way.wigFix.gz
-      - chrX.phastCons100way.wigFix.gz
-      - chrY.phastCons100way.wigFix.gz
-      - chrM.phastCons100way.wigFix.gz
-      name: phastCons
-      type: score
-      utils:
-      - args:
-          remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phastCons100way/hg19.100way.phastCons/
-          remoteFiles:
-          - chr1.phastCons100way.wigFix.gz
-          - chr2.phastCons100way.wigFix.gz
-          - chr3.phastCons100way.wigFix.gz
-          - chr4.phastCons100way.wigFix.gz
-          - chr5.phastCons100way.wigFix.gz
-          - chr6.phastCons100way.wigFix.gz
-          - chr7.phastCons100way.wigFix.gz
-          - chr8.phastCons100way.wigFix.gz
-          - chr9.phastCons100way.wigFix.gz
-          - chr10.phastCons100way.wigFix.gz
-          - chr11.phastCons100way.wigFix.gz
-          - chr12.phastCons100way.wigFix.gz
-          - chr13.phastCons100way.wigFix.gz
-          - chr14.phastCons100way.wigFix.gz
-          - chr15.phastCons100way.wigFix.gz
-          - chr16.phastCons100way.wigFix.gz
-          - chr17.phastCons100way.wigFix.gz
-          - chr18.phastCons100way.wigFix.gz
-          - chr19.phastCons100way.wigFix.gz
-          - chr20.phastCons100way.wigFix.gz
-          - chr21.phastCons100way.wigFix.gz
-          - chr22.phastCons100way.wigFix.gz
-          - chrX.phastCons100way.wigFix.gz
-          - chrY.phastCons100way.wigFix.gz
-          - chrM.phastCons100way.wigFix.gz
-        completed: 2019-09-21T20:20:00
-        name: fetch
-      version: 21
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
-      local_files:
-      - chr1.phyloP100way.wigFix.gz
-      - chr2.phyloP100way.wigFix.gz
-      - chr3.phyloP100way.wigFix.gz
-      - chr4.phyloP100way.wigFix.gz
-      - chr5.phyloP100way.wigFix.gz
-      - chr6.phyloP100way.wigFix.gz
-      - chr7.phyloP100way.wigFix.gz
-      - chr8.phyloP100way.wigFix.gz
-      - chr9.phyloP100way.wigFix.gz
-      - chr10.phyloP100way.wigFix.gz
-      - chr11.phyloP100way.wigFix.gz
-      - chr12.phyloP100way.wigFix.gz
-      - chr13.phyloP100way.wigFix.gz
-      - chr14.phyloP100way.wigFix.gz
-      - chr15.phyloP100way.wigFix.gz
-      - chr16.phyloP100way.wigFix.gz
-      - chr17.phyloP100way.wigFix.gz
-      - chr18.phyloP100way.wigFix.gz
-      - chr19.phyloP100way.wigFix.gz
-      - chr20.phyloP100way.wigFix.gz
-      - chr21.phyloP100way.wigFix.gz
-      - chr22.phyloP100way.wigFix.gz
-      - chrX.phyloP100way.wigFix.gz
-      - chrY.phyloP100way.wigFix.gz
-      - chrM.phyloP100way.wigFix.gz
-      name: phyloP
-      type: score
-      utils:
-      - args:
-          remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phyloP100way/hg19.100way.phyloP100way/
-          remoteFiles:
-          - chr1.phyloP100way.wigFix.gz
-          - chr2.phyloP100way.wigFix.gz
-          - chr3.phyloP100way.wigFix.gz
-          - chr4.phyloP100way.wigFix.gz
-          - chr5.phyloP100way.wigFix.gz
-          - chr6.phyloP100way.wigFix.gz
-          - chr7.phyloP100way.wigFix.gz
-          - chr8.phyloP100way.wigFix.gz
-          - chr9.phyloP100way.wigFix.gz
-          - chr10.phyloP100way.wigFix.gz
-          - chr11.phyloP100way.wigFix.gz
-          - chr12.phyloP100way.wigFix.gz
-          - chr13.phyloP100way.wigFix.gz
-          - chr14.phyloP100way.wigFix.gz
-          - chr15.phyloP100way.wigFix.gz
-          - chr16.phyloP100way.wigFix.gz
-          - chr17.phyloP100way.wigFix.gz
-          - chr18.phyloP100way.wigFix.gz
-          - chr19.phyloP100way.wigFix.gz
-          - chr20.phyloP100way.wigFix.gz
-          - chr21.phyloP100way.wigFix.gz
-          - chr22.phyloP100way.wigFix.gz
-          - chrX.phyloP100way.wigFix.gz
-          - chrY.phyloP100way.wigFix.gz
-          - chrM.phyloP100way.wigFix.gz
-        completed: 2019-09-21T20:27:00
-        name: fetch
-      version: 20
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
-      local_files:
-      - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
-      name: cadd
-      sorted: 1
-      type: cadd
-      utils:
-      - args:
-          remoteDir: https://bystro-db.s3.amazonaws.com/src/cadd1.4/hg19/cadd/
-          remoteFiles:
-          - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
-          - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
-        completed: 2019-09-21T20:35:00
-        name: fetch
-      version: 20
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
+        - args:
+            remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/chromosomes/
+            remoteFiles:
+              - chr1.fa.gz
+              - chr2.fa.gz
+              - chr3.fa.gz
+              - chr4.fa.gz
+              - chr5.fa.gz
+              - chr6.fa.gz
+              - chr7.fa.gz
+              - chr8.fa.gz
+              - chr9.fa.gz
+              - chr10.fa.gz
+              - chr11.fa.gz
+              - chr12.fa.gz
+              - chr13.fa.gz
+              - chr14.fa.gz
+              - chr15.fa.gz
+              - chr16.fa.gz
+              - chr17.fa.gz
+              - chr18.fa.gz
+              - chr19.fa.gz
+              - chr20.fa.gz
+              - chr21.fa.gz
+              - chr22.fa.gz
+              - chrM.fa.gz
+              - chrX.fa.gz
+              - chrY.fa.gz
+          name: fetch
+      version: 32
+    - build_author: alexkotlar
+      build_date: 2023-11-08T00:03:00
       build_field_transformations:
-        description: split [;]
-        ensemblID: split [;]
-        kgID: split [;]
-        mRNA: split [;]
-        protAcc: split [;]
-        rfamAcc: split [;]
-        spDisplayID: split [;]
-        spID: split [;]
-        tRnaName: split [;]
+        CLNDISDB: split [|]
+        CLNDN: split [|]
+        CLNSIGCONF: split [|]
+        CLNSIGINC: split [|]
       features:
-      - name
-      - name2
-      - description
-      - kgID
-      - mRNA
-      - spID
-      - spDisplayID
-      - protAcc
-      - rfamAcc
-      - tRnaName
-      - ensemblID
-      join:
-        features:
-        - alleleID
-        - phenotypeList
-        - clinicalSignificance
-        - type
-        - origin
-        - numberSubmitters
-        - reviewStatus
-        - chromStart
-        - chromEnd
-        track: clinvar
+        - id
+        - alt
+        - AF_ESP: number
+        - AF_EXAC: number
+        - AF_TGP: number
+        - ALLELEID: number
+        - CLNDN
+        - CLNDNINCL
+        - CLNHGVS
+        - CLNREVSTAT
+        - CLNSIG
+        - CLNSIGCONF
+        - CLNVCSO
+        - DBVARID
+        - ORIGIN
+        - SSR
+        - RS
       local_files:
-      - hg19.kgXref.chr1.with_dbnsfp.gz
-      - hg19.kgXref.chr13.with_dbnsfp.gz
-      - hg19.kgXref.chr4.with_dbnsfp.gz
-      - hg19.kgXref.chr22.with_dbnsfp.gz
-      - hg19.kgXref.chr3.with_dbnsfp.gz
-      - hg19.kgXref.chr17.with_dbnsfp.gz
-      - hg19.kgXref.chrM.with_dbnsfp.gz
-      - hg19.kgXref.chr9.with_dbnsfp.gz
-      - hg19.kgXref.chr5.with_dbnsfp.gz
-      - hg19.kgXref.chrX.with_dbnsfp.gz
-      - hg19.kgXref.chr12.with_dbnsfp.gz
-      - hg19.kgXref.chr15.with_dbnsfp.gz
-      - hg19.kgXref.chr19.with_dbnsfp.gz
-      - hg19.kgXref.chr10.with_dbnsfp.gz
-      - hg19.kgXref.chr8.with_dbnsfp.gz
-      - hg19.kgXref.chr16.with_dbnsfp.gz
-      - hg19.kgXref.chr18.with_dbnsfp.gz
-      - hg19.kgXref.chr20.with_dbnsfp.gz
-      - hg19.kgXref.chr14.with_dbnsfp.gz
-      - hg19.kgXref.chr2.with_dbnsfp.gz
-      - hg19.kgXref.chr7.with_dbnsfp.gz
-      - hg19.kgXref.chrY.with_dbnsfp.gz
-      - hg19.kgXref.chr11.with_dbnsfp.gz
-      - hg19.kgXref.chr6.with_dbnsfp.gz
-      - hg19.kgXref.chr21.with_dbnsfp.gz
-      name: refSeq
-      type: gene
-      utils:
-      - args:
-          connection:
-            database: hg19
-          sql: SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
-            ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
-            (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
-            e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
-            (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
-            kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
-            GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
-            x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
-            GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
-            x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
-            refGene r WHERE chrom=%chromosomes%;
-        completed: 2019-09-21T20:54:00
-        name: fetch
-      - args:
-          geneFile: /mnt/data/bystro_source_files/dbNSFP4.0_gene.complete.gz
-        completed: 2019-09-21T20:54:00
-        name: refGeneXdbnsfp
-      version: 29
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      build_field_transformations:
-        pmid: split [;]
-        uniprot.func: split [;]
-      dist: false
-      features:
-      - name2
-      - pLi: number
-      - pRec: number
-      - pNull: number
-      - lofTool_score: number
-      - lof_fdr_exac: number
-      - pHi: number
-      - nonTCGA.pRec: number
-      - nonTCGA.pNull: number
-      - nonTCGA.pLi: number
-      - nonPsych.pRec: number
-      - nonPsych.pNull: number
-      - nonPsych.pLi: number
-      - gdi: number
-      - cnv.score: number
-      - cnv.flag
-      - pmid: number
-      - rvis: number
-      fieldMap:
-        dbnsfp.Disease_description: uniprot.disease
-        dbnsfp.ExAC_cnv.score: cnv.score
-        dbnsfp.ExAC_cnv_flag: cnv.flag
-        dbnsfp.ExAC_nonTCGA_pLI: nonTCGA.pLi
-        dbnsfp.ExAC_nonTCGA_pNull: nonTCGA.pNull
-        dbnsfp.ExAC_nonTCGA_pRec: nonTCGA.pRec
-        dbnsfp.ExAC_nonpsych_pLI: nonPsych.pLi
-        dbnsfp.ExAC_nonpsych_pNull: nonPsych.pNull
-        dbnsfp.ExAC_nonpsych_pRec: nonPsych.pRec
-        dbnsfp.ExAC_pLI: pLi
-        dbnsfp.ExAC_pNull: pNull
-        dbnsfp.ExAC_pRec: pRec
-        dbnsfp.Expression(GNF/Atlas): expression.gnfAtlas
-        dbnsfp.Expression(egenetics): expression.egenetics
-        dbnsfp.Function_description: function
-        dbnsfp.GDI-Phred: gdi
-        dbnsfp.GO_biological_process: go.biologicalProcess
-        dbnsfp.GO_cellular_component: go.cellularComponent
-        dbnsfp.GO_molecular_function: go.molecularFunction
-        dbnsfp.Known_rec_info: knownRecInfo
-        dbnsfp.LoF-FDR_ExAC: lof_fdr_exac
-        dbnsfp.LoFtool_score: lofTool_score
-        dbnsfp.P(HI): pHi
-        dbnsfp.P(rec): pRec
-        dbnsfp.RVIS_percentile_ExAC: rvis
-        dbnsfp.Tissue_specificity(Uniprot): uniprot.tissue
-        dbnsfp.Trait_association(GWAS): trait_association
-        dbnsfp.pubmedID: pmid
-      from: txStart
-      local_files:
-      - hg19.kgXref.chr*.with_dbnsfp.gz
-      name: refSeq.gene
-      storeNearest: false
-      to: txEnd
-      type: nearest
-      version: 24
-    - build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
-      build_field_transformations:
-        alleleFreqs: split [,]
-        alleleNs: split [,]
-        alleles: split [,]
-        exceptions: split [,]
-        func: split [,]
-        observed: split [\/]
-        submitters: split [,]
-      features:
-      - name
-      - strand
-      - observed
-      - class
-      - func
-      - refUCSC
-      - alleles
-      - alleleNs: number
-      - alleleFreqs: number
-      - exceptions
-      - submitterCount: number
-      - submitters
-      local_files:
-      - hg19.snp151.chr1.gz
-      - hg19.snp151.chr2.gz
-      - hg19.snp151.chr3.gz
-      - hg19.snp151.chr4.gz
-      - hg19.snp151.chr5.gz
-      - hg19.snp151.chr6.gz
-      - hg19.snp151.chr7.gz
-      - hg19.snp151.chr8.gz
-      - hg19.snp151.chr9.gz
-      - hg19.snp151.chr10.gz
-      - hg19.snp151.chr11.gz
-      - hg19.snp151.chr12.gz
-      - hg19.snp151.chr13.gz
-      - hg19.snp151.chr14.gz
-      - hg19.snp151.chr15.gz
-      - hg19.snp151.chr16.gz
-      - hg19.snp151.chr17.gz
-      - hg19.snp151.chr18.gz
-      - hg19.snp151.chr19.gz
-      - hg19.snp151.chr20.gz
-      - hg19.snp151.chr21.gz
-      - hg19.snp151.chr22.gz
-      - hg19.snp151.chrM.gz
-      - hg19.snp151.chrX.gz
-      - hg19.snp151.chrY.gz
-      name: dbSNP
-      type: sparse
-      utils:
-      - args:
-          sql: SELECT * FROM hg19.snp151 WHERE chrom = %chromosomes%
-        completed: 2019-09-21T20:55:00
-        name: fetch
-      version: 29
-    - build_author: ec2-user
-      build_row_filters:
-        AS_FilterStatus: == PASS
-      features:
-      - alt
-      - id
-      - af: number
-      - an: number
-      - an_afr: number
-      - an_amr: number
-      - an_asj: number
-      - an_eas: number
-      - an_fin: number
-      - an_nfe: number
-      - an_oth: number
-      - an_sas: number
-      - an_male: number
-      - an_female: number
-      - af_afr: number
-      - af_amr: number
-      - af_asj: number
-      - af_eas: number
-      - af_fin: number
-      - af_nfe: number
-      - af_oth: number
-      - af_sas: number
-      - af_male: number
-      - af_female: number
-      fieldMap:
-        AF: af
-        AF_AFR: af_afr
-        AF_AMR: af_amr
-        AF_ASJ: af_asj
-        AF_EAS: af_eas
-        AF_FIN: af_fin
-        AF_Female: af_female
-        AF_Male: af_male
-        AF_NFE: af_nfe
-        AF_OTH: af_oth
-        AF_SAS: af_sas
-        AN: an
-        AN_AFR: an_afr
-        AN_AMR: an_amr
-        AN_ASJ: an_asj
-        AN_EAS: an_eas
-        AN_FIN: an_fin
-        AN_Female: an_female
-        AN_Male: an_male
-        AN_NFE: an_nfe
-        AN_OTH: an_oth
-        AN_SAS: an_sas
-      local_files:
-      - gnomad.genomes.r2.1.1.sites.1.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.2.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.3.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.4.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.5.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.6.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.7.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.8.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.9.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.10.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.11.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.12.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.13.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.14.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.15.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.16.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.17.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.18.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.19.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.20.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.21.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.22.vcf.bgz
-      - gnomad.genomes.r2.1.1.sites.X.vcf.bgz
-      name: gnomad.genomes
+        - /mnt/files1/bystro_annotator/raw_files/hg19/clinvar/clinvar_20221001.vcf.gz
+      name: clinvar2
       type: vcf
-      utils:
-      - args:
-          remoteDir: https://storage.googleapis.com/gnomad-public/release/2.1.1/vcf/genomes/
-          remoteFiles:
-          - gnomad.genomes.r2.1.1.sites.1.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.2.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.3.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.4.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.5.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.6.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.7.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.8.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.9.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.10.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.11.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.12.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.13.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.14.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.15.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.16.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.17.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.18.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.19.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.20.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.21.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.22.vcf.bgz
-          - gnomad.genomes.r2.1.1.sites.X.vcf.bgz
-        completed: 2019-09-22T00:55:00
-        name: fetch
-      version: 24
-    - build_author: ec2-user
-      build_row_filters:
-        AS_FilterStatus: == PASS
-      features:
-      - alt
-      - id
-      - af: number
-      - an: number
-      - an_afr: number
-      - an_amr: number
-      - an_asj: number
-      - an_eas: number
-      - an_fin: number
-      - an_nfe: number
-      - an_oth: number
-      - an_sas: number
-      - an_male: number
-      - an_female: number
-      - af_afr: number
-      - af_amr: number
-      - af_asj: number
-      - af_eas: number
-      - af_fin: number
-      - af_nfe: number
-      - af_oth: number
-      - af_sas: number
-      - af_male: number
-      - af_female: number
-      fieldMap:
-        AF: af
-        AF_AFR: af_afr
-        AF_AMR: af_amr
-        AF_ASJ: af_asj
-        AF_EAS: af_eas
-        AF_FIN: af_fin
-        AF_Female: af_female
-        AF_Male: af_male
-        AF_NFE: af_nfe
-        AF_OTH: af_oth
-        AF_SAS: af_sas
-        AN: an
-        AN_AFR: an_afr
-        AN_AMR: an_amr
-        AN_ASJ: an_asj
-        AN_EAS: an_eas
-        AN_FIN: an_fin
-        AN_Female: an_female
-        AN_Male: an_male
-        AN_NFE: an_nfe
-        AN_OTH: an_oth
-        AN_SAS: an_sas
-      local_files:
-      - gnomad.exomes.r2.1.1.sites.1.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.2.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.3.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.4.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.5.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.6.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.7.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.8.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.9.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.10.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.11.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.12.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.13.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.14.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.15.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.16.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.17.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.18.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.19.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.20.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.21.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.22.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.X.vcf.bgz
-      - gnomad.exomes.r2.1.1.sites.Y.vcf.bgz
-      name: gnomad.exomes
-      type: vcf
-      utils:
-      - args:
-          remoteDir: https://storage.googleapis.com/gnomad-public/release/2.1.1/vcf/exomes/
-          remoteFiles:
-          - gnomad.exomes.r2.1.1.sites.1.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.2.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.3.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.4.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.5.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.6.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.7.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.8.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.9.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.10.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.11.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.12.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.13.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.14.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.15.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.16.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.17.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.18.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.19.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.20.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.21.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.22.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.X.vcf.bgz
-          - gnomad.exomes.r2.1.1.sites.Y.vcf.bgz
-        completed: 2019-09-22T02:16:00
-        name: fetch
-      version: 24
-    - based: 1
-      build_author: ec2-user
-      build_date: 2019-09-22T04:22:00
-      build_field_transformations:
-        chrom: chr .
-        clinicalSignificance: split [;]
-        origin: split [;]
-        phenotypeList: split [;]
-        reviewStatus: split [;]
-        type: split [;]
-      build_row_filters:
-        Assembly: == GRCh38
-      features:
-      - alleleID: number
-      - phenotypeList
-      - clinicalSignificance
-      - type
-      - origin
-      - numberSubmitters: number
-      - reviewStatus
-      - referenceAllele
-      - alternateAllele
-      fieldMap:
-        '#AlleleID': alleleID
-        AlternateAllele: alternateAllele
-        Chromosome: chrom
-        ClinicalSignificance: clinicalSignificance
-        NumberSubmitters: numberSubmitters
-        Origin: origin
-        PhenotypeIDS: phenotypeIDs
-        PhenotypeList: phenotypeList
-        ReferenceAllele: referenceAllele
-        ReviewStatus: reviewStatus
-        Start: chromStart
-        Stop: chromEnd
-        Type: type
-      local_files:
-      - variant_summary.txt.gz
-      name: clinvar
-      type: sparse
-      utils:
-      - args:
-          remoteFiles:
-          - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
-        completed: 2019-09-22T02:27:00
-        name: fetch
-      version: 21
-  version: 217
-  
+      version: 5
+version: 16

--- a/config/hg19_ensembl.clean.yml
+++ b/config/hg19_ensembl.clean.yml
@@ -1,8 +1,8 @@
 ---
-  assembly: hg19
-  build_author: ec2-user
-  build_date: 2017-10-07T17:00:00
-  chromosomes:
+assembly: hg19
+build_author: ec2-user
+build_date: 2017-10-07T17:00:00
+chromosomes:
   - chr1
   - chr2
   - chr3
@@ -28,204 +28,205 @@
   - chrM
   - chrX
   - chrY
-  database_dir: '~'
-  files_dir: '~'
-  statistics:
-    dbSNPnameField: dbSNP.name
-    exonicAlleleFunctionField: refSeq.exonicAlleleFunction
-    outputExtensions:
-      json: .statistics.json
-      qc: .statistics.qc.tsv
-      tab: .statistics.tsv
-    programPath: bystro-stats
-    refTrackField: ref
-    siteTypeField: refSeq.siteType
-  fileProcessors:
-    snp:
-      args: --emptyField ! --minGq .95
-      program: bystro-snp
-    vcf:
-      args: --emptyField ! --sample %sampleList%
-      program: bystro-vcf
-  temp_dir: '~'
-  tracks:
+database_dir: "~"
+files_dir: "~"
+statistics:
+  dbSNPnameField: dbSNP.name
+  exonicAlleleFunctionField: refSeq.exonicAlleleFunction
+  outputExtensions:
+    json: .statistics.json
+    qc: .statistics.qc.tsv
+    tab: .statistics.tsv
+  programPath: bystro-stats
+  refTrackField: ref
+  siteTypeField: refSeq.siteType
+fileProcessors:
+  snp:
+    args: --emptyField NA --minGq .95
+    program: bystro-snp
+  vcf:
+    args: --emptyField NA --sample %sampleList%
+    program: bystro-vcf
+temp_dir: "~"
+tracks:
   - build_author: ec2-user
     build_date: 2017-09-27T18:27:00
     fetch_date: 2017-09-27T02:05:00
     local_files:
-    - chr1.fa.gz
-    - chr2.fa.gz
-    - chr3.fa.gz
-    - chr4.fa.gz
-    - chr5.fa.gz
-    - chr6.fa.gz
-    - chr7.fa.gz
-    - chr8.fa.gz
-    - chr9.fa.gz
-    - chr10.fa.gz
-    - chr11.fa.gz
-    - chr12.fa.gz
-    - chr13.fa.gz
-    - chr14.fa.gz
-    - chr15.fa.gz
-    - chr16.fa.gz
-    - chr17.fa.gz
-    - chr18.fa.gz
-    - chr19.fa.gz
-    - chr20.fa.gz
-    - chr21.fa.gz
-    - chr22.fa.gz
-    - chrM.fa.gz
-    - chrX.fa.gz
-    - chrY.fa.gz
+      - chr1.fa.gz
+      - chr2.fa.gz
+      - chr3.fa.gz
+      - chr4.fa.gz
+      - chr5.fa.gz
+      - chr6.fa.gz
+      - chr7.fa.gz
+      - chr8.fa.gz
+      - chr9.fa.gz
+      - chr10.fa.gz
+      - chr11.fa.gz
+      - chr12.fa.gz
+      - chr13.fa.gz
+      - chr14.fa.gz
+      - chr15.fa.gz
+      - chr16.fa.gz
+      - chr17.fa.gz
+      - chr18.fa.gz
+      - chr19.fa.gz
+      - chr20.fa.gz
+      - chr21.fa.gz
+      - chr22.fa.gz
+      - chrM.fa.gz
+      - chrX.fa.gz
+      - chrY.fa.gz
     name: ref
     remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/chromosomes/
     remote_files:
-    - chr1.fa.gz
-    - chr2.fa.gz
-    - chr3.fa.gz
-    - chr4.fa.gz
-    - chr5.fa.gz
-    - chr6.fa.gz
-    - chr7.fa.gz
-    - chr8.fa.gz
-    - chr9.fa.gz
-    - chr10.fa.gz
-    - chr11.fa.gz
-    - chr12.fa.gz
-    - chr13.fa.gz
-    - chr14.fa.gz
-    - chr15.fa.gz
-    - chr16.fa.gz
-    - chr17.fa.gz
-    - chr18.fa.gz
-    - chr19.fa.gz
-    - chr20.fa.gz
-    - chr21.fa.gz
-    - chr22.fa.gz
-    - chrM.fa.gz
-    - chrX.fa.gz
-    - chrY.fa.gz
+      - chr1.fa.gz
+      - chr2.fa.gz
+      - chr3.fa.gz
+      - chr4.fa.gz
+      - chr5.fa.gz
+      - chr6.fa.gz
+      - chr7.fa.gz
+      - chr8.fa.gz
+      - chr9.fa.gz
+      - chr10.fa.gz
+      - chr11.fa.gz
+      - chr12.fa.gz
+      - chr13.fa.gz
+      - chr14.fa.gz
+      - chr15.fa.gz
+      - chr16.fa.gz
+      - chr17.fa.gz
+      - chr18.fa.gz
+      - chr19.fa.gz
+      - chr20.fa.gz
+      - chr21.fa.gz
+      - chr22.fa.gz
+      - chrM.fa.gz
+      - chrX.fa.gz
+      - chrY.fa.gz
     type: reference
     version: 1
   - build_author: ec2-user
     build_date: 2017-10-07T17:00:00
     features:
-    - name
-    - name2
-    - gene
-    - strand
-    - txStart
+      - name
+      - name2
+      - gene
+      - strand
+      - txStart
     fetch_date: 2017-10-07T16:57:00
     join:
       features:
-      - alleleID
-      - phenotypeList
-      - clinicalSignificance
-      - type
-      - origin
-      - numberSubmitters
-      - reviewStatus
-      - chromStart
-      - chromEnd
+        - alleleID
+        - phenotypeList
+        - clinicalSignificance
+        - type
+        - origin
+        - numberSubmitters
+        - reviewStatus
+        - chromStart
+        - chromEnd
       track: clinvar
     local_files:
-    - hg19.ensGene.chr1.gz
-    - hg19.ensGene.chr2.gz
-    - hg19.ensGene.chr3.gz
-    - hg19.ensGene.chr4.gz
-    - hg19.ensGene.chr5.gz
-    - hg19.ensGene.chr6.gz
-    - hg19.ensGene.chr7.gz
-    - hg19.ensGene.chr8.gz
-    - hg19.ensGene.chr9.gz
-    - hg19.ensGene.chr10.gz
-    - hg19.ensGene.chr11.gz
-    - hg19.ensGene.chr12.gz
-    - hg19.ensGene.chr13.gz
-    - hg19.ensGene.chr14.gz
-    - hg19.ensGene.chr15.gz
-    - hg19.ensGene.chr16.gz
-    - hg19.ensGene.chr17.gz
-    - hg19.ensGene.chr18.gz
-    - hg19.ensGene.chr19.gz
-    - hg19.ensGene.chr20.gz
-    - hg19.ensGene.chr21.gz
-    - hg19.ensGene.chr22.gz
-    - hg19.ensGene.chrM.gz
-    - hg19.ensGene.chrX.gz
-    - hg19.ensGene.chrY.gz
+      - hg19.ensGene.chr1.gz
+      - hg19.ensGene.chr2.gz
+      - hg19.ensGene.chr3.gz
+      - hg19.ensGene.chr4.gz
+      - hg19.ensGene.chr5.gz
+      - hg19.ensGene.chr6.gz
+      - hg19.ensGene.chr7.gz
+      - hg19.ensGene.chr8.gz
+      - hg19.ensGene.chr9.gz
+      - hg19.ensGene.chr10.gz
+      - hg19.ensGene.chr11.gz
+      - hg19.ensGene.chr12.gz
+      - hg19.ensGene.chr13.gz
+      - hg19.ensGene.chr14.gz
+      - hg19.ensGene.chr15.gz
+      - hg19.ensGene.chr16.gz
+      - hg19.ensGene.chr17.gz
+      - hg19.ensGene.chr18.gz
+      - hg19.ensGene.chr19.gz
+      - hg19.ensGene.chr20.gz
+      - hg19.ensGene.chr21.gz
+      - hg19.ensGene.chr22.gz
+      - hg19.ensGene.chrM.gz
+      - hg19.ensGene.chrX.gz
+      - hg19.ensGene.chrY.gz
     name: ensembl
-    sql_statement: SELECT ensGene.name,chrom,strand,txStart,txEnd,cdsStart,cdsEnd,exonCount,exonStarts,exonEnds,name2,value
+    sql_statement:
+      SELECT ensGene.name,chrom,strand,txStart,txEnd,cdsStart,cdsEnd,exonCount,exonStarts,exonEnds,name2,value
       AS gene FROM hg19.ensGene LEFT JOIN hg19.ensemblToGeneName ON (hg19.ensGene.name=hg19.ensemblToGeneName.name)
     type: gene
     version: 2
   - build_author: ec2-user
     build_date: 2017-09-27T18:27:00
     local_files:
-    - chr*.phastCons100way.wigFix.gz
+      - chr*.phastCons100way.wigFix.gz
     name: phastCons
     remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phastCons100way/hg19.100way.phastCons/
     remote_files:
-    - chr1.phastCons100way.wigFix.gz
-    - chr2.phastCons100way.wigFix.gz
-    - chr3.phastCons100way.wigFix.gz
-    - chr4.phastCons100way.wigFix.gz
-    - chr5.phastCons100way.wigFix.gz
-    - chr6.phastCons100way.wigFix.gz
-    - chr7.phastCons100way.wigFix.gz
-    - chr8.phastCons100way.wigFix.gz
-    - chr9.phastCons100way.wigFix.gz
-    - chr10.phastCons100way.wigFix.gz
-    - chr11.phastCons100way.wigFix.gz
-    - chr12.phastCons100way.wigFix.gz
-    - chr13.phastCons100way.wigFix.gz
-    - chr14.phastCons100way.wigFix.gz
-    - chr15.phastCons100way.wigFix.gz
-    - chr16.phastCons100way.wigFix.gz
-    - chr17.phastCons100way.wigFix.gz
-    - chr18.phastCons100way.wigFix.gz
-    - chr19.phastCons100way.wigFix.gz
-    - chr20.phastCons100way.wigFix.gz
-    - chr21.phastCons100way.wigFix.gz
-    - chr22.phastCons100way.wigFix.gz
-    - chrX.phastCons100way.wigFix.gz
-    - chrY.phastCons100way.wigFix.gz
-    - chrM.phastCons100way.wigFix.gz
+      - chr1.phastCons100way.wigFix.gz
+      - chr2.phastCons100way.wigFix.gz
+      - chr3.phastCons100way.wigFix.gz
+      - chr4.phastCons100way.wigFix.gz
+      - chr5.phastCons100way.wigFix.gz
+      - chr6.phastCons100way.wigFix.gz
+      - chr7.phastCons100way.wigFix.gz
+      - chr8.phastCons100way.wigFix.gz
+      - chr9.phastCons100way.wigFix.gz
+      - chr10.phastCons100way.wigFix.gz
+      - chr11.phastCons100way.wigFix.gz
+      - chr12.phastCons100way.wigFix.gz
+      - chr13.phastCons100way.wigFix.gz
+      - chr14.phastCons100way.wigFix.gz
+      - chr15.phastCons100way.wigFix.gz
+      - chr16.phastCons100way.wigFix.gz
+      - chr17.phastCons100way.wigFix.gz
+      - chr18.phastCons100way.wigFix.gz
+      - chr19.phastCons100way.wigFix.gz
+      - chr20.phastCons100way.wigFix.gz
+      - chr21.phastCons100way.wigFix.gz
+      - chr22.phastCons100way.wigFix.gz
+      - chrX.phastCons100way.wigFix.gz
+      - chrY.phastCons100way.wigFix.gz
+      - chrM.phastCons100way.wigFix.gz
     type: score
     version: 1
   - build_author: ec2-user
     build_date: 2017-09-27T18:27:00
     local_files:
-    - chr*.phyloP100way.wigFix.gz
+      - chr*.phyloP100way.wigFix.gz
     name: phyloP
     remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phyloP100way/hg19.100way.phyloP100way/
     remote_files:
-    - chr1.phyloP100way.wigFix.gz
-    - chr2.phyloP100way.wigFix.gz
-    - chr3.phyloP100way.wigFix.gz
-    - chr4.phyloP100way.wigFix.gz
-    - chr5.phyloP100way.wigFix.gz
-    - chr6.phyloP100way.wigFix.gz
-    - chr7.phyloP100way.wigFix.gz
-    - chr8.phyloP100way.wigFix.gz
-    - chr9.phyloP100way.wigFix.gz
-    - chr10.phyloP100way.wigFix.gz
-    - chr11.phyloP100way.wigFix.gz
-    - chr12.phyloP100way.wigFix.gz
-    - chr13.phyloP100way.wigFix.gz
-    - chr14.phyloP100way.wigFix.gz
-    - chr15.phyloP100way.wigFix.gz
-    - chr16.phyloP100way.wigFix.gz
-    - chr17.phyloP100way.wigFix.gz
-    - chr18.phyloP100way.wigFix.gz
-    - chr19.phyloP100way.wigFix.gz
-    - chr20.phyloP100way.wigFix.gz
-    - chr21.phyloP100way.wigFix.gz
-    - chr22.phyloP100way.wigFix.gz
-    - chrX.phyloP100way.wigFix.gz
-    - chrY.phyloP100way.wigFix.gz
-    - chrM.phyloP100way.wigFix.gz
+      - chr1.phyloP100way.wigFix.gz
+      - chr2.phyloP100way.wigFix.gz
+      - chr3.phyloP100way.wigFix.gz
+      - chr4.phyloP100way.wigFix.gz
+      - chr5.phyloP100way.wigFix.gz
+      - chr6.phyloP100way.wigFix.gz
+      - chr7.phyloP100way.wigFix.gz
+      - chr8.phyloP100way.wigFix.gz
+      - chr9.phyloP100way.wigFix.gz
+      - chr10.phyloP100way.wigFix.gz
+      - chr11.phyloP100way.wigFix.gz
+      - chr12.phyloP100way.wigFix.gz
+      - chr13.phyloP100way.wigFix.gz
+      - chr14.phyloP100way.wigFix.gz
+      - chr15.phyloP100way.wigFix.gz
+      - chr16.phyloP100way.wigFix.gz
+      - chr17.phyloP100way.wigFix.gz
+      - chr18.phyloP100way.wigFix.gz
+      - chr19.phyloP100way.wigFix.gz
+      - chr20.phyloP100way.wigFix.gz
+      - chr21.phyloP100way.wigFix.gz
+      - chr22.phyloP100way.wigFix.gz
+      - chrX.phyloP100way.wigFix.gz
+      - chrY.phyloP100way.wigFix.gz
+      - chrM.phyloP100way.wigFix.gz
     type: score
     version: 1
   - build_author: ec2-user
@@ -233,8 +234,8 @@
     caddToBed_date: 2017-04-22T06:41:00
     liftOverCadd_date: 2017-07-28T17:35:00
     local_files:
-    - whole_genome_SNVs.tsv.bed.chr*.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.bed.chrM.organized-by-chr.txt.sorted.txt.mapped.gz
+      - whole_genome_SNVs.tsv.bed.chr*.organized-by-chr.txt.sorted.txt.gz
+      - whole_genome_SNVs.tsv.bed.chrM.organized-by-chr.txt.sorted.txt.mapped.gz
     name: cadd
     sortCadd_date: 2017-04-23T15:44:00
     sort_date: 2017-01-20T16:06:00
@@ -250,41 +251,41 @@
       func: split [,]
       observed: split [\/]
     features:
-    - name
-    - strand
-    - observed
-    - class
-    - func
-    - alleles
-    - alleleNs: number
-    - alleleFreqs: number
+      - name
+      - strand
+      - observed
+      - class
+      - func
+      - alleles
+      - alleleNs: number
+      - alleleFreqs: number
     fetch_date: 2017-09-27T02:12:00
     local_files:
-    - hg19.snp150.chr1.gz
-    - hg19.snp150.chr2.gz
-    - hg19.snp150.chr3.gz
-    - hg19.snp150.chr4.gz
-    - hg19.snp150.chr5.gz
-    - hg19.snp150.chr6.gz
-    - hg19.snp150.chr7.gz
-    - hg19.snp150.chr8.gz
-    - hg19.snp150.chr9.gz
-    - hg19.snp150.chr10.gz
-    - hg19.snp150.chr11.gz
-    - hg19.snp150.chr12.gz
-    - hg19.snp150.chr13.gz
-    - hg19.snp150.chr14.gz
-    - hg19.snp150.chr15.gz
-    - hg19.snp150.chr16.gz
-    - hg19.snp150.chr17.gz
-    - hg19.snp150.chr18.gz
-    - hg19.snp150.chr19.gz
-    - hg19.snp150.chr20.gz
-    - hg19.snp150.chr21.gz
-    - hg19.snp150.chr22.gz
-    - hg19.snp150.chrM.gz
-    - hg19.snp150.chrX.gz
-    - hg19.snp150.chrY.gz
+      - hg19.snp150.chr1.gz
+      - hg19.snp150.chr2.gz
+      - hg19.snp150.chr3.gz
+      - hg19.snp150.chr4.gz
+      - hg19.snp150.chr5.gz
+      - hg19.snp150.chr6.gz
+      - hg19.snp150.chr7.gz
+      - hg19.snp150.chr8.gz
+      - hg19.snp150.chr9.gz
+      - hg19.snp150.chr10.gz
+      - hg19.snp150.chr11.gz
+      - hg19.snp150.chr12.gz
+      - hg19.snp150.chr13.gz
+      - hg19.snp150.chr14.gz
+      - hg19.snp150.chr15.gz
+      - hg19.snp150.chr16.gz
+      - hg19.snp150.chr17.gz
+      - hg19.snp150.chr18.gz
+      - hg19.snp150.chr19.gz
+      - hg19.snp150.chr20.gz
+      - hg19.snp150.chr21.gz
+      - hg19.snp150.chr22.gz
+      - hg19.snp150.chrM.gz
+      - hg19.snp150.chrX.gz
+      - hg19.snp150.chrY.gz
     name: dbSNP
     sql_statement: SELECT * FROM hg19.snp150
     type: sparse
@@ -302,18 +303,18 @@
     build_row_filters:
       Assembly: == GRCh37
     features:
-    - alleleID: number
-    - phenotypeList
-    - clinicalSignificance
-    - type
-    - origin
-    - numberSubmitters: number
-    - reviewStatus
-    - referenceAllele
-    - alternateAllele
+      - alleleID: number
+      - phenotypeList
+      - clinicalSignificance
+      - type
+      - origin
+      - numberSubmitters: number
+      - reviewStatus
+      - referenceAllele
+      - alternateAllele
     fetch_date: 2017-10-07T16:57:00
     fieldMap:
-      '#AlleleID': alleleID
+      "#AlleleID": alleleID
       AlternateAllele: alternateAllele
       Chromosome: chrom
       ClinicalSignificance: clinicalSignificance
@@ -327,10 +328,10 @@
       Stop: chromEnd
       Type: type
     local_files:
-    - variant_summary.txt.gz
+      - variant_summary.txt.gz
     name: clinvar
     remote_files:
-    - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
+      - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
     type: sparse
     version: 1
   - build_author: ec2-user
@@ -338,28 +339,28 @@
     build_row_filters:
       AS_FilterStatus: == PASS
     features:
-    - alt
-    - id
-    - af: number
-    - an: number
-    - an_afr: number
-    - an_amr: number
-    - an_asj: number
-    - an_eas: number
-    - an_fin: number
-    - an_nfe: number
-    - an_oth: number
-    - an_male: number
-    - an_female: number
-    - af_afr: number
-    - af_amr: number
-    - af_asj: number
-    - af_eas: number
-    - af_fin: number
-    - af_nfe: number
-    - af_oth: number
-    - af_male: number
-    - af_female: number
+      - alt
+      - id
+      - af: number
+      - an: number
+      - an_afr: number
+      - an_amr: number
+      - an_asj: number
+      - an_eas: number
+      - an_fin: number
+      - an_nfe: number
+      - an_oth: number
+      - an_male: number
+      - an_female: number
+      - af_afr: number
+      - af_amr: number
+      - af_asj: number
+      - af_eas: number
+      - af_fin: number
+      - af_nfe: number
+      - af_oth: number
+      - af_male: number
+      - af_female: number
     fieldMap:
       AF: af
       AF_AFR: af_afr
@@ -382,7 +383,7 @@
       AN_NFE: an_nfe
       AN_OTH: an_oth
     local_files:
-    - gnomad.genomes.r2.0.1.sites.*.vcf.gz
+      - gnomad.genomes.r2.0.1.sites.*.vcf.gz
     name: gnomad.genomes
     type: vcf
     version: 1
@@ -391,28 +392,28 @@
     build_row_filters:
       AS_FilterStatus: == PASS
     features:
-    - alt
-    - id
-    - af: number
-    - an: number
-    - an_afr: number
-    - an_amr: number
-    - an_asj: number
-    - an_eas: number
-    - an_fin: number
-    - an_nfe: number
-    - an_oth: number
-    - an_male: number
-    - an_female: number
-    - af_afr: number
-    - af_amr: number
-    - af_asj: number
-    - af_eas: number
-    - af_fin: number
-    - af_nfe: number
-    - af_oth: number
-    - af_male: number
-    - af_female: number
+      - alt
+      - id
+      - af: number
+      - an: number
+      - an_afr: number
+      - an_amr: number
+      - an_asj: number
+      - an_eas: number
+      - an_fin: number
+      - an_nfe: number
+      - an_oth: number
+      - an_male: number
+      - an_female: number
+      - af_afr: number
+      - af_amr: number
+      - af_asj: number
+      - af_eas: number
+      - af_fin: number
+      - af_nfe: number
+      - af_oth: number
+      - af_male: number
+      - af_female: number
     fieldMap:
       AF: af
       AF_AFR: af_afr
@@ -435,9 +436,8 @@
       AN_NFE: an_nfe
       AN_OTH: an_oth
     local_files:
-    - gnomad.exomes.r2.0.1.sites.vcf.gz
+      - gnomad.exomes.r2.0.1.sites.vcf.gz
     name: gnomad.exomes
     type: vcf
     version: 1
-  version: 2
-  
+version: 2

--- a/config/hg38-small.clean.yml
+++ b/config/hg38-small.clean.yml
@@ -3,38 +3,38 @@ assembly: hg38
 build_author: ec2-user
 build_date: 2018-09-07T19:32:00
 chromosomes:
-- chr1
-- chr2
-- chr3
-- chr4
-- chr5
-- chr6
-- chr7
-- chr8
-- chr9
-- chr10
-- chr11
-- chr12
-- chr13
-- chr14
-- chr15
-- chr16
-- chr17
-- chr18
-- chr19
-- chr20
-- chr21
-- chr22
-- chrM
-- chrX
-- chrY
+  - chr1
+  - chr2
+  - chr3
+  - chr4
+  - chr5
+  - chr6
+  - chr7
+  - chr8
+  - chr9
+  - chr10
+  - chr11
+  - chr12
+  - chr13
+  - chr14
+  - chr15
+  - chr16
+  - chr17
+  - chr18
+  - chr19
+  - chr20
+  - chr21
+  - chr22
+  - chrM
+  - chrX
+  - chrY
 database_dir: ~
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --sample %sampleList%
+    args: --emptyField NA --sample %sampleList%
     program: bystro-vcf
 files_dir: ~
 statistics:
@@ -50,169 +50,169 @@ statistics:
 temp_dir: ~
 tracks:
   outputOrder:
-  - ref
-  - refSeq
-  - nearest.refSeq
-  - cadd
+    - ref
+    - refSeq
+    - nearest.refSeq
+    - cadd
   tracks:
-  - build_author: ec2-user
-    build_date: 2018-09-07T19:32:00
-    local_files:
-    - chr*.fa.gz
-    name: ref
-    type: reference
-    utils:
-    - args:
-        remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/chromosomes/
-        remoteFiles:
-        - chr1.fa.gz
-        - chr2.fa.gz
-        - chr3.fa.gz
-        - chr4.fa.gz
-        - chr5.fa.gz
-        - chr6.fa.gz
-        - chr7.fa.gz
-        - chr8.fa.gz
-        - chr9.fa.gz
-        - chr10.fa.gz
-        - chr11.fa.gz
-        - chr12.fa.gz
-        - chr13.fa.gz
-        - chr14.fa.gz
-        - chr15.fa.gz
-        - chr16.fa.gz
-        - chr17.fa.gz
-        - chr18.fa.gz
-        - chr19.fa.gz
-        - chr20.fa.gz
-        - chr21.fa.gz
-        - chr22.fa.gz
-        - chrM.fa.gz
-        - chrX.fa.gz
-        - chrY.fa.gz
-      completed: 2017-11-24T02:27:00
-      name: fetch
-    version: 28
-  - build_author: ec2-user
-    build_date: 2018-09-07T19:32:00
-    dist: true
-    features:
-    - name2
-    - name
-    from: txStart
-    local_files:
-    - hg38.kgXref.chr*.with_dbnsfp.gz
-    name: nearest.refSeq
-    to: txEnd
-    type: nearest
-    version: 2
-  - build_author: ec2-user
-    build_date: 2018-09-07T19:32:00
-    local_files:
-    - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
-    - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
-    name: cadd
-    sorted: 1
-    type: cadd
-    utils:
-    - args:
-        remoteFiles:
-        - http://krishna.gs.washington.edu/download/CADD/v1.4/GRCh38/whole_genome_SNVs.tsv.gz
-      completed: 2018-09-06T03:52:00
-      name: fetch
-    - completed: 2018-09-06T05:39:00
-      name: SortCadd
-    version: 19
-  - build_author: ec2-user
-    build_date: 2018-09-07T19:32:00
-    build_field_transformations:
-      description: split [;]
-      ensemblID: split [;]
-      kgID: split [;]
-      mRNA: split [;]
-      protAcc: split [;]
-      rfamAcc: split [;]
-      spDisplayID: split [;]
-      spID: split [;]
-      tRnaName: split [;]
-    features:
-    - name
-    - name2
-    local_files:
-    - hg38.kgXref.chr8.with_dbnsfp.gz
-    - hg38.kgXref.chr4.with_dbnsfp.gz
-    - hg38.kgXref.chr3.with_dbnsfp.gz
-    - hg38.kgXref.chr1.with_dbnsfp.gz
-    - hg38.kgXref.chr6.with_dbnsfp.gz
-    - hg38.kgXref.chr2.with_dbnsfp.gz
-    - hg38.kgXref.chr5.with_dbnsfp.gz
-    - hg38.kgXref.chr7.with_dbnsfp.gz
-    - hg38.kgXref.chr10.with_dbnsfp.gz
-    - hg38.kgXref.chr9.with_dbnsfp.gz
-    - hg38.kgXref.chr16.with_dbnsfp.gz
-    - hg38.kgXref.chr11.with_dbnsfp.gz
-    - hg38.kgXref.chr12.with_dbnsfp.gz
-    - hg38.kgXref.chr14.with_dbnsfp.gz
-    - hg38.kgXref.chr15.with_dbnsfp.gz
-    - hg38.kgXref.chr13.with_dbnsfp.gz
-    - hg38.kgXref.chr18.with_dbnsfp.gz
-    - hg38.kgXref.chrY.with_dbnsfp.gz
-    - hg38.kgXref.chrM.with_dbnsfp.gz
-    - hg38.kgXref.chr17.with_dbnsfp.gz
-    - hg38.kgXref.chr22.with_dbnsfp.gz
-    - hg38.kgXref.chr21.with_dbnsfp.gz
-    - hg38.kgXref.chrX.with_dbnsfp.gz
-    - hg38.kgXref.chr19.with_dbnsfp.gz
-    - hg38.kgXref.chr20.with_dbnsfp.gz
-    name: refSeq
-    type: gene
-    utils:
-    - args:
-        connection:
-          database: hg38
-        sql: SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
-          ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
-          '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
-          (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
-          e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
-          (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
-          kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
-          '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
-          GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
-          x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
-          '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
-          GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
-          x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
-          '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
-          refGene r WHERE chrom=%chromosomes%;
-      completed: 2018-09-07T14:04:00
-      name: fetch
-    - args:
-        geneFile: /mnt/bystro-files/dbnsfp//dbNSFP3.5_gene.complete
-      completed: 2018-09-07T14:05:00
-      name: refGeneXdbnsfp
-    version: 28
+    - build_author: ec2-user
+      build_date: 2018-09-07T19:32:00
+      local_files:
+        - chr*.fa.gz
+      name: ref
+      type: reference
+      utils:
+        - args:
+            remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/chromosomes/
+            remoteFiles:
+              - chr1.fa.gz
+              - chr2.fa.gz
+              - chr3.fa.gz
+              - chr4.fa.gz
+              - chr5.fa.gz
+              - chr6.fa.gz
+              - chr7.fa.gz
+              - chr8.fa.gz
+              - chr9.fa.gz
+              - chr10.fa.gz
+              - chr11.fa.gz
+              - chr12.fa.gz
+              - chr13.fa.gz
+              - chr14.fa.gz
+              - chr15.fa.gz
+              - chr16.fa.gz
+              - chr17.fa.gz
+              - chr18.fa.gz
+              - chr19.fa.gz
+              - chr20.fa.gz
+              - chr21.fa.gz
+              - chr22.fa.gz
+              - chrM.fa.gz
+              - chrX.fa.gz
+              - chrY.fa.gz
+          completed: 2017-11-24T02:27:00
+          name: fetch
+      version: 28
+    - build_author: ec2-user
+      build_date: 2018-09-07T19:32:00
+      dist: true
+      features:
+        - name2
+        - name
+      from: txStart
+      local_files:
+        - hg38.kgXref.chr*.with_dbnsfp.gz
+      name: nearest.refSeq
+      to: txEnd
+      type: nearest
+      version: 2
+    - build_author: ec2-user
+      build_date: 2018-09-07T19:32:00
+      local_files:
+        - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
+      name: cadd
+      sorted: 1
+      type: cadd
+      utils:
+        - args:
+            remoteFiles:
+              - http://krishna.gs.washington.edu/download/CADD/v1.4/GRCh38/whole_genome_SNVs.tsv.gz
+          completed: 2018-09-06T03:52:00
+          name: fetch
+        - completed: 2018-09-06T05:39:00
+          name: SortCadd
+      version: 19
+    - build_author: ec2-user
+      build_date: 2018-09-07T19:32:00
+      build_field_transformations:
+        description: split [;]
+        ensemblID: split [;]
+        kgID: split [;]
+        mRNA: split [;]
+        protAcc: split [;]
+        rfamAcc: split [;]
+        spDisplayID: split [;]
+        spID: split [;]
+        tRnaName: split [;]
+      features:
+        - name
+        - name2
+      local_files:
+        - hg38.kgXref.chr8.with_dbnsfp.gz
+        - hg38.kgXref.chr4.with_dbnsfp.gz
+        - hg38.kgXref.chr3.with_dbnsfp.gz
+        - hg38.kgXref.chr1.with_dbnsfp.gz
+        - hg38.kgXref.chr6.with_dbnsfp.gz
+        - hg38.kgXref.chr2.with_dbnsfp.gz
+        - hg38.kgXref.chr5.with_dbnsfp.gz
+        - hg38.kgXref.chr7.with_dbnsfp.gz
+        - hg38.kgXref.chr10.with_dbnsfp.gz
+        - hg38.kgXref.chr9.with_dbnsfp.gz
+        - hg38.kgXref.chr16.with_dbnsfp.gz
+        - hg38.kgXref.chr11.with_dbnsfp.gz
+        - hg38.kgXref.chr12.with_dbnsfp.gz
+        - hg38.kgXref.chr14.with_dbnsfp.gz
+        - hg38.kgXref.chr15.with_dbnsfp.gz
+        - hg38.kgXref.chr13.with_dbnsfp.gz
+        - hg38.kgXref.chr18.with_dbnsfp.gz
+        - hg38.kgXref.chrY.with_dbnsfp.gz
+        - hg38.kgXref.chrM.with_dbnsfp.gz
+        - hg38.kgXref.chr17.with_dbnsfp.gz
+        - hg38.kgXref.chr22.with_dbnsfp.gz
+        - hg38.kgXref.chr21.with_dbnsfp.gz
+        - hg38.kgXref.chrX.with_dbnsfp.gz
+        - hg38.kgXref.chr19.with_dbnsfp.gz
+        - hg38.kgXref.chr20.with_dbnsfp.gz
+      name: refSeq
+      type: gene
+      utils:
+        - args:
+            connection:
+              database: hg38
+            sql:
+              SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
+              ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
+              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
+              e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
+              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
+              kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
+              GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
+              x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
+              GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
+              x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
+              refGene r WHERE chrom=%chromosomes%;
+          completed: 2018-09-07T14:04:00
+          name: fetch
+        - args:
+            geneFile: /mnt/bystro-files/dbnsfp//dbNSFP3.5_gene.complete
+          completed: 2018-09-07T14:05:00
+          name: refGeneXdbnsfp
+      version: 28
 version: 215
-

--- a/config/hg38.clean.yml
+++ b/config/hg38.clean.yml
@@ -1,8 +1,8 @@
 ---
-  assembly: hg38
-  build_author: ec2-user
-  build_date: 2018-09-08T12:25:00
-  chromosomes:
+assembly: hg38
+build_author: ec2-user
+build_date: 2018-09-08T12:25:00
+chromosomes:
   - chr1
   - chr2
   - chr3
@@ -28,28 +28,28 @@
   - chrM
   - chrX
   - chrY
-  database_dir: '~'
-  fileProcessors:
-    snp:
-      args: --emptyField ! --minGq .95
-      program: bystro-snp
-    vcf:
-      args: --emptyField ! --sample %sampleList%
-      program: bystro-vcf
-  files_dir: '~'
-  statistics:
-    dbSNPnameField: dbSNP.name
-    exonicAlleleFunctionField: refSeq.exonicAlleleFunction
-    outputExtensions:
-      json: .statistics.json
-      qc: .statistics.qc.tsv
-      tab: .statistics.tsv
-    programPath: bystro-stats
-    refTrackField: ref
-    siteTypeField: refSeq.siteType
-  temp_dir: '~'
-  tracks:
-    outputOrder:
+database_dir: "~"
+fileProcessors:
+  snp:
+    args: --emptyField NA --minGq .95
+    program: bystro-snp
+  vcf:
+    args: --emptyField NA --sample %sampleList%
+    program: bystro-vcf
+files_dir: "~"
+statistics:
+  dbSNPnameField: dbSNP.name
+  exonicAlleleFunctionField: refSeq.exonicAlleleFunction
+  outputExtensions:
+    json: .statistics.json
+    qc: .statistics.qc.tsv
+    tab: .statistics.tsv
+  programPath: bystro-stats
+  refTrackField: ref
+  siteTypeField: refSeq.siteType
+temp_dir: "~"
+tracks:
+  outputOrder:
     - ref
     - refSeq
     - refSeq.gene
@@ -64,54 +64,54 @@
     - clinvar
     - cosmic.coding
     - cosmic.nonCoding
-    tracks:
+  tracks:
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
       local_files:
-      - chr*.fa.gz
+        - chr*.fa.gz
       name: ref
       type: reference
       utils:
-      - args:
-          remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/chromosomes/
-          remoteFiles:
-          - chr1.fa.gz
-          - chr2.fa.gz
-          - chr3.fa.gz
-          - chr4.fa.gz
-          - chr5.fa.gz
-          - chr6.fa.gz
-          - chr7.fa.gz
-          - chr8.fa.gz
-          - chr9.fa.gz
-          - chr10.fa.gz
-          - chr11.fa.gz
-          - chr12.fa.gz
-          - chr13.fa.gz
-          - chr14.fa.gz
-          - chr15.fa.gz
-          - chr16.fa.gz
-          - chr17.fa.gz
-          - chr18.fa.gz
-          - chr19.fa.gz
-          - chr20.fa.gz
-          - chr21.fa.gz
-          - chr22.fa.gz
-          - chrM.fa.gz
-          - chrX.fa.gz
-          - chrY.fa.gz
-        completed: 2017-11-24T02:27:00
-        name: fetch
+        - args:
+            remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/chromosomes/
+            remoteFiles:
+              - chr1.fa.gz
+              - chr2.fa.gz
+              - chr3.fa.gz
+              - chr4.fa.gz
+              - chr5.fa.gz
+              - chr6.fa.gz
+              - chr7.fa.gz
+              - chr8.fa.gz
+              - chr9.fa.gz
+              - chr10.fa.gz
+              - chr11.fa.gz
+              - chr12.fa.gz
+              - chr13.fa.gz
+              - chr14.fa.gz
+              - chr15.fa.gz
+              - chr16.fa.gz
+              - chr17.fa.gz
+              - chr18.fa.gz
+              - chr19.fa.gz
+              - chr20.fa.gz
+              - chr21.fa.gz
+              - chr22.fa.gz
+              - chrM.fa.gz
+              - chrX.fa.gz
+              - chrY.fa.gz
+          completed: 2017-11-24T02:27:00
+          name: fetch
       version: 28
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
       dist: true
       features:
-      - name
-      - name2
+        - name
+        - name2
       from: txStart
       local_files:
-      - hg38.kgXref.chr*.with_dbnsfp.gz
+        - hg38.kgXref.chr*.with_dbnsfp.gz
       name: nearest.refSeq
       to: txEnd
       type: nearest
@@ -120,128 +120,128 @@
       build_date: 2018-09-07T19:32:00
       dist: true
       features:
-      - name
-      - name2
+        - name
+        - name2
       from: txStart
       local_files:
-      - hg38.kgXref.chr*.with_dbnsfp.gz
+        - hg38.kgXref.chr*.with_dbnsfp.gz
       name: nearestTss.refSeq
       type: nearest
       version: 19
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
       local_files:
-      - chr*.phastCons100way.wigFix.gz
+        - chr*.phastCons100way.wigFix.gz
       name: phastCons
       type: score
       utils:
-      - args:
-          remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/phastCons100way/hg38.100way.phastCons/
-          remoteFiles:
-          - chr1.phastCons100way.wigFix.gz
-          - chr2.phastCons100way.wigFix.gz
-          - chr3.phastCons100way.wigFix.gz
-          - chr4.phastCons100way.wigFix.gz
-          - chr5.phastCons100way.wigFix.gz
-          - chr6.phastCons100way.wigFix.gz
-          - chr7.phastCons100way.wigFix.gz
-          - chr8.phastCons100way.wigFix.gz
-          - chr9.phastCons100way.wigFix.gz
-          - chr10.phastCons100way.wigFix.gz
-          - chr11.phastCons100way.wigFix.gz
-          - chr12.phastCons100way.wigFix.gz
-          - chr13.phastCons100way.wigFix.gz
-          - chr14.phastCons100way.wigFix.gz
-          - chr15.phastCons100way.wigFix.gz
-          - chr16.phastCons100way.wigFix.gz
-          - chr17.phastCons100way.wigFix.gz
-          - chr18.phastCons100way.wigFix.gz
-          - chr19.phastCons100way.wigFix.gz
-          - chr20.phastCons100way.wigFix.gz
-          - chr21.phastCons100way.wigFix.gz
-          - chr22.phastCons100way.wigFix.gz
-          - chrX.phastCons100way.wigFix.gz
-          - chrY.phastCons100way.wigFix.gz
-          - chrM.phastCons100way.wigFix.gz
-        completed: 2017-11-23T21:05:00
-        name: fetch
+        - args:
+            remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/phastCons100way/hg38.100way.phastCons/
+            remoteFiles:
+              - chr1.phastCons100way.wigFix.gz
+              - chr2.phastCons100way.wigFix.gz
+              - chr3.phastCons100way.wigFix.gz
+              - chr4.phastCons100way.wigFix.gz
+              - chr5.phastCons100way.wigFix.gz
+              - chr6.phastCons100way.wigFix.gz
+              - chr7.phastCons100way.wigFix.gz
+              - chr8.phastCons100way.wigFix.gz
+              - chr9.phastCons100way.wigFix.gz
+              - chr10.phastCons100way.wigFix.gz
+              - chr11.phastCons100way.wigFix.gz
+              - chr12.phastCons100way.wigFix.gz
+              - chr13.phastCons100way.wigFix.gz
+              - chr14.phastCons100way.wigFix.gz
+              - chr15.phastCons100way.wigFix.gz
+              - chr16.phastCons100way.wigFix.gz
+              - chr17.phastCons100way.wigFix.gz
+              - chr18.phastCons100way.wigFix.gz
+              - chr19.phastCons100way.wigFix.gz
+              - chr20.phastCons100way.wigFix.gz
+              - chr21.phastCons100way.wigFix.gz
+              - chr22.phastCons100way.wigFix.gz
+              - chrX.phastCons100way.wigFix.gz
+              - chrY.phastCons100way.wigFix.gz
+              - chrM.phastCons100way.wigFix.gz
+          completed: 2017-11-23T21:05:00
+          name: fetch
       version: 20
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
       local_files:
-      - chr*.phyloP100way.wigFix.gz
+        - chr*.phyloP100way.wigFix.gz
       name: phyloP
       type: score
       utils:
-      - args:
-          remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP100way/hg38.100way.phyloP100way/
-          remoteFiles:
-          - chr1.phyloP100way.wigFix.gz
-          - chr2.phyloP100way.wigFix.gz
-          - chr3.phyloP100way.wigFix.gz
-          - chr4.phyloP100way.wigFix.gz
-          - chr5.phyloP100way.wigFix.gz
-          - chr6.phyloP100way.wigFix.gz
-          - chr7.phyloP100way.wigFix.gz
-          - chr8.phyloP100way.wigFix.gz
-          - chr9.phyloP100way.wigFix.gz
-          - chr10.phyloP100way.wigFix.gz
-          - chr11.phyloP100way.wigFix.gz
-          - chr12.phyloP100way.wigFix.gz
-          - chr13.phyloP100way.wigFix.gz
-          - chr14.phyloP100way.wigFix.gz
-          - chr15.phyloP100way.wigFix.gz
-          - chr16.phyloP100way.wigFix.gz
-          - chr17.phyloP100way.wigFix.gz
-          - chr18.phyloP100way.wigFix.gz
-          - chr19.phyloP100way.wigFix.gz
-          - chr20.phyloP100way.wigFix.gz
-          - chr21.phyloP100way.wigFix.gz
-          - chr22.phyloP100way.wigFix.gz
-          - chrX.phyloP100way.wigFix.gz
-          - chrY.phyloP100way.wigFix.gz
-          - chrM.phyloP100way.wigFix.gz
-        completed: 2017-11-23T21:10:00
-        name: fetch
+        - args:
+            remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP100way/hg38.100way.phyloP100way/
+            remoteFiles:
+              - chr1.phyloP100way.wigFix.gz
+              - chr2.phyloP100way.wigFix.gz
+              - chr3.phyloP100way.wigFix.gz
+              - chr4.phyloP100way.wigFix.gz
+              - chr5.phyloP100way.wigFix.gz
+              - chr6.phyloP100way.wigFix.gz
+              - chr7.phyloP100way.wigFix.gz
+              - chr8.phyloP100way.wigFix.gz
+              - chr9.phyloP100way.wigFix.gz
+              - chr10.phyloP100way.wigFix.gz
+              - chr11.phyloP100way.wigFix.gz
+              - chr12.phyloP100way.wigFix.gz
+              - chr13.phyloP100way.wigFix.gz
+              - chr14.phyloP100way.wigFix.gz
+              - chr15.phyloP100way.wigFix.gz
+              - chr16.phyloP100way.wigFix.gz
+              - chr17.phyloP100way.wigFix.gz
+              - chr18.phyloP100way.wigFix.gz
+              - chr19.phyloP100way.wigFix.gz
+              - chr20.phyloP100way.wigFix.gz
+              - chr21.phyloP100way.wigFix.gz
+              - chr22.phyloP100way.wigFix.gz
+              - chrX.phyloP100way.wigFix.gz
+              - chrY.phyloP100way.wigFix.gz
+              - chrM.phyloP100way.wigFix.gz
+          completed: 2017-11-23T21:10:00
+          name: fetch
       version: 19
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
       local_files:
-      - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
-      - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
       name: cadd
       sorted: 1
       type: cadd
       utils:
-      - args:
-          remoteFiles:
-          - http://krishna.gs.washington.edu/download/CADD/v1.4/GRCh38/whole_genome_SNVs.tsv.gz
-        completed: 2018-09-06T03:52:00
-        name: fetch
-      - completed: 2018-09-06T05:39:00
-        name: SortCadd
+        - args:
+            remoteFiles:
+              - http://krishna.gs.washington.edu/download/CADD/v1.4/GRCh38/whole_genome_SNVs.tsv.gz
+          completed: 2018-09-06T03:52:00
+          name: fetch
+        - completed: 2018-09-06T05:39:00
+          name: SortCadd
       version: 19
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
@@ -256,82 +256,83 @@
         spID: split [;]
         tRnaName: split [;]
       features:
-      - name
-      - name2
-      - description
-      - kgID
-      - mRNA
-      - spID
-      - spDisplayID
-      - protAcc
-      - rfamAcc
-      - tRnaName
-      - ensemblID
+        - name
+        - name2
+        - description
+        - kgID
+        - mRNA
+        - spID
+        - spDisplayID
+        - protAcc
+        - rfamAcc
+        - tRnaName
+        - ensemblID
       join:
         features:
-        - alleleID
-        - phenotypeList
-        - clinicalSignificance
-        - type
-        - origin
-        - numberSubmitters
-        - reviewStatus
-        - chromStart
-        - chromEnd
+          - alleleID
+          - phenotypeList
+          - clinicalSignificance
+          - type
+          - origin
+          - numberSubmitters
+          - reviewStatus
+          - chromStart
+          - chromEnd
         track: clinvar
       local_files:
-      - hg38.kgXref.chr8.with_dbnsfp.gz
-      - hg38.kgXref.chr4.with_dbnsfp.gz
-      - hg38.kgXref.chr3.with_dbnsfp.gz
-      - hg38.kgXref.chr1.with_dbnsfp.gz
-      - hg38.kgXref.chr6.with_dbnsfp.gz
-      - hg38.kgXref.chr2.with_dbnsfp.gz
-      - hg38.kgXref.chr5.with_dbnsfp.gz
-      - hg38.kgXref.chr7.with_dbnsfp.gz
-      - hg38.kgXref.chr10.with_dbnsfp.gz
-      - hg38.kgXref.chr9.with_dbnsfp.gz
-      - hg38.kgXref.chr16.with_dbnsfp.gz
-      - hg38.kgXref.chr11.with_dbnsfp.gz
-      - hg38.kgXref.chr12.with_dbnsfp.gz
-      - hg38.kgXref.chr14.with_dbnsfp.gz
-      - hg38.kgXref.chr15.with_dbnsfp.gz
-      - hg38.kgXref.chr13.with_dbnsfp.gz
-      - hg38.kgXref.chr18.with_dbnsfp.gz
-      - hg38.kgXref.chrY.with_dbnsfp.gz
-      - hg38.kgXref.chrM.with_dbnsfp.gz
-      - hg38.kgXref.chr17.with_dbnsfp.gz
-      - hg38.kgXref.chr22.with_dbnsfp.gz
-      - hg38.kgXref.chr21.with_dbnsfp.gz
-      - hg38.kgXref.chrX.with_dbnsfp.gz
-      - hg38.kgXref.chr19.with_dbnsfp.gz
-      - hg38.kgXref.chr20.with_dbnsfp.gz
+        - hg38.kgXref.chr8.with_dbnsfp.gz
+        - hg38.kgXref.chr4.with_dbnsfp.gz
+        - hg38.kgXref.chr3.with_dbnsfp.gz
+        - hg38.kgXref.chr1.with_dbnsfp.gz
+        - hg38.kgXref.chr6.with_dbnsfp.gz
+        - hg38.kgXref.chr2.with_dbnsfp.gz
+        - hg38.kgXref.chr5.with_dbnsfp.gz
+        - hg38.kgXref.chr7.with_dbnsfp.gz
+        - hg38.kgXref.chr10.with_dbnsfp.gz
+        - hg38.kgXref.chr9.with_dbnsfp.gz
+        - hg38.kgXref.chr16.with_dbnsfp.gz
+        - hg38.kgXref.chr11.with_dbnsfp.gz
+        - hg38.kgXref.chr12.with_dbnsfp.gz
+        - hg38.kgXref.chr14.with_dbnsfp.gz
+        - hg38.kgXref.chr15.with_dbnsfp.gz
+        - hg38.kgXref.chr13.with_dbnsfp.gz
+        - hg38.kgXref.chr18.with_dbnsfp.gz
+        - hg38.kgXref.chrY.with_dbnsfp.gz
+        - hg38.kgXref.chrM.with_dbnsfp.gz
+        - hg38.kgXref.chr17.with_dbnsfp.gz
+        - hg38.kgXref.chr22.with_dbnsfp.gz
+        - hg38.kgXref.chr21.with_dbnsfp.gz
+        - hg38.kgXref.chrX.with_dbnsfp.gz
+        - hg38.kgXref.chr19.with_dbnsfp.gz
+        - hg38.kgXref.chr20.with_dbnsfp.gz
       name: refSeq
       type: gene
       utils:
-      - args:
-          connection:
-            database: hg38
-          sql: SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
-            ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
-            (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
-            e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
-            (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
-            kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
-            GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
-            x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
-            GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
-            x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
-            '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
-            refGene r WHERE chrom=%chromosomes%;
-        completed: 2018-09-07T14:04:00
-        name: fetch
-      - args:
-          geneFile: /mnt/bystro-files/dbnsfp//dbNSFP3.5_gene.complete
-        completed: 2018-09-07T14:05:00
-        name: refGeneXdbnsfp
+        - args:
+            connection:
+              database: hg38
+            sql:
+              SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
+              ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
+              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
+              e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
+              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
+              kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
+              GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
+              x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
+              GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
+              x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
+              refGene r WHERE chrom=%chromosomes%;
+          completed: 2018-09-07T14:04:00
+          name: fetch
+        - args:
+            geneFile: /mnt/bystro-files/dbnsfp//dbNSFP3.5_gene.complete
+          completed: 2018-09-07T14:05:00
+          name: refGeneXdbnsfp
       version: 28
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
@@ -340,24 +341,24 @@
         uniprot.func: split [;]
       dist: false
       features:
-      - name2
-      - pLi: number
-      - pRec: number
-      - pNull: number
-      - lofTool: number
-      - lofFdr: number
-      - pHi: number
-      - nonTCGA.pRec: number
-      - nonTCGA.pNull: number
-      - nonTCGA.pLi: number
-      - nonPsych.pRec: number
-      - nonPsych.pNull: number
-      - nonPsych.pLi: number
-      - gdi: number
-      - cnv.score: number
-      - cnv.flag
-      - pmid: number
-      - rvis: number
+        - name2
+        - pLi: number
+        - pRec: number
+        - pNull: number
+        - lofTool: number
+        - lofFdr: number
+        - pHi: number
+        - nonTCGA.pRec: number
+        - nonTCGA.pNull: number
+        - nonTCGA.pLi: number
+        - nonPsych.pRec: number
+        - nonPsych.pNull: number
+        - nonPsych.pLi: number
+        - gdi: number
+        - cnv.score: number
+        - cnv.flag
+        - pmid: number
+        - rvis: number
       fieldMap:
         dbnsfp.Disease_description: uniprot.disease
         dbnsfp.ExAC_cnv.score: cnv.score
@@ -389,7 +390,7 @@
         dbnsfp.pubmedID: pmid
       from: txStart
       local_files:
-      - hg38.kgXref.chr*.with_dbnsfp.gz
+        - hg38.kgXref.chr*.with_dbnsfp.gz
       name: refSeq.gene
       storeNearest: false
       to: txEnd
@@ -404,77 +405,77 @@
         func: split [,]
         observed: split [\/]
       features:
-      - name
-      - strand
-      - observed
-      - class
-      - func
-      - alleles
-      - alleleNs: number
-      - alleleFreqs: number
+        - name
+        - strand
+        - observed
+        - class
+        - func
+        - alleles
+        - alleleNs: number
+        - alleleFreqs: number
       local_files:
-      - hg38.snp150.chr1.gz
-      - hg38.snp150.chr2.gz
-      - hg38.snp150.chr3.gz
-      - hg38.snp150.chr4.gz
-      - hg38.snp150.chr5.gz
-      - hg38.snp150.chr6.gz
-      - hg38.snp150.chr7.gz
-      - hg38.snp150.chr8.gz
-      - hg38.snp150.chr9.gz
-      - hg38.snp150.chr10.gz
-      - hg38.snp150.chr11.gz
-      - hg38.snp150.chr12.gz
-      - hg38.snp150.chr13.gz
-      - hg38.snp150.chr14.gz
-      - hg38.snp150.chr15.gz
-      - hg38.snp150.chr16.gz
-      - hg38.snp150.chr17.gz
-      - hg38.snp150.chr18.gz
-      - hg38.snp150.chr19.gz
-      - hg38.snp150.chr20.gz
-      - hg38.snp150.chr21.gz
-      - hg38.snp150.chr22.gz
-      - hg38.snp150.chrM.gz
-      - hg38.snp150.chrX.gz
-      - hg38.snp150.chrY.gz
+        - hg38.snp150.chr1.gz
+        - hg38.snp150.chr2.gz
+        - hg38.snp150.chr3.gz
+        - hg38.snp150.chr4.gz
+        - hg38.snp150.chr5.gz
+        - hg38.snp150.chr6.gz
+        - hg38.snp150.chr7.gz
+        - hg38.snp150.chr8.gz
+        - hg38.snp150.chr9.gz
+        - hg38.snp150.chr10.gz
+        - hg38.snp150.chr11.gz
+        - hg38.snp150.chr12.gz
+        - hg38.snp150.chr13.gz
+        - hg38.snp150.chr14.gz
+        - hg38.snp150.chr15.gz
+        - hg38.snp150.chr16.gz
+        - hg38.snp150.chr17.gz
+        - hg38.snp150.chr18.gz
+        - hg38.snp150.chr19.gz
+        - hg38.snp150.chr20.gz
+        - hg38.snp150.chr21.gz
+        - hg38.snp150.chr22.gz
+        - hg38.snp150.chrM.gz
+        - hg38.snp150.chrX.gz
+        - hg38.snp150.chrY.gz
       name: dbSNP
       type: sparse
       utils:
-      - args:
-          sql: SELECT * FROM hg38.snp150 WHERE chrom = %chromosomes%
-        completed: 2018-09-07T14:06:00
-        name: fetch
+        - args:
+            sql: SELECT * FROM hg38.snp150 WHERE chrom = %chromosomes%
+          completed: 2018-09-07T14:06:00
+          name: fetch
       version: 28
     - build_author: ec2-user
       build_date: 2018-09-08T12:25:00
       build_row_filters:
         AS_FilterStatus: == PASS
       features:
-      - alt
-      - id
-      - af: number
-      - an: number
-      - an_afr: number
-      - an_amr: number
-      - an_asj: number
-      - an_eas: number
-      - an_fin: number
-      - an_nfe: number
-      - an_oth: number
-      - an_sas: number
-      - an_male: number
-      - an_female: number
-      - af_afr: number
-      - af_amr: number
-      - af_asj: number
-      - af_eas: number
-      - af_fin: number
-      - af_nfe: number
-      - af_oth: number
-      - af_sas: number
-      - af_male: number
-      - af_female: number
+        - alt
+        - id
+        - af: number
+        - an: number
+        - an_afr: number
+        - an_amr: number
+        - an_asj: number
+        - an_eas: number
+        - an_fin: number
+        - an_nfe: number
+        - an_oth: number
+        - an_sas: number
+        - an_male: number
+        - an_female: number
+        - af_afr: number
+        - af_amr: number
+        - af_asj: number
+        - af_eas: number
+        - af_fin: number
+        - af_nfe: number
+        - af_oth: number
+        - af_sas: number
+        - af_male: number
+        - af_female: number
       fieldMap:
         AF: af
         AF_AFR: af_afr
@@ -499,7 +500,7 @@
         AN_OTH: an_oth
         AN_SAS: an_sas
       local_files:
-      - gnomad.genomes.r2.0.2.sites.chr*.liftedOver.hg38.vcf.liftedOver.gz
+        - gnomad.genomes.r2.0.2.sites.chr*.liftedOver.hg38.vcf.liftedOver.gz
       name: gnomad.genomes
       type: vcf
       version: 24
@@ -508,30 +509,30 @@
       build_row_filters:
         AS_FilterStatus: == PASS
       features:
-      - alt
-      - id
-      - af: number
-      - an: number
-      - an_afr: number
-      - an_amr: number
-      - an_asj: number
-      - an_eas: number
-      - an_fin: number
-      - an_nfe: number
-      - an_oth: number
-      - an_sas: number
-      - an_male: number
-      - an_female: number
-      - af_afr: number
-      - af_amr: number
-      - af_asj: number
-      - af_eas: number
-      - af_fin: number
-      - af_nfe: number
-      - af_oth: number
-      - af_sas: number
-      - af_male: number
-      - af_female: number
+        - alt
+        - id
+        - af: number
+        - an: number
+        - an_afr: number
+        - an_amr: number
+        - an_asj: number
+        - an_eas: number
+        - an_fin: number
+        - an_nfe: number
+        - an_oth: number
+        - an_sas: number
+        - an_male: number
+        - an_female: number
+        - af_afr: number
+        - af_amr: number
+        - af_asj: number
+        - af_eas: number
+        - af_fin: number
+        - af_nfe: number
+        - af_oth: number
+        - af_sas: number
+        - af_male: number
+        - af_female: number
       fieldMap:
         AF: af
         AF_AFR: af_afr
@@ -556,7 +557,7 @@
         AN_OTH: an_oth
         AN_SAS: an_sas
       local_files:
-      - gnomad.exomes.r2.0.2.sites.liftedOver.hg38.vcf.liftedOver.gz
+        - gnomad.exomes.r2.0.2.sites.liftedOver.hg38.vcf.liftedOver.gz
       name: gnomad.exomes
       type: vcf
       version: 24
@@ -573,17 +574,17 @@
       build_row_filters:
         Assembly: == GRCh38
       features:
-      - alleleID: number
-      - phenotypeList
-      - clinicalSignificance
-      - type
-      - origin
-      - numberSubmitters: number
-      - reviewStatus
-      - referenceAllele
-      - alternateAllele
+        - alleleID: number
+        - phenotypeList
+        - clinicalSignificance
+        - type
+        - origin
+        - numberSubmitters: number
+        - reviewStatus
+        - referenceAllele
+        - alternateAllele
       fieldMap:
-        '#AlleleID': alleleID
+        "#AlleleID": alleleID
         AlternateAllele: alternateAllele
         Chromosome: chrom
         ClinicalSignificance: clinicalSignificance
@@ -597,26 +598,26 @@
         Stop: chromEnd
         Type: type
       local_files:
-      - variant_summary.txt.gz
+        - variant_summary.txt.gz
       name: clinvar
       type: sparse
       utils:
-      - args:
-          remoteFiles:
-          - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
-        completed: 2018-09-07T17:31:00
-        name: fetch
+        - args:
+            remoteFiles:
+              - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
+          completed: 2018-09-07T17:31:00
+          name: fetch
       version: 20
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
       features:
-      - alt
-      - id
-      - cnt: number
-      - aa
-      - cds
-      - gene
-      - strand
+        - alt
+        - id
+        - cnt: number
+        - aa
+        - cds
+        - gene
+        - strand
       fieldMap:
         AA: aa
         CDS: cds
@@ -624,26 +625,26 @@
         GENE: gene
         STRAND: strand
       local_files:
-      - CosmicCodingMuts.vcf.gz
+        - CosmicCodingMuts.vcf.gz
       name: cosmic.coding
       type: vcf
       utils:
-      - args:
-          remoteFiles:
-          - https://s3.amazonaws.com/bystro-db/src/CosmicCodingMuts.vcf.gz
-        completed: 2018-09-07T17:31:00
-        name: fetch
+        - args:
+            remoteFiles:
+              - https://s3.amazonaws.com/bystro-db/src/CosmicCodingMuts.vcf.gz
+          completed: 2018-09-07T17:31:00
+          name: fetch
       version: 2
     - build_author: ec2-user
       build_date: 2018-09-07T19:32:00
       features:
-      - alt
-      - id
-      - cnt: number
-      - aa
-      - cds
-      - gene
-      - strand
+        - alt
+        - id
+        - cnt: number
+        - aa
+        - cds
+        - gene
+        - strand
       fieldMap:
         AA: aa
         CDS: cds
@@ -651,15 +652,14 @@
         GENE: gene
         STRAND: strand
       local_files:
-      - CosmicNonCodingVariants.vcf.gz
+        - CosmicNonCodingVariants.vcf.gz
       name: cosmic.nonCoding
       type: vcf
       utils:
-      - args:
-          remoteFiles:
-          - https://s3.amazonaws.com/bystro-db/src/CosmicNonCodingVariants.vcf.gz
-        completed: 2018-09-07T17:31:00
-        name: fetch
+        - args:
+            remoteFiles:
+              - https://s3.amazonaws.com/bystro-db/src/CosmicNonCodingVariants.vcf.gz
+          completed: 2018-09-07T17:31:00
+          name: fetch
       version: 2
-  version: 216
-  
+version: 216

--- a/config/mm10.clean.yml
+++ b/config/mm10.clean.yml
@@ -1,30 +1,30 @@
 ---
 assembly: mm10
 chromosomes:
-- chr1
-- chr2
-- chr3
-- chr4
-- chr5
-- chr6
-- chr7
-- chr8
-- chr9
-- chr10
-- chr11
-- chr12
-- chr13
-- chr14
-- chr15
-- chr16
-- chr17
-- chr18
-- chr19
-- chrM
-- chrX
-- chrY
-database_dir: '~'
-files: '~'
+  - chr1
+  - chr2
+  - chr3
+  - chr4
+  - chr5
+  - chr6
+  - chr7
+  - chr8
+  - chr9
+  - chr10
+  - chr11
+  - chr12
+  - chr13
+  - chr14
+  - chr15
+  - chr16
+  - chr17
+  - chr18
+  - chr19
+  - chrM
+  - chrX
+  - chrY
+database_dir: "~"
+files: "~"
 files_dir: ~
 statistics:
   dbSNPnameField: dbSNP.name
@@ -36,125 +36,125 @@ statistics:
   refTrackField: ref
   siteTypeField: refSeq.siteType
   programPath: bystro-stats
-temp_dir: '~'
+temp_dir: "~"
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --sample %sampleList% --keepPos --keepId
+    args: --emptyField NA --sample %sampleList% --keepPos --keepId
     program: bystro-vcf
 tracks:
-- name: ref
-  remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/mm10/chromosomes/
-  remote_files:
-  - chr1.fa.gz
-  - chr2.fa.gz
-  - chr3.fa.gz
-  - chr4.fa.gz
-  - chr5.fa.gz
-  - chr6.fa.gz
-  - chr7.fa.gz
-  - chr8.fa.gz
-  - chr9.fa.gz
-  - chr10.fa.gz
-  - chr11.fa.gz
-  - chr12.fa.gz
-  - chr13.fa.gz
-  - chr14.fa.gz
-  - chr15.fa.gz
-  - chr16.fa.gz
-  - chr17.fa.gz
-  - chr18.fa.gz
-  - chr19.fa.gz
-  - chrM.fa.gz
-  - chrX.fa.gz
-  - chrY.fa.gz
-  type: reference
-- features:
-  - kgID
-  - mRNA
-  - spID
-  - spDisplayID
-  - refseq
-  - protAcc
-  - description
-  - rfamAcc
-  - name
-  - name2
-  name: refSeq
-  sql_statement: SELECT * FROM mm10.refGene LEFT JOIN mm10.kgXref ON mm10.kgXref.refseq
-    = mm10.refGene.name
-  type: gene
-  version: 1
-- name: phastCons
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm10/phastCons60way/mm10.60way.phastCons/
-  remote_files:
-  - chr1.phastCons60way.wigFix.gz
-  - chr2.phastCons60way.wigFix.gz
-  - chr3.phastCons60way.wigFix.gz
-  - chr4.phastCons60way.wigFix.gz
-  - chr5.phastCons60way.wigFix.gz
-  - chr6.phastCons60way.wigFix.gz
-  - chr7.phastCons60way.wigFix.gz
-  - chr8.phastCons60way.wigFix.gz
-  - chr9.phastCons60way.wigFix.gz
-  - chr10.phastCons60way.wigFix.gz
-  - chr11.phastCons60way.wigFix.gz
-  - chr12.phastCons60way.wigFix.gz
-  - chr13.phastCons60way.wigFix.gz
-  - chr14.phastCons60way.wigFix.gz
-  - chr15.phastCons60way.wigFix.gz
-  - chr16.phastCons60way.wigFix.gz
-  - chr17.phastCons60way.wigFix.gz
-  - chr18.phastCons60way.wigFix.gz
-  - chr19.phastCons60way.wigFix.gz
-  - chrX.phastCons60way.wigFix.gz
-  - chrY.phastCons60way.wigFix.gz
-  - chrM.phastCons60way.wigFix.gz
-  type: score
-- name: phyloP
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm10/phyloP60way/mm10.60way.phyloP60way/
-  remote_files:
-  - chr1.phyloP60way.wigFix.gz
-  - chr2.phyloP60way.wigFix.gz
-  - chr3.phyloP60way.wigFix.gz
-  - chr4.phyloP60way.wigFix.gz
-  - chr5.phyloP60way.wigFix.gz
-  - chr6.phyloP60way.wigFix.gz
-  - chr7.phyloP60way.wigFix.gz
-  - chr8.phyloP60way.wigFix.gz
-  - chr9.phyloP60way.wigFix.gz
-  - chr10.phyloP60way.wigFix.gz
-  - chr11.phyloP60way.wigFix.gz
-  - chr12.phyloP60way.wigFix.gz
-  - chr13.phyloP60way.wigFix.gz
-  - chr14.phyloP60way.wigFix.gz
-  - chr15.phyloP60way.wigFix.gz
-  - chr16.phyloP60way.wigFix.gz
-  - chr17.phyloP60way.wigFix.gz
-  - chr18.phyloP60way.wigFix.gz
-  - chr19.phyloP60way.wigFix.gz
-  - chrX.phyloP60way.wigFix.gz
-  - chrY.phyloP60way.wigFix.gz
-  - chrM.phyloP60way.wigFix.gz
-  type: score
-- build_field_transformations:
-    alleleFreqs: split [,]
-    alleleNs: split [,]
-    alleles: split [,]
-    func: split [,]
-    observed: split [\/]
-  features:
-  - name
-  - strand
-  - observed
-  - class
-  - func
-  - alleles
-  - alleleNs: number
-  - alleleFreqs: number
-  name: dbSNP
-  sql_statement: SELECT * FROM mm10.snp142
-  type: sparse
-
+  - name: ref
+    remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/mm10/chromosomes/
+    remote_files:
+      - chr1.fa.gz
+      - chr2.fa.gz
+      - chr3.fa.gz
+      - chr4.fa.gz
+      - chr5.fa.gz
+      - chr6.fa.gz
+      - chr7.fa.gz
+      - chr8.fa.gz
+      - chr9.fa.gz
+      - chr10.fa.gz
+      - chr11.fa.gz
+      - chr12.fa.gz
+      - chr13.fa.gz
+      - chr14.fa.gz
+      - chr15.fa.gz
+      - chr16.fa.gz
+      - chr17.fa.gz
+      - chr18.fa.gz
+      - chr19.fa.gz
+      - chrM.fa.gz
+      - chrX.fa.gz
+      - chrY.fa.gz
+    type: reference
+  - features:
+      - kgID
+      - mRNA
+      - spID
+      - spDisplayID
+      - refseq
+      - protAcc
+      - description
+      - rfamAcc
+      - name
+      - name2
+    name: refSeq
+    sql_statement:
+      SELECT * FROM mm10.refGene LEFT JOIN mm10.kgXref ON mm10.kgXref.refseq
+      = mm10.refGene.name
+    type: gene
+    version: 1
+  - name: phastCons
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm10/phastCons60way/mm10.60way.phastCons/
+    remote_files:
+      - chr1.phastCons60way.wigFix.gz
+      - chr2.phastCons60way.wigFix.gz
+      - chr3.phastCons60way.wigFix.gz
+      - chr4.phastCons60way.wigFix.gz
+      - chr5.phastCons60way.wigFix.gz
+      - chr6.phastCons60way.wigFix.gz
+      - chr7.phastCons60way.wigFix.gz
+      - chr8.phastCons60way.wigFix.gz
+      - chr9.phastCons60way.wigFix.gz
+      - chr10.phastCons60way.wigFix.gz
+      - chr11.phastCons60way.wigFix.gz
+      - chr12.phastCons60way.wigFix.gz
+      - chr13.phastCons60way.wigFix.gz
+      - chr14.phastCons60way.wigFix.gz
+      - chr15.phastCons60way.wigFix.gz
+      - chr16.phastCons60way.wigFix.gz
+      - chr17.phastCons60way.wigFix.gz
+      - chr18.phastCons60way.wigFix.gz
+      - chr19.phastCons60way.wigFix.gz
+      - chrX.phastCons60way.wigFix.gz
+      - chrY.phastCons60way.wigFix.gz
+      - chrM.phastCons60way.wigFix.gz
+    type: score
+  - name: phyloP
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm10/phyloP60way/mm10.60way.phyloP60way/
+    remote_files:
+      - chr1.phyloP60way.wigFix.gz
+      - chr2.phyloP60way.wigFix.gz
+      - chr3.phyloP60way.wigFix.gz
+      - chr4.phyloP60way.wigFix.gz
+      - chr5.phyloP60way.wigFix.gz
+      - chr6.phyloP60way.wigFix.gz
+      - chr7.phyloP60way.wigFix.gz
+      - chr8.phyloP60way.wigFix.gz
+      - chr9.phyloP60way.wigFix.gz
+      - chr10.phyloP60way.wigFix.gz
+      - chr11.phyloP60way.wigFix.gz
+      - chr12.phyloP60way.wigFix.gz
+      - chr13.phyloP60way.wigFix.gz
+      - chr14.phyloP60way.wigFix.gz
+      - chr15.phyloP60way.wigFix.gz
+      - chr16.phyloP60way.wigFix.gz
+      - chr17.phyloP60way.wigFix.gz
+      - chr18.phyloP60way.wigFix.gz
+      - chr19.phyloP60way.wigFix.gz
+      - chrX.phyloP60way.wigFix.gz
+      - chrY.phyloP60way.wigFix.gz
+      - chrM.phyloP60way.wigFix.gz
+    type: score
+  - build_field_transformations:
+      alleleFreqs: split [,]
+      alleleNs: split [,]
+      alleles: split [,]
+      func: split [,]
+      observed: split [\/]
+    features:
+      - name
+      - strand
+      - observed
+      - class
+      - func
+      - alleles
+      - alleleNs: number
+      - alleleFreqs: number
+    name: dbSNP
+    sql_statement: SELECT * FROM mm10.snp142
+    type: sparse

--- a/config/mm9.clean.yml
+++ b/config/mm9.clean.yml
@@ -1,30 +1,30 @@
 ---
 assembly: mm9
 chromosomes:
-- chr1
-- chr2
-- chr3
-- chr4
-- chr5
-- chr6
-- chr7
-- chr8
-- chr9
-- chr10
-- chr11
-- chr12
-- chr13
-- chr14
-- chr15
-- chr16
-- chr17
-- chr18
-- chr19
-- chrM
-- chrX
-- chrY
-database_dir: '~'
-files: '~'
+  - chr1
+  - chr2
+  - chr3
+  - chr4
+  - chr5
+  - chr6
+  - chr7
+  - chr8
+  - chr9
+  - chr10
+  - chr11
+  - chr12
+  - chr13
+  - chr14
+  - chr15
+  - chr16
+  - chr17
+  - chr18
+  - chr19
+  - chrM
+  - chrX
+  - chrY
+database_dir: "~"
+files: "~"
 files_dir: ~
 statistics:
   dbSNPnameField: dbSNP.name
@@ -36,119 +36,119 @@ statistics:
   refTrackField: ref
   siteTypeField: refSeq.siteType
   programPath: bystro-stats
-temp_dir: '~'
+temp_dir: "~"
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --keepId --keepPos
+    args: --emptyField NA --keepId --keepPos
     program: bystro-vcf
 tracks:
-- name: ref
-  remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/mm9/chromosomes/
-  remote_files:
-  - chr1.fa.gz
-  - chr2.fa.gz
-  - chr3.fa.gz
-  - chr4.fa.gz
-  - chr5.fa.gz
-  - chr6.fa.gz
-  - chr7.fa.gz
-  - chr8.fa.gz
-  - chr9.fa.gz
-  - chr10.fa.gz
-  - chr11.fa.gz
-  - chr12.fa.gz
-  - chr13.fa.gz
-  - chr14.fa.gz
-  - chr15.fa.gz
-  - chr16.fa.gz
-  - chr17.fa.gz
-  - chr18.fa.gz
-  - chr19.fa.gz
-  - chrM.fa.gz
-  - chrX.fa.gz
-  - chrY.fa.gz
-  type: reference
-- features:
-  - kgID
-  - mRNA
-  - spID
-  - spDisplayID
-  - refseq
-  - protAcc
-  - description
-  - name
-  - name2
-  name: refSeq
-  sql_statement: SELECT * FROM mm9.refGene LEFT JOIN mm9.kgXref ON mm9.kgXref.refseq
-    = mm9.refGene.name
-  type: gene
-- name: phastCons
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm9/phastCons30way/vertebrate/
-  remote_files:
-  - chr1.data.gz
-  - chr2.data.gz
-  - chr3.data.gz
-  - chr4.data.gz
-  - chr5.data.gz
-  - chr6.data.gz
-  - chr7.data.gz
-  - chr8.data.gz
-  - chr9.data.gz
-  - chr10.data.gz
-  - chr11.data.gz
-  - chr12.data.gz
-  - chr13.data.gz
-  - chr14.data.gz
-  - chr15.data.gz
-  - chr16.data.gz
-  - chr17.data.gz
-  - chr18.data.gz
-  - chr19.data.gz
-  - chrX.data.gz
-  - chrY.data.gz
-  - chrM.data.gz
-  type: score
-- name: phyloP
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm9/phyloP30way/vertebrate/
-  remote_files:
-  - chr1.phyloP30way.wigFix.gz
-  - chr2.phyloP30way.wigFix.gz
-  - chr3.phyloP30way.wigFix.gz
-  - chr4.phyloP30way.wigFix.gz
-  - chr5.phyloP30way.wigFix.gz
-  - chr6.phyloP30way.wigFix.gz
-  - chr7.phyloP30way.wigFix.gz
-  - chr8.phyloP30way.wigFix.gz
-  - chr9.phyloP30way.wigFix.gz
-  - chr10.phyloP30way.wigFix.gz
-  - chr11.phyloP30way.wigFix.gz
-  - chr12.phyloP30way.wigFix.gz
-  - chr13.phyloP30way.wigFix.gz
-  - chr14.phyloP30way.wigFix.gz
-  - chr15.phyloP30way.wigFix.gz
-  - chr16.phyloP30way.wigFix.gz
-  - chr17.phyloP30way.wigFix.gz
-  - chr18.phyloP30way.wigFix.gz
-  - chr19.phyloP30way.wigFix.gz
-  - chrX.phyloP30way.wigFix.gz
-  - chrY.phyloP30way.wigFix.gz
-  - chrM.phyloP30way.wigFix.gz
-  type: score
-- build_field_transformations:
-    func: split [,]
-    observed: split [\/]
-  features:
-  - name
-  - strand
-  - observed
-  - class
-  - func
-  - avHet: number
-  - avHetSE: number
-  name: dbSNP
-  sql_statement: SELECT * FROM mm9.snp128
-  type: sparse
-
+  - name: ref
+    remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/mm9/chromosomes/
+    remote_files:
+      - chr1.fa.gz
+      - chr2.fa.gz
+      - chr3.fa.gz
+      - chr4.fa.gz
+      - chr5.fa.gz
+      - chr6.fa.gz
+      - chr7.fa.gz
+      - chr8.fa.gz
+      - chr9.fa.gz
+      - chr10.fa.gz
+      - chr11.fa.gz
+      - chr12.fa.gz
+      - chr13.fa.gz
+      - chr14.fa.gz
+      - chr15.fa.gz
+      - chr16.fa.gz
+      - chr17.fa.gz
+      - chr18.fa.gz
+      - chr19.fa.gz
+      - chrM.fa.gz
+      - chrX.fa.gz
+      - chrY.fa.gz
+    type: reference
+  - features:
+      - kgID
+      - mRNA
+      - spID
+      - spDisplayID
+      - refseq
+      - protAcc
+      - description
+      - name
+      - name2
+    name: refSeq
+    sql_statement:
+      SELECT * FROM mm9.refGene LEFT JOIN mm9.kgXref ON mm9.kgXref.refseq
+      = mm9.refGene.name
+    type: gene
+  - name: phastCons
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm9/phastCons30way/vertebrate/
+    remote_files:
+      - chr1.data.gz
+      - chr2.data.gz
+      - chr3.data.gz
+      - chr4.data.gz
+      - chr5.data.gz
+      - chr6.data.gz
+      - chr7.data.gz
+      - chr8.data.gz
+      - chr9.data.gz
+      - chr10.data.gz
+      - chr11.data.gz
+      - chr12.data.gz
+      - chr13.data.gz
+      - chr14.data.gz
+      - chr15.data.gz
+      - chr16.data.gz
+      - chr17.data.gz
+      - chr18.data.gz
+      - chr19.data.gz
+      - chrX.data.gz
+      - chrY.data.gz
+      - chrM.data.gz
+    type: score
+  - name: phyloP
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/mm9/phyloP30way/vertebrate/
+    remote_files:
+      - chr1.phyloP30way.wigFix.gz
+      - chr2.phyloP30way.wigFix.gz
+      - chr3.phyloP30way.wigFix.gz
+      - chr4.phyloP30way.wigFix.gz
+      - chr5.phyloP30way.wigFix.gz
+      - chr6.phyloP30way.wigFix.gz
+      - chr7.phyloP30way.wigFix.gz
+      - chr8.phyloP30way.wigFix.gz
+      - chr9.phyloP30way.wigFix.gz
+      - chr10.phyloP30way.wigFix.gz
+      - chr11.phyloP30way.wigFix.gz
+      - chr12.phyloP30way.wigFix.gz
+      - chr13.phyloP30way.wigFix.gz
+      - chr14.phyloP30way.wigFix.gz
+      - chr15.phyloP30way.wigFix.gz
+      - chr16.phyloP30way.wigFix.gz
+      - chr17.phyloP30way.wigFix.gz
+      - chr18.phyloP30way.wigFix.gz
+      - chr19.phyloP30way.wigFix.gz
+      - chrX.phyloP30way.wigFix.gz
+      - chrY.phyloP30way.wigFix.gz
+      - chrM.phyloP30way.wigFix.gz
+    type: score
+  - build_field_transformations:
+      func: split [,]
+      observed: split [\/]
+    features:
+      - name
+      - strand
+      - observed
+      - class
+      - func
+      - avHet: number
+      - avHetSE: number
+    name: dbSNP
+    sql_statement: SELECT * FROM mm9.snp128
+    type: sparse

--- a/config/rheMac8.clean.yml
+++ b/config/rheMac8.clean.yml
@@ -29,10 +29,10 @@ files: '~'
 files_dir: ~
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --keepId --keepPos
+    args: --emptyField NA --keepId --keepPos
     program: bystro-vcf
 statistics:
   exonicAlleleFunctionField: refSeq.exonicAlleleFunction
@@ -46,10 +46,10 @@ statistics:
 temp_dir: '~'
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --keepId --keepPos
+    args: --emptyField NA --keepId --keepPos
     program: bystro-vcf
 tracks:
 - name: ref

--- a/config/rn6.clean.yml
+++ b/config/rn6.clean.yml
@@ -38,34 +38,34 @@ statistics:
 temp_dir: "~"
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --keepId --keepPos
+    args: --emptyField NA --keepId --keepPos
     program: bystro-vcf
 tracks:
-- name: ref
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/rn6/bigZips/
-  remote_files:
-  - rn6.fa.gz
-  type: reference
-- features:
-  - name
-  - name2
-  name: refSeq
-  sql_statement: SELECT * FROM rn6.refGene
-  type: gene
-- local_files:
-  - rn6.phastCons20way.wigFix.gz
-  name: phastCons
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/rn6/phastCons20way/
-  remote_files:
-  - rn6.phastCons20way.wigFix.gz
-  type: score
-- local_files:
-  - rn6.phyloP20way.wigFix.gz
-  name: phyloP
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/rn6/phyloP20way/
-  remote_files:
-  - rn6.phyloP20way.wigFix.gz
-  type: score
+  - name: ref
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/rn6/bigZips/
+    remote_files:
+      - rn6.fa.gz
+    type: reference
+  - features:
+      - name
+      - name2
+    name: refSeq
+    sql_statement: SELECT * FROM rn6.refGene
+    type: gene
+  - local_files:
+      - rn6.phastCons20way.wigFix.gz
+    name: phastCons
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/rn6/phastCons20way/
+    remote_files:
+      - rn6.phastCons20way.wigFix.gz
+    type: score
+  - local_files:
+      - rn6.phyloP20way.wigFix.gz
+    name: phyloP
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/rn6/phyloP20way/
+    remote_files:
+      - rn6.phyloP20way.wigFix.gz
+    type: score

--- a/config/sacCer3.clean.yml
+++ b/config/sacCer3.clean.yml
@@ -33,61 +33,61 @@ statistics:
 temp_dir: "~"
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --keepId --keepPos
+    args: --emptyField NA --keepId --keepPos
     program: bystro-vcf
 tracks:
-- name: ref
-  remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/sacCer3/chromosomes/
-  remote_files:
-  - chrI.fa.gz
-  - chrII.fa.gz
-  - chrIII.fa.gz
-  - chrIV.fa.gz
-  - chrIX.fa.gz
-  - chrM.fa.gz
-  - chrV.fa.gz
-  - chrVI.fa.gz
-  - chrVII.fa.gz
-  - chrVIII.fa.gz
-  - chrX.fa.gz
-  - chrXI.fa.gz
-  - chrXII.fa.gz
-  - chrXIII.fa.gz
-  - chrXIV.fa.gz
-  - chrXV.fa.gz
-  - chrXVI.fa.gz
-  type: reference
-- features:
-  - name
-  - type
-  - description
-  - proteinID
-  name: sgd
-  sql_statement: SELECT sgdGene.name,chrom,strand,txStart,txEnd,cdsStart,cdsEnd,exonCount,exonStarts,exonEnds,proteinID,type,description
-    FROM sacCer3.sgdGene LEFT JOIN sgdDescription ON sgdGene.name = sgdDescription.name
-  type: gene
-- name: phastCons
-  remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/sacCer3/phastCons7way/
-  remote_files:
-  - sacCer3.chrI.wigFixed.gz
-  - sacCer3.chrII.wigFixed.gz
-  - sacCer3.chrIII.wigFixed.gz
-  - sacCer3.chrIV.wigFixed.gz
-  - sacCer3.chrIX.wigFixed.gz
-  - sacCer3.chrM.wigFixed.gz
-  - sacCer3.chrV.wigFixed.gz
-  - sacCer3.chrVI.wigFixed.gz
-  - sacCer3.chrVII.wigFixed.gz
-  - sacCer3.chrVIII.wigFixed.gz
-  - sacCer3.chrX.wigFixed.gz
-  - sacCer3.chrXI.wigFixed.gz
-  - sacCer3.chrXII.wigFixed.gz
-  - sacCer3.chrXIII.wigFixed.gz
-  - sacCer3.chrXIV.wigFixed.gz
-  - sacCer3.chrXV.wigFixed.gz
-  - sacCer3.chrXVI.wigFixed.gz
-  type: score
-
+  - name: ref
+    remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/sacCer3/chromosomes/
+    remote_files:
+      - chrI.fa.gz
+      - chrII.fa.gz
+      - chrIII.fa.gz
+      - chrIV.fa.gz
+      - chrIX.fa.gz
+      - chrM.fa.gz
+      - chrV.fa.gz
+      - chrVI.fa.gz
+      - chrVII.fa.gz
+      - chrVIII.fa.gz
+      - chrX.fa.gz
+      - chrXI.fa.gz
+      - chrXII.fa.gz
+      - chrXIII.fa.gz
+      - chrXIV.fa.gz
+      - chrXV.fa.gz
+      - chrXVI.fa.gz
+    type: reference
+  - features:
+      - name
+      - type
+      - description
+      - proteinID
+    name: sgd
+    sql_statement:
+      SELECT sgdGene.name,chrom,strand,txStart,txEnd,cdsStart,cdsEnd,exonCount,exonStarts,exonEnds,proteinID,type,description
+      FROM sacCer3.sgdGene LEFT JOIN sgdDescription ON sgdGene.name = sgdDescription.name
+    type: gene
+  - name: phastCons
+    remote_dir: http://hgdownload.cse.ucsc.edu/goldenPath/sacCer3/phastCons7way/
+    remote_files:
+      - sacCer3.chrI.wigFixed.gz
+      - sacCer3.chrII.wigFixed.gz
+      - sacCer3.chrIII.wigFixed.gz
+      - sacCer3.chrIV.wigFixed.gz
+      - sacCer3.chrIX.wigFixed.gz
+      - sacCer3.chrM.wigFixed.gz
+      - sacCer3.chrV.wigFixed.gz
+      - sacCer3.chrVI.wigFixed.gz
+      - sacCer3.chrVII.wigFixed.gz
+      - sacCer3.chrVIII.wigFixed.gz
+      - sacCer3.chrX.wigFixed.gz
+      - sacCer3.chrXI.wigFixed.gz
+      - sacCer3.chrXII.wigFixed.gz
+      - sacCer3.chrXIII.wigFixed.gz
+      - sacCer3.chrXIV.wigFixed.gz
+      - sacCer3.chrXV.wigFixed.gz
+      - sacCer3.chrXVI.wigFixed.gz
+    type: score

--- a/perl/lib/Seq/Output/Delimiters.pm
+++ b/perl/lib/Seq/Output/Delimiters.pm
@@ -28,7 +28,7 @@ has overlapDelimiter => ( is => 'ro', isa => 'Str', default => chr(31) );
 
 has fieldSeparator => ( is => 'ro', isa => 'Str', default => "\t" );
 
-has emptyFieldChar => ( is => 'ro', isa => 'Str', default => '!' );
+has emptyFieldChar => ( is => 'ro', isa => 'Str', default => "NA" );
 
 # What to replace the flagged characters with if found in a string
 has globalReplaceChar => ( is => 'ro', isa => 'Str', default => ',' );

--- a/perl/t/tracks/vcf/clinvar.yml
+++ b/perl/t/tracks/vcf/clinvar.yml
@@ -3,10 +3,10 @@ build_author: ec2-user
 build_date: 2017-08-08T03:49:00
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField !
+    args: --emptyField NA
     program: bystro-vcf
 chromosomes:
   - chr1

--- a/perl/t/tracks/vcf/test.hg38.chr22.yml
+++ b/perl/t/tracks/vcf/test.hg38.chr22.yml
@@ -4,13 +4,13 @@ build_author: ec2-user
 build_date: 2017-08-08T03:49:00
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField !
+    args: --emptyField NA
     program: bystro-vcf
 chromosomes:
-- chr22
+  - chr22
 database_dir: t/tracks/vcf/index/
 files_dir: t/tracks/vcf/raw/
 statistics:
@@ -23,79 +23,79 @@ statistics:
   programPath: bystro-stats
   refTrackField: ref
   siteTypeField: refSeq.siteType
-temp_dir: '~'
+temp_dir: "~"
 tracks:
   tracks:
-  - name: ref
-    type: reference
-  - features:
-    - alt
-    - id
-    - trTv: number
-    - ac: number
-    - af: number
-    - an: number
-    - ac_afr: number
-    - ac_amr: number
-    - ac_asj: number
-    - ac_eas: number
-    - ac_fin: number
-    - ac_nfe: number
-    - ac_oth: number
-    - ac_male: number
-    - ac_female: number
-    - an_afr: number
-    - an_amr: number
-    - an_asj: number
-    - an_eas: number
-    - an_fin: number
-    - an_nfe: number
-    - an_oth: number
-    - an_male: number
-    - an_female: number
-    - af_afr: number
-    - af_amr: number
-    - af_asj: number
-    - af_eas: number
-    - af_fin: number
-    - af_nfe: number
-    - af_oth: number
-    - af_male: number
-    - af_female: number
-    build_row_filters:
-      AS_FilterStatus: == PASS
-    fieldMap:
-      AC: ac
-      AF: af
-      AN: an
-      AC_AFR: ac_afr
-      AC_AMR: ac_amr
-      AC_ASJ: ac_asj
-      AC_EAS: ac_eas
-      AC_FIN: ac_fin
-      AC_NFE: ac_nfe
-      AC_OTH: ac_oth
-      AC_Male: ac_male
-      AC_Female: ac_female
-      AN_AFR: an_afr
-      AN_AMR: an_amr
-      AN_ASJ: an_asj
-      AN_EAS: an_eas
-      AN_FIN: an_fin
-      AN_NFE: an_nfe
-      AN_OTH: an_oth
-      AN_Male: an_male
-      AN_Female: an_female
-      AF_AFR: af_afr
-      AF_AMR: af_amr
-      AF_ASJ: af_asj
-      AF_EAS: af_eas
-      AF_FIN: af_fin
-      AF_NFE: af_nfe
-      AF_OTH: af_oth
-      AF_Male: af_male
-      AF_Female: af_female
-    local_files:
-    - test.vcf
-    name: gnomad.genomes
-    type: vcf
+    - name: ref
+      type: reference
+    - features:
+        - alt
+        - id
+        - trTv: number
+        - ac: number
+        - af: number
+        - an: number
+        - ac_afr: number
+        - ac_amr: number
+        - ac_asj: number
+        - ac_eas: number
+        - ac_fin: number
+        - ac_nfe: number
+        - ac_oth: number
+        - ac_male: number
+        - ac_female: number
+        - an_afr: number
+        - an_amr: number
+        - an_asj: number
+        - an_eas: number
+        - an_fin: number
+        - an_nfe: number
+        - an_oth: number
+        - an_male: number
+        - an_female: number
+        - af_afr: number
+        - af_amr: number
+        - af_asj: number
+        - af_eas: number
+        - af_fin: number
+        - af_nfe: number
+        - af_oth: number
+        - af_male: number
+        - af_female: number
+      build_row_filters:
+        AS_FilterStatus: == PASS
+      fieldMap:
+        AC: ac
+        AF: af
+        AN: an
+        AC_AFR: ac_afr
+        AC_AMR: ac_amr
+        AC_ASJ: ac_asj
+        AC_EAS: ac_eas
+        AC_FIN: ac_fin
+        AC_NFE: ac_nfe
+        AC_OTH: ac_oth
+        AC_Male: ac_male
+        AC_Female: ac_female
+        AN_AFR: an_afr
+        AN_AMR: an_amr
+        AN_ASJ: an_asj
+        AN_EAS: an_eas
+        AN_FIN: an_fin
+        AN_NFE: an_nfe
+        AN_OTH: an_oth
+        AN_Male: an_male
+        AN_Female: an_female
+        AF_AFR: af_afr
+        AF_AMR: af_amr
+        AF_ASJ: af_asj
+        AF_EAS: af_eas
+        AF_FIN: af_fin
+        AF_NFE: af_nfe
+        AF_OTH: af_oth
+        AF_Male: af_male
+        AF_Female: af_female
+      local_files:
+        - test.vcf
+      name: gnomad.genomes
+      type: vcf

--- a/perl/t/tracks/vcf/test.scrambled_multiple_files.yml
+++ b/perl/t/tracks/vcf/test.scrambled_multiple_files.yml
@@ -4,13 +4,13 @@ build_author: ec2-user
 build_date: 2017-08-08T03:49:00
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField !
+    args: --emptyField NA
     program: bystro-vcf
 chromosomes:
-- chr22
+  - chr22
 database_dir: t/tracks/vcf/index/
 files_dir: t/tracks/vcf/raw/
 statistics:
@@ -23,79 +23,79 @@ statistics:
   programPath: bystro-stats
   refTrackField: ref
   siteTypeField: refSeq.siteType
-temp_dir: '~'
+temp_dir: "~"
 tracks:
   tracks:
-  - name: ref
-    type: reference
-  - features:
-    - alt
-    - id
-    - trTv: number
-    - ac: number
-    - af: number
-    - an: number
-    - ac_afr: number
-    - ac_amr: number
-    - ac_asj: number
-    - ac_eas: number
-    - ac_fin: number
-    - ac_nfe: number
-    - ac_oth: number
-    - ac_male: number
-    - ac_female: number
-    - an_afr: number
-    - an_amr: number
-    - an_asj: number
-    - an_eas: number
-    - an_fin: number
-    - an_nfe: number
-    - an_oth: number
-    - an_male: number
-    - an_female: number
-    - af_afr: number
-    - af_amr: number
-    - af_asj: number
-    - af_eas: number
-    - af_fin: number
-    - af_nfe: number
-    - af_oth: number
-    - af_male: number
-    - af_female: number
-    build_row_filters:
-      AS_FilterStatus: == PASS
-    fieldMap:
-      AC: ac
-      AF: af
-      AN: an
-      AC_AFR: ac_afr
-      AC_AMR: ac_amr
-      AC_ASJ: ac_asj
-      AC_EAS: ac_eas
-      AC_FIN: ac_fin
-      AC_NFE: ac_nfe
-      AC_OTH: ac_oth
-      AC_Male: ac_male
-      AC_Female: ac_female
-      AN_AFR: an_afr
-      AN_AMR: an_amr
-      AN_ASJ: an_asj
-      AN_EAS: an_eas
-      AN_FIN: an_fin
-      AN_NFE: an_nfe
-      AN_OTH: an_oth
-      AN_Male: an_male
-      AN_Female: an_female
-      AF_AFR: af_afr
-      AF_AMR: af_amr
-      AF_ASJ: af_asj
-      AF_EAS: af_eas
-      AF_FIN: af_fin
-      AF_NFE: af_nfe
-      AF_OTH: af_oth
-      AF_Male: af_male
-      AF_Female: af_female
-    local_files:
-    - test_split_part*.vcf*
-    name: gnomad.genomes.scrambled
-    type: vcf
+    - name: ref
+      type: reference
+    - features:
+        - alt
+        - id
+        - trTv: number
+        - ac: number
+        - af: number
+        - an: number
+        - ac_afr: number
+        - ac_amr: number
+        - ac_asj: number
+        - ac_eas: number
+        - ac_fin: number
+        - ac_nfe: number
+        - ac_oth: number
+        - ac_male: number
+        - ac_female: number
+        - an_afr: number
+        - an_amr: number
+        - an_asj: number
+        - an_eas: number
+        - an_fin: number
+        - an_nfe: number
+        - an_oth: number
+        - an_male: number
+        - an_female: number
+        - af_afr: number
+        - af_amr: number
+        - af_asj: number
+        - af_eas: number
+        - af_fin: number
+        - af_nfe: number
+        - af_oth: number
+        - af_male: number
+        - af_female: number
+      build_row_filters:
+        AS_FilterStatus: == PASS
+      fieldMap:
+        AC: ac
+        AF: af
+        AN: an
+        AC_AFR: ac_afr
+        AC_AMR: ac_amr
+        AC_ASJ: ac_asj
+        AC_EAS: ac_eas
+        AC_FIN: ac_fin
+        AC_NFE: ac_nfe
+        AC_OTH: ac_oth
+        AC_Male: ac_male
+        AC_Female: ac_female
+        AN_AFR: an_afr
+        AN_AMR: an_amr
+        AN_ASJ: an_asj
+        AN_EAS: an_eas
+        AN_FIN: an_fin
+        AN_NFE: an_nfe
+        AN_OTH: an_oth
+        AN_Male: an_male
+        AN_Female: an_female
+        AF_AFR: af_afr
+        AF_AMR: af_amr
+        AF_ASJ: af_asj
+        AF_EAS: af_eas
+        AF_FIN: af_fin
+        AF_NFE: af_nfe
+        AF_OTH: af_oth
+        AF_Male: af_male
+        AF_Female: af_female
+      local_files:
+        - test_split_part*.vcf*
+      name: gnomad.genomes.scrambled
+      type: vcf

--- a/python/python/bystro/search/index/t/hg19.yml
+++ b/python/python/bystro/search/index/t/hg19.yml
@@ -3,39 +3,39 @@ assembly: hg19
 build_author: ec2-user
 build_date: 2018-02-26T22:21:00
 chromosomes:
-- chr1
-- chr2
-- chr3
-- chr4
-- chr5
-- chr6
-- chr7
-- chr8
-- chr9
-- chr10
-- chr11
-- chr12
-- chr13
-- chr14
-- chr15
-- chr16
-- chr17
-- chr18
-- chr19
-- chr20
-- chr21
-- chr22
-- chrM
-- chrX
-- chrY
+  - chr1
+  - chr2
+  - chr3
+  - chr4
+  - chr5
+  - chr6
+  - chr7
+  - chr8
+  - chr9
+  - chr10
+  - chr11
+  - chr12
+  - chr13
+  - chr14
+  - chr15
+  - chr16
+  - chr17
+  - chr18
+  - chr19
+  - chr20
+  - chr21
+  - chr22
+  - chrM
+  - chrX
+  - chrY
 database_dir: ~
 files_dir: ~
 fileProcessors:
   snp:
-    args: --emptyField ! --minGq .95
+    args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField ! --sample %sampleList% --keepPos --keepId
+    args: --emptyField NA --sample %sampleList% --keepPos --keepId
     program: bystro-vcf
 statistics:
   dbSNPnameField: dbSNP.name
@@ -49,361 +49,362 @@ statistics:
   siteTypeField: refSeq.siteType
 temp_dir: /mnt/annotator/tmp
 tracks:
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  fetch_date: 2017-02-04T22:36:00
-  local_files:
-  - chr*.fa.gz
-  name: ref
-  remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/chromosomes/
-  remote_files:
-  - chr1.fa.gz
-  - chr2.fa.gz
-  - chr3.fa.gz
-  - chr4.fa.gz
-  - chr5.fa.gz
-  - chr6.fa.gz
-  - chr7.fa.gz
-  - chr8.fa.gz
-  - chr9.fa.gz
-  - chr10.fa.gz
-  - chr11.fa.gz
-  - chr12.fa.gz
-  - chr13.fa.gz
-  - chr14.fa.gz
-  - chr15.fa.gz
-  - chr16.fa.gz
-  - chr17.fa.gz
-  - chr18.fa.gz
-  - chr19.fa.gz
-  - chr20.fa.gz
-  - chr21.fa.gz
-  - chr22.fa.gz
-  - chrM.fa.gz
-  - chrX.fa.gz
-  - chrY.fa.gz
-  type: reference
-  version: 7
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  features:
-  - kgID
-  - mRNA
-  - spID
-  - spDisplayID
-  - protAcc
-  - description
-  - rfamAcc
-  - name
-  - name2
-  fetch_date: 2018-02-26T22:17:00
-  join:
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    fetch_date: 2017-02-04T22:36:00
+    local_files:
+      - chr*.fa.gz
+    name: ref
+    remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/chromosomes/
+    remote_files:
+      - chr1.fa.gz
+      - chr2.fa.gz
+      - chr3.fa.gz
+      - chr4.fa.gz
+      - chr5.fa.gz
+      - chr6.fa.gz
+      - chr7.fa.gz
+      - chr8.fa.gz
+      - chr9.fa.gz
+      - chr10.fa.gz
+      - chr11.fa.gz
+      - chr12.fa.gz
+      - chr13.fa.gz
+      - chr14.fa.gz
+      - chr15.fa.gz
+      - chr16.fa.gz
+      - chr17.fa.gz
+      - chr18.fa.gz
+      - chr19.fa.gz
+      - chr20.fa.gz
+      - chr21.fa.gz
+      - chr22.fa.gz
+      - chrM.fa.gz
+      - chrX.fa.gz
+      - chrY.fa.gz
+    type: reference
+    version: 7
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
     features:
-    - alleleID
-    - phenotypeList
-    - clinicalSignificance
-    - type
-    - origin
-    - numberSubmitters
-    - reviewStatus
-    - chromStart
-    - chromEnd
-    track: clinvar
-  local_files:
-  - hg19.refGene.chr1.gz
-  - hg19.refGene.chr2.gz
-  - hg19.refGene.chr3.gz
-  - hg19.refGene.chr4.gz
-  - hg19.refGene.chr5.gz
-  - hg19.refGene.chr6.gz
-  - hg19.refGene.chr7.gz
-  - hg19.refGene.chr8.gz
-  - hg19.refGene.chr9.gz
-  - hg19.refGene.chr10.gz
-  - hg19.refGene.chr11.gz
-  - hg19.refGene.chr12.gz
-  - hg19.refGene.chr13.gz
-  - hg19.refGene.chr14.gz
-  - hg19.refGene.chr15.gz
-  - hg19.refGene.chr16.gz
-  - hg19.refGene.chr17.gz
-  - hg19.refGene.chr18.gz
-  - hg19.refGene.chr19.gz
-  - hg19.refGene.chr20.gz
-  - hg19.refGene.chr21.gz
-  - hg19.refGene.chr22.gz
-  - hg19.refGene.chrM.gz
-  - hg19.refGene.chrX.gz
-  - hg19.refGene.chrY.gz
-  name: refSeq
-  nearest:
-  - name
-  - name2
-  sql_statement: SELECT * FROM hg19.refGene LEFT JOIN hg19.kgXref ON hg19.kgXref.refseq
-    = hg19.refGene.name
-  type: gene
-  version: 7
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  fetch_date: 2017-02-04T16:52:00
-  local_files:
-  - chr*.phastCons100way.wigFix.gz
-  name: phastCons
-  remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phastCons100way/hg19.100way.phastCons/
-  remote_files:
-  - chr1.phastCons100way.wigFix.gz
-  - chr2.phastCons100way.wigFix.gz
-  - chr3.phastCons100way.wigFix.gz
-  - chr4.phastCons100way.wigFix.gz
-  - chr5.phastCons100way.wigFix.gz
-  - chr6.phastCons100way.wigFix.gz
-  - chr7.phastCons100way.wigFix.gz
-  - chr8.phastCons100way.wigFix.gz
-  - chr9.phastCons100way.wigFix.gz
-  - chr10.phastCons100way.wigFix.gz
-  - chr11.phastCons100way.wigFix.gz
-  - chr12.phastCons100way.wigFix.gz
-  - chr13.phastCons100way.wigFix.gz
-  - chr14.phastCons100way.wigFix.gz
-  - chr15.phastCons100way.wigFix.gz
-  - chr16.phastCons100way.wigFix.gz
-  - chr17.phastCons100way.wigFix.gz
-  - chr18.phastCons100way.wigFix.gz
-  - chr19.phastCons100way.wigFix.gz
-  - chr20.phastCons100way.wigFix.gz
-  - chr21.phastCons100way.wigFix.gz
-  - chr22.phastCons100way.wigFix.gz
-  - chrX.phastCons100way.wigFix.gz
-  - chrY.phastCons100way.wigFix.gz
-  - chrM.phastCons100way.wigFix.gz
-  type: score
-  version: 7
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  fetch_date: 2017-02-03T20:57:00
-  local_files:
-  - chr*.phyloP100way.wigFix.gz
-  name: phyloP
-  remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phyloP100way/hg19.100way.phyloP100way/
-  remote_files:
-  - chr1.phyloP100way.wigFix.gz
-  - chr2.phyloP100way.wigFix.gz
-  - chr3.phyloP100way.wigFix.gz
-  - chr4.phyloP100way.wigFix.gz
-  - chr5.phyloP100way.wigFix.gz
-  - chr6.phyloP100way.wigFix.gz
-  - chr7.phyloP100way.wigFix.gz
-  - chr8.phyloP100way.wigFix.gz
-  - chr9.phyloP100way.wigFix.gz
-  - chr10.phyloP100way.wigFix.gz
-  - chr11.phyloP100way.wigFix.gz
-  - chr12.phyloP100way.wigFix.gz
-  - chr13.phyloP100way.wigFix.gz
-  - chr14.phyloP100way.wigFix.gz
-  - chr15.phyloP100way.wigFix.gz
-  - chr16.phyloP100way.wigFix.gz
-  - chr17.phyloP100way.wigFix.gz
-  - chr18.phyloP100way.wigFix.gz
-  - chr19.phyloP100way.wigFix.gz
-  - chr20.phyloP100way.wigFix.gz
-  - chr21.phyloP100way.wigFix.gz
-  - chr22.phyloP100way.wigFix.gz
-  - chrX.phyloP100way.wigFix.gz
-  - chrY.phyloP100way.wigFix.gz
-  - chrM.phyloP100way.wigFix.gz
-  type: score
-  version: 7
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  caddToBed_date: 2017-04-22T06:41:00
-  liftOverCadd_date: 2017-07-28T17:35:00
-  local_files:
-  - whole_genome_SNVs.tsv.bed.chr*.organized-by-chr.txt.sorted.txt.gz
-  - whole_genome_SNVs.tsv.bed.chrM.organized-by-chr.txt.sorted.txt.mapped.gz
-  name: cadd
-  sortCadd_date: 2017-04-23T15:44:00
-  sort_date: 2017-01-20T16:06:00
-  sorted_guaranteed: 1
-  type: cadd
-  version: 7
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  build_field_transformations:
-    alleleFreqs: split [,]
-    alleleNs: split [,]
-    alleles: split [,]
-    func: split [,]
-    observed: split [\/]
-  features:
-  - name
-  - strand
-  - observed
-  - class
-  - func
-  - alleles
-  - alleleNs: number
-  - alleleFreqs: number
-  fetch_date: 2017-02-04T21:35:00
-  local_files:
-  - hg19.snp150.chr*.gz
-  name: dbSNP
-  sql_statement: SELECT * FROM hg19.snp150
-  type: sparse
-  version: 7
-- based: 1
-  build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  build_field_transformations:
-    chrom: chr .
-    clinicalSignificance: split [;]
-    origin: split [;]
-    phenotypeList: split [;]
-    reviewStatus: split [;]
-    type: split [;]
-  build_row_filters:
-    Assembly: == GRCh37
-  features:
-  - alleleID: number
-  - phenotypeList
-  - clinicalSignificance
-  - type
-  - origin
-  - numberSubmitters: number
-  - reviewStatus
-  - referenceAllele
-  - alternateAllele
-  fetch_date: 2018-02-26T21:56:00
-  fieldMap:
-    '#AlleleID': alleleID
-    AlternateAllele: alternateAllele
-    Chromosome: chrom
-    ClinicalSignificance: clinicalSignificance
-    NumberSubmitters: numberSubmitters
-    Origin: origin
-    PhenotypeIDS: phenotypeIDs
-    PhenotypeList: phenotypeList
-    ReferenceAllele: referenceAllele
-    ReviewStatus: reviewStatus
-    Start: chromStart
-    Stop: chromEnd
-    Type: type
-  local_files:
-  - variant_summary.txt.gz
-  name: clinvar
-  remote_files:
-  - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
-  type: sparse
-  version: 7
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  build_row_filters:
-    AS_FilterStatus: == PASS
-  features:
-  - alt
-  - id
-  - af: number
-  - an: number
-  - an_afr: number
-  - an_amr: number
-  - an_asj: number
-  - an_eas: number
-  - an_fin: number
-  - an_nfe: number
-  - an_oth: number
-  - an_male: number
-  - an_female: number
-  - af_afr: number
-  - af_amr: number
-  - af_asj: number
-  - af_eas: number
-  - af_fin: number
-  - af_nfe: number
-  - af_oth: number
-  - af_male: number
-  - af_female: number
-  fieldMap:
-    AF: af
-    AF_AFR: af_afr
-    AF_AMR: af_amr
-    AF_ASJ: af_asj
-    AF_EAS: af_eas
-    AF_FIN: af_fin
-    AF_Female: af_female
-    AF_Male: af_male
-    AF_NFE: af_nfe
-    AF_OTH: af_oth
-    AF_SAS: af_sas
-    AN: an
-    AN_AFR: an_afr
-    AN_AMR: an_amr
-    AN_ASJ: an_asj
-    AN_EAS: an_eas
-    AN_FIN: an_fin
-    AN_Female: an_female
-    AN_Male: an_male
-    AN_NFE: an_nfe
-    AN_OTH: an_oth
-    AN_SAS: an_sas
-  local_files:
-  - gnomad.genomes.r2.0.2.sites.chr*.vcf.bgz
-  name: gnomad.genomes
-  type: vcf
-  version: 7
-- build_author: ec2-user
-  build_date: 2018-02-26T22:21:00
-  build_row_filters:
-    AS_FilterStatus: == PASS
-  features:
-  - alt
-  - id
-  - af: number
-  - an: number
-  - an_afr: number
-  - an_amr: number
-  - an_asj: number
-  - an_eas: number
-  - an_fin: number
-  - an_nfe: number
-  - an_oth: number
-  - an_sas: number
-  - an_male: number
-  - an_female: number
-  - af_afr: number
-  - af_amr: number
-  - af_asj: number
-  - af_eas: number
-  - af_fin: number
-  - af_nfe: number
-  - af_oth: number
-  - af_sas: number
-  - af_male: number
-  - af_female: number
-  fieldMap:
-    AF: af
-    AF_AFR: af_afr
-    AF_AMR: af_amr
-    AF_ASJ: af_asj
-    AF_EAS: af_eas
-    AF_FIN: af_fin
-    AF_Female: af_female
-    AF_Male: af_male
-    AF_NFE: af_nfe
-    AF_OTH: af_oth
-    AF_SAS: af_sas
-    AN: an
-    AN_AFR: an_afr
-    AN_AMR: an_amr
-    AN_ASJ: an_asj
-    AN_EAS: an_eas
-    AN_FIN: an_fin
-    AN_Female: an_female
-    AN_Male: an_male
-    AN_NFE: an_nfe
-    AN_OTH: an_oth
-    AN_SAS: an_sas
-  local_files:
-  - gnomad.exomes.r2.0.2.sites.vcf.bgz
-  name: gnomad.exomes
-  type: vcf
-  version: 7
+      - kgID
+      - mRNA
+      - spID
+      - spDisplayID
+      - protAcc
+      - description
+      - rfamAcc
+      - name
+      - name2
+    fetch_date: 2018-02-26T22:17:00
+    join:
+      features:
+        - alleleID
+        - phenotypeList
+        - clinicalSignificance
+        - type
+        - origin
+        - numberSubmitters
+        - reviewStatus
+        - chromStart
+        - chromEnd
+      track: clinvar
+    local_files:
+      - hg19.refGene.chr1.gz
+      - hg19.refGene.chr2.gz
+      - hg19.refGene.chr3.gz
+      - hg19.refGene.chr4.gz
+      - hg19.refGene.chr5.gz
+      - hg19.refGene.chr6.gz
+      - hg19.refGene.chr7.gz
+      - hg19.refGene.chr8.gz
+      - hg19.refGene.chr9.gz
+      - hg19.refGene.chr10.gz
+      - hg19.refGene.chr11.gz
+      - hg19.refGene.chr12.gz
+      - hg19.refGene.chr13.gz
+      - hg19.refGene.chr14.gz
+      - hg19.refGene.chr15.gz
+      - hg19.refGene.chr16.gz
+      - hg19.refGene.chr17.gz
+      - hg19.refGene.chr18.gz
+      - hg19.refGene.chr19.gz
+      - hg19.refGene.chr20.gz
+      - hg19.refGene.chr21.gz
+      - hg19.refGene.chr22.gz
+      - hg19.refGene.chrM.gz
+      - hg19.refGene.chrX.gz
+      - hg19.refGene.chrY.gz
+    name: refSeq
+    nearest:
+      - name
+      - name2
+    sql_statement:
+      SELECT * FROM hg19.refGene LEFT JOIN hg19.kgXref ON hg19.kgXref.refseq
+      = hg19.refGene.name
+    type: gene
+    version: 7
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    fetch_date: 2017-02-04T16:52:00
+    local_files:
+      - chr*.phastCons100way.wigFix.gz
+    name: phastCons
+    remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phastCons100way/hg19.100way.phastCons/
+    remote_files:
+      - chr1.phastCons100way.wigFix.gz
+      - chr2.phastCons100way.wigFix.gz
+      - chr3.phastCons100way.wigFix.gz
+      - chr4.phastCons100way.wigFix.gz
+      - chr5.phastCons100way.wigFix.gz
+      - chr6.phastCons100way.wigFix.gz
+      - chr7.phastCons100way.wigFix.gz
+      - chr8.phastCons100way.wigFix.gz
+      - chr9.phastCons100way.wigFix.gz
+      - chr10.phastCons100way.wigFix.gz
+      - chr11.phastCons100way.wigFix.gz
+      - chr12.phastCons100way.wigFix.gz
+      - chr13.phastCons100way.wigFix.gz
+      - chr14.phastCons100way.wigFix.gz
+      - chr15.phastCons100way.wigFix.gz
+      - chr16.phastCons100way.wigFix.gz
+      - chr17.phastCons100way.wigFix.gz
+      - chr18.phastCons100way.wigFix.gz
+      - chr19.phastCons100way.wigFix.gz
+      - chr20.phastCons100way.wigFix.gz
+      - chr21.phastCons100way.wigFix.gz
+      - chr22.phastCons100way.wigFix.gz
+      - chrX.phastCons100way.wigFix.gz
+      - chrY.phastCons100way.wigFix.gz
+      - chrM.phastCons100way.wigFix.gz
+    type: score
+    version: 7
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    fetch_date: 2017-02-03T20:57:00
+    local_files:
+      - chr*.phyloP100way.wigFix.gz
+    name: phyloP
+    remote_dir: http://hgdownload.soe.ucsc.edu/goldenPath/hg19/phyloP100way/hg19.100way.phyloP100way/
+    remote_files:
+      - chr1.phyloP100way.wigFix.gz
+      - chr2.phyloP100way.wigFix.gz
+      - chr3.phyloP100way.wigFix.gz
+      - chr4.phyloP100way.wigFix.gz
+      - chr5.phyloP100way.wigFix.gz
+      - chr6.phyloP100way.wigFix.gz
+      - chr7.phyloP100way.wigFix.gz
+      - chr8.phyloP100way.wigFix.gz
+      - chr9.phyloP100way.wigFix.gz
+      - chr10.phyloP100way.wigFix.gz
+      - chr11.phyloP100way.wigFix.gz
+      - chr12.phyloP100way.wigFix.gz
+      - chr13.phyloP100way.wigFix.gz
+      - chr14.phyloP100way.wigFix.gz
+      - chr15.phyloP100way.wigFix.gz
+      - chr16.phyloP100way.wigFix.gz
+      - chr17.phyloP100way.wigFix.gz
+      - chr18.phyloP100way.wigFix.gz
+      - chr19.phyloP100way.wigFix.gz
+      - chr20.phyloP100way.wigFix.gz
+      - chr21.phyloP100way.wigFix.gz
+      - chr22.phyloP100way.wigFix.gz
+      - chrX.phyloP100way.wigFix.gz
+      - chrY.phyloP100way.wigFix.gz
+      - chrM.phyloP100way.wigFix.gz
+    type: score
+    version: 7
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    caddToBed_date: 2017-04-22T06:41:00
+    liftOverCadd_date: 2017-07-28T17:35:00
+    local_files:
+      - whole_genome_SNVs.tsv.bed.chr*.organized-by-chr.txt.sorted.txt.gz
+      - whole_genome_SNVs.tsv.bed.chrM.organized-by-chr.txt.sorted.txt.mapped.gz
+    name: cadd
+    sortCadd_date: 2017-04-23T15:44:00
+    sort_date: 2017-01-20T16:06:00
+    sorted_guaranteed: 1
+    type: cadd
+    version: 7
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    build_field_transformations:
+      alleleFreqs: split [,]
+      alleleNs: split [,]
+      alleles: split [,]
+      func: split [,]
+      observed: split [\/]
+    features:
+      - name
+      - strand
+      - observed
+      - class
+      - func
+      - alleles
+      - alleleNs: number
+      - alleleFreqs: number
+    fetch_date: 2017-02-04T21:35:00
+    local_files:
+      - hg19.snp150.chr*.gz
+    name: dbSNP
+    sql_statement: SELECT * FROM hg19.snp150
+    type: sparse
+    version: 7
+  - based: 1
+    build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    build_field_transformations:
+      chrom: chr .
+      clinicalSignificance: split [;]
+      origin: split [;]
+      phenotypeList: split [;]
+      reviewStatus: split [;]
+      type: split [;]
+    build_row_filters:
+      Assembly: == GRCh37
+    features:
+      - alleleID: number
+      - phenotypeList
+      - clinicalSignificance
+      - type
+      - origin
+      - numberSubmitters: number
+      - reviewStatus
+      - referenceAllele
+      - alternateAllele
+    fetch_date: 2018-02-26T21:56:00
+    fieldMap:
+      "#AlleleID": alleleID
+      AlternateAllele: alternateAllele
+      Chromosome: chrom
+      ClinicalSignificance: clinicalSignificance
+      NumberSubmitters: numberSubmitters
+      Origin: origin
+      PhenotypeIDS: phenotypeIDs
+      PhenotypeList: phenotypeList
+      ReferenceAllele: referenceAllele
+      ReviewStatus: reviewStatus
+      Start: chromStart
+      Stop: chromEnd
+      Type: type
+    local_files:
+      - variant_summary.txt.gz
+    name: clinvar
+    remote_files:
+      - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
+    type: sparse
+    version: 7
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    build_row_filters:
+      AS_FilterStatus: == PASS
+    features:
+      - alt
+      - id
+      - af: number
+      - an: number
+      - an_afr: number
+      - an_amr: number
+      - an_asj: number
+      - an_eas: number
+      - an_fin: number
+      - an_nfe: number
+      - an_oth: number
+      - an_male: number
+      - an_female: number
+      - af_afr: number
+      - af_amr: number
+      - af_asj: number
+      - af_eas: number
+      - af_fin: number
+      - af_nfe: number
+      - af_oth: number
+      - af_male: number
+      - af_female: number
+    fieldMap:
+      AF: af
+      AF_AFR: af_afr
+      AF_AMR: af_amr
+      AF_ASJ: af_asj
+      AF_EAS: af_eas
+      AF_FIN: af_fin
+      AF_Female: af_female
+      AF_Male: af_male
+      AF_NFE: af_nfe
+      AF_OTH: af_oth
+      AF_SAS: af_sas
+      AN: an
+      AN_AFR: an_afr
+      AN_AMR: an_amr
+      AN_ASJ: an_asj
+      AN_EAS: an_eas
+      AN_FIN: an_fin
+      AN_Female: an_female
+      AN_Male: an_male
+      AN_NFE: an_nfe
+      AN_OTH: an_oth
+      AN_SAS: an_sas
+    local_files:
+      - gnomad.genomes.r2.0.2.sites.chr*.vcf.bgz
+    name: gnomad.genomes
+    type: vcf
+    version: 7
+  - build_author: ec2-user
+    build_date: 2018-02-26T22:21:00
+    build_row_filters:
+      AS_FilterStatus: == PASS
+    features:
+      - alt
+      - id
+      - af: number
+      - an: number
+      - an_afr: number
+      - an_amr: number
+      - an_asj: number
+      - an_eas: number
+      - an_fin: number
+      - an_nfe: number
+      - an_oth: number
+      - an_sas: number
+      - an_male: number
+      - an_female: number
+      - af_afr: number
+      - af_amr: number
+      - af_asj: number
+      - af_eas: number
+      - af_fin: number
+      - af_nfe: number
+      - af_oth: number
+      - af_sas: number
+      - af_male: number
+      - af_female: number
+    fieldMap:
+      AF: af
+      AF_AFR: af_afr
+      AF_AMR: af_amr
+      AF_ASJ: af_asj
+      AF_EAS: af_eas
+      AF_FIN: af_fin
+      AF_Female: af_female
+      AF_Male: af_male
+      AF_NFE: af_nfe
+      AF_OTH: af_oth
+      AF_SAS: af_sas
+      AN: an
+      AN_AFR: an_afr
+      AN_AMR: an_amr
+      AN_ASJ: an_asj
+      AN_EAS: an_eas
+      AN_FIN: an_fin
+      AN_Female: an_female
+      AN_Male: an_male
+      AN_NFE: an_nfe
+      AN_OTH: an_oth
+      AN_SAS: an_sas
+    local_files:
+      - gnomad.exomes.r2.0.2.sites.vcf.bgz
+    name: gnomad.exomes
+    type: vcf
+    version: 7
 version: 11

--- a/python/python/bystro/search/save/tests/test_make_output_string.py
+++ b/python/python/bystro/search/save/tests/test_make_output_string.py
@@ -2,7 +2,7 @@ from bystro.search.save.handler import _make_output_string, _populate_data
 from bystro.search.utils.annotation import DelimitersConfig
 
 delims = DelimitersConfig(
-    empty_field="!",
+    empty_field="NA",
     overlap="/",
     value=";",
     position="|",
@@ -95,7 +95,7 @@ def test_basic_functionality():
         ],
     ]
 
-    expected = b"gene1_mrna1/!/gene1_mrna2;gene1|position2a;position2b\tcol2_scalar\nrow2_scalar\n"
+    expected = b"gene1_mrna1/NA/gene1_mrna2;gene1|position2a;position2b\tcol2_scalar\nrow2_scalar\n"
 
     assert _make_output_string(rows, delims) == expected
 

--- a/python/python/bystro/search/utils/annotation.py
+++ b/python/python/bystro/search/utils/annotation.py
@@ -146,7 +146,7 @@ class DelimitersConfig(Struct, frozen=True, forbid_unknown_fields=True):
     position: str = "|"
     overlap: str = chr(31)
     value: str = ";"
-    empty_field: str = "!"
+    empty_field: str = "NA"
 
     @staticmethod
     def from_dict(annotation_config: dict[str, Any]):

--- a/python/python/bystro/search/utils/annotation.py
+++ b/python/python/bystro/search/utils/annotation.py
@@ -226,7 +226,7 @@ class Statistics:
             f"-outQcTabPath {self.qc_output_path} -refColumn {ref_field} "
             f"-altColumn {alt_field} -homozygotesColumn {hom_field} "
             f"-heterozygotesColumn {het_field} -siteTypeColumn {site_type_field} "
-            f"{dbSNPpart} -emptyField '{empty_field}' "
+            f"{dbSNPpart} -emptyField {empty_field} "
             f"-exonicAlleleFunctionColumn {ea_fun_field} "
             f"-primaryDelimiter '{value_delim}' -fieldSeparator '{field_delim}'"
         )

--- a/python/python/bystro/search/utils/tests/test_annotation.py
+++ b/python/python/bystro/search/utils/tests/test_annotation.py
@@ -14,7 +14,7 @@ def assert_defaults(config: DelimitersConfig):
     assert config.position == "|"
     assert config.overlap == chr(31)
     assert config.value == ";"
-    assert config.empty_field == "!"
+    assert config.empty_field == "NA"
 
 
 def test_delimiters_default_values():
@@ -69,7 +69,7 @@ def test_delimiters_from_dict_partial_delimiters_key():
     assert config.position == "y"
     assert config.overlap == chr(31)  # default value
     assert config.value == ";"  # default value
-    assert config.empty_field == "!"  # default value
+    assert config.empty_field == "NA"  # default value
 
 
 def test_delimiters_unexpected_key():
@@ -210,7 +210,7 @@ def test_statistics_get_stats_arguments(mocker):
         "-outQcTabPath /dummy/output_base_path.statistics.qc.tsv "
         "-refColumn ref -altColumn alt -homozygotesColumn homozygotes "
         "-heterozygotesColumn heterozygotes -siteTypeColumn refSeq.siteType "
-        "-dbSnpNameColumn dbSNP.name -emptyField '!' "
+        "-dbSnpNameColumn dbSNP.name -emptyField NA "
         "-exonicAlleleFunctionColumn refSeq.exonicAlleleFunction "
         "-primaryDelimiter ';' -fieldSeparator '\t'"
     )


### PR DESCRIPTION
* Use NA as the empty field value everywhere

This ensures that pandas and R read missing values as missing. Better to go with the tide on these things: while "!" is more space efficient, the cons for downstream processing are large: you need to override default missing value in data frame libraries.


Almost all of the changes are in "*.yml". Ignore those. It's 99% formatting changes, the only other difference is using "--emptyField NA" instead of "--emptyField '!'" and the hg19.clean.yml is updated to reflect the newest database build. Ignore these and assume they are right.