### PR TITLE
[annotator] Add no_build option which allows tracks to be skipped

### DIFF
--- a/install/install-perl-libs.sh
+++ b/install/install-perl-libs.sh
@@ -51,6 +51,7 @@ cpanm install Hash::Merge::Simple
 cpanm install Module::Build::XSUtil
 cpanm install Test::LeakTrace
 cpanm install Test::Pod
+cpanm install Test::Exception
 
 cpanm install Log::Any::Adapter
 

--- a/perl/bench/serialization_test.pl
+++ b/perl/bench/serialization_test.pl
@@ -18,14 +18,13 @@ require bytes;
 use Seq::DBManager;
 use Scalar::Util qw/looks_like_number/;
 use Data::Float;
-# my $seq = MockBuilder->new_with_config({config => './config/hg19.yml', debug => 1});
+
 Seq::DBManager::initialize(
   databaseDir => '/mnt/annotator/bystro-dev/hg19/index',
   readOnly    => 1,
 );
 my $db = Seq::DBManager->new();
-# my $stuff = $db->dbReadOne('chr21', 49e6, 0 , 1);
-# p $stuff;
+
 my $nobless;
 
 my $mpt = Data::MessagePack->new()->prefer_float32();

--- a/perl/lib/Interface.pm
+++ b/perl/lib/Interface.pm
@@ -13,8 +13,6 @@ use Mouse::Util::TypeConstraints;
 
 use namespace::autoclean;
 
-use DDP;
-
 use YAML::XS qw/LoadFile/;
 
 use Getopt::Long::Descriptive;

--- a/perl/lib/Seq/Base.pm
+++ b/perl/lib/Seq/Base.pm
@@ -19,7 +19,6 @@ use namespace::autoclean;
 use Seq::DBManager;
 use Seq::Tracks;
 
-use DDP;
 #exports new_with_config
 with 'Seq::Role::ConfigFromFile',
   #setLogLevel, setLogPath, setPublisher

--- a/perl/lib/Seq/Build.pm
+++ b/perl/lib/Seq/Build.pm
@@ -5,7 +5,6 @@ use warnings;
 package Seq::Build;
 our $VERSION = '0.001';
 
-use DDP;
 # ABSTRACT: A class for building all files associated with a genome assembly
 # VERSION
 
@@ -109,10 +108,19 @@ sub BUILD {
     }
   }
 
+  if ( $tracks->getRefTrackBuilder()->no_build ) {
+    $self->log( 'fatal', "Reference track is marked as no_build, but must be built" );
+  }
+
   #TODO: return error codes from the rest of the buildTrack methods
   my $decodedConfig = LoadFile( $self->config );
 
   for my $builder (@builders) {
+    if ( $builder->no_build ) {
+      $self->log( 'info', "Marked as no_build, skipping: " . $builder->name . "\n" );
+      next;
+    }
+
     $self->log( 'info', "Started building " . $builder->name . "\n" );
 
     #TODO: implement errors for all tracks

--- a/perl/lib/Seq/DBManager.pm
+++ b/perl/lib/Seq/DBManager.pm
@@ -19,7 +19,7 @@ with 'Seq::Role::Message';
 use Data::MessagePack;
 use LMDB_File         qw(:all);
 use Types::Path::Tiny qw/AbsPath/;
-use DDP;
+
 use Hash::Merge::Simple qw/ merge /;
 use Path::Tiny;
 use Scalar::Util qw/looks_like_number/;

--- a/perl/lib/Seq/Definition.pm
+++ b/perl/lib/Seq/Definition.pm
@@ -5,7 +5,7 @@ use warnings;
 package Seq::Definition;
 use Mouse::Role 2;
 use Path::Tiny;
-use DDP;
+
 use Types::Path::Tiny qw/AbsPath AbsFile AbsDir/;
 use List::MoreUtils   qw/first_index/;
 use Mouse::Util::TypeConstraints;

--- a/perl/lib/Seq/InputFile.pm
+++ b/perl/lib/Seq/InputFile.pm
@@ -16,7 +16,7 @@ use Mouse::Util::TypeConstraints;
 use File::Which qw(which);
 use File::Basename;
 use List::MoreUtils qw(firstidx);
-use List::Util qw( max );
+use List::Util      qw( max );
 
 use namespace::autoclean;
 

--- a/perl/lib/Seq/InputFile.pm
+++ b/perl/lib/Seq/InputFile.pm
@@ -16,9 +16,9 @@ use Mouse::Util::TypeConstraints;
 use File::Which qw(which);
 use File::Basename;
 use List::MoreUtils qw(firstidx);
-use namespace::autoclean;
-use DDP;
 use List::Util qw( max );
+
+use namespace::autoclean;
 
 with 'Seq::Role::Message';
 

--- a/perl/lib/Seq/Role/ConfigFromFile.pm
+++ b/perl/lib/Seq/Role/ConfigFromFile.pm
@@ -34,7 +34,6 @@ use Type::Params    qw/ compile /;
 use Types::Standard qw/ :types /;
 use Scalar::Util    qw/ reftype /;
 use YAML::XS        qw/ LoadFile /;
-use DDP;
 
 with 'Seq::Role::IO', 'MouseX::Getopt';
 

--- a/perl/lib/Seq/Role/IO.pm
+++ b/perl/lib/Seq/Role/IO.pm
@@ -18,7 +18,7 @@ use Sys::CpuAffinity;
 
 use Path::Tiny;
 use Try::Tiny;
-use DDP;
+
 use Scalar::Util qw/looks_like_number/;
 with 'Seq::Role::Message';
 # tried various ways of assigning this to an attrib, with the intention that

--- a/perl/lib/Seq/Role/Validator.pm
+++ b/perl/lib/Seq/Role/Validator.pm
@@ -9,8 +9,6 @@ use namespace::autoclean;
 #also prrovides ->is_file function
 use Types::Path::Tiny qw/File AbsFile AbsPath AbsDir/;
 
-use DDP;
-
 use Path::Tiny;
 use Cwd 'abs_path';
 

--- a/perl/lib/Seq/Tracks/Base.pm
+++ b/perl/lib/Seq/Tracks/Base.pm
@@ -30,6 +30,16 @@ with 'Seq::Role::Message';
 # Not worth complexity of Maybe[Type], default => undef,
 has dbName => ( is => 'ro', init_arg => undef, writer => '_setDbName' );
 
+# Don't actually build, used if we want a track to serve as a join track
+# Where the track must exist in the tracks list, so that the "join" property of a different track can reference it
+# but we don't want to build it
+# An example of this is clinvar. We don't want to build the actual track, because it only allows for position-wise
+# matching, rather than allele-wise, but it contains large structural variations which we want to capture
+# where they overlap with genes.
+# So we join this clinvar data on refSeq data, capturing larger variation, but don't build a clinvar track
+# using this data; instead we build a clinvar track using the VCF dataset, and call that clinvarVcf
+has no_build => ( is => 'ro', isa => 'Bool', default => 0 );
+
 # TODO: Evaluate removing joinTracks in favor of utilities
 # or otherwise make them more flexible (array of them)
 has joinTrackFeatures => (

--- a/perl/lib/Seq/Tracks/Base.pm
+++ b/perl/lib/Seq/Tracks/Base.pm
@@ -12,7 +12,6 @@ our $VERSION = '0.001';
 use Mouse 2;
 use MouseX::NativeTraits;
 
-use DDP;
 use List::Util qw/first/;
 
 use Seq::Tracks::Base::MapTrackNames;

--- a/perl/lib/Seq/Tracks/Base/MapFieldNames.pm
+++ b/perl/lib/Seq/Tracks/Base/MapFieldNames.pm
@@ -15,7 +15,7 @@ package Seq::Tracks::Base::MapFieldNames;
 use Mouse 2;
 use List::Util qw/max/;
 use Seq::DBManager;
-use DDP;
+
 with 'Seq::Role::Message';
 
 ################### Required attributes at construction #######################

--- a/perl/lib/Seq/Tracks/Base/MapTrackNames.pm
+++ b/perl/lib/Seq/Tracks/Base/MapTrackNames.pm
@@ -11,7 +11,7 @@ use warnings;
 package Seq::Tracks::Base::MapTrackNames;
 use Mouse 2;
 use List::Util qw/max/;
-use DDP;
+
 use Seq::DBManager;
 
 with 'Seq::Role::Message';

--- a/perl/lib/Seq/Tracks/Base/Types.pm
+++ b/perl/lib/Seq/Tracks/Base/Types.pm
@@ -15,7 +15,7 @@ use Mouse::Util::TypeConstraints;
 use namespace::autoclean;
 use Scalar::Util  qw/looks_like_number/;
 use Math::SigFigs qw(:all);
-use DDP;
+
 #What the types must be called in the config file
 # TODO: build these track maps automatically
 # by title casing the "type" field

--- a/perl/lib/Seq/Tracks/Build.pm
+++ b/perl/lib/Seq/Tracks/Build.pm
@@ -41,9 +41,6 @@ has db => (
   }
 );
 
-# Don't actually build, used if we want a track to serve as a join track
-has no_build => ( is => 'ro', isa => 'Bool', default => 0 );
-
 # Allows consumers to record track completion, skipping chromosomes that have
 # already been built
 has completionMeta => (

--- a/perl/lib/Seq/Tracks/Build.pm
+++ b/perl/lib/Seq/Tracks/Build.pm
@@ -42,7 +42,7 @@ has db => (
 );
 
 # Don't actually build, used if we want a track to serve as a join track
-has no_build => ( is => 'ro', isa => 'Bool', default => 0);
+has no_build => ( is => 'ro', isa => 'Bool', default => 0 );
 
 # Allows consumers to record track completion, skipping chromosomes that have
 # already been built

--- a/perl/lib/Seq/Tracks/Build.pm
+++ b/perl/lib/Seq/Tracks/Build.pm
@@ -13,7 +13,6 @@ use Mouse 2;
 use MouseX::NativeTraits;
 use namespace::autoclean;
 use Scalar::Util qw/looks_like_number/;
-use DDP;
 
 use Seq::DBManager;
 use Seq::Tracks::Build::CompletionMeta;
@@ -41,6 +40,9 @@ has db => (
     return Seq::DBManager->new();
   }
 );
+
+# Don't actually build, used if we want a track to serve as a join track
+has no_build => ( is => 'ro', isa => 'Bool', default => 0);
 
 # Allows consumers to record track completion, skipping chromosomes that have
 # already been built
@@ -156,7 +158,6 @@ sub BUILD {
   my $d = Seq::Output::Delimiters->new();
   $self->{_cleanDelims} = $d->cleanDelims;
   $self->{_missChar}    = $d->emptyFieldChar;
-  $self->{_replChar}    = $d->globalReplaceChar;
   # Commit, sync, and remove any databases opened
   # This is useful because locking may occur if there is an open transaction
   # before fork(), and to make sure that any database meta data is properly

--- a/perl/lib/Seq/Tracks/Build/CompletionMeta.pm
+++ b/perl/lib/Seq/Tracks/Build/CompletionMeta.pm
@@ -8,7 +8,6 @@ package Seq::Tracks::Build::CompletionMeta;
 # TODO: better error handling, not sure how w/ present LMDB API without perf loss
 use Mouse 2;
 use namespace::autoclean;
-use DDP;
 
 with 'Seq::Role::Message';
 

--- a/perl/lib/Seq/Tracks/Build/LocalFilesPaths.pm
+++ b/perl/lib/Seq/Tracks/Build/LocalFilesPaths.pm
@@ -5,7 +5,7 @@ use warnings;
 package Seq::Tracks::Build::LocalFilesPaths;
 
 use Mouse 2;
-use DDP;
+
 use Path::Tiny qw/path/;
 use File::Glob ':bsd_glob';
 

--- a/perl/lib/Seq/Tracks/Cadd/Build.pm
+++ b/perl/lib/Seq/Tracks/Cadd/Build.pm
@@ -8,8 +8,6 @@ package Seq::Tracks::Cadd::Build;
 use Mouse 2;
 extends 'Seq::Tracks::Build';
 
-use DDP;
-
 use Seq::Tracks::Cadd::Order;
 use Seq::Tracks::Score::Build::Round;
 use Seq::Tracks;

--- a/perl/lib/Seq/Tracks/Gene.pm
+++ b/perl/lib/Seq/Tracks/Gene.pm
@@ -21,7 +21,6 @@ our $VERSION = '0.001';
 use Mouse 2;
 
 use namespace::autoclean;
-use DDP;
 
 use Seq::Tracks::Gene::Site;
 use Seq::Tracks::Gene::Site::SiteTypeMap;

--- a/perl/lib/Seq/Tracks/Gene/Build.pm
+++ b/perl/lib/Seq/Tracks/Gene/Build.pm
@@ -22,7 +22,6 @@ extends 'Seq::Tracks::Build';
 #exports regionTrackPath
 with 'Seq::Tracks::Region::RegionTrackPath';
 
-use DDP;
 use List::Util qw/first/;
 
 my $geneDef = Seq::Tracks::Gene::Definition->new();

--- a/perl/lib/Seq/Tracks/Gene/Build/TX.pm
+++ b/perl/lib/Seq/Tracks/Gene/Build/TX.pm
@@ -231,18 +231,11 @@ sub _buildTranscript {
 
     my $exonPosHref = [ $exonStarts[$i] .. $exonEnds[$i] - 1 ];
 
-    # say "exon start was " . $exonStarts[$i];
-    # say "exon end was " . ($exonEnds[$i] - 1);
-    # say "from that we got exonPosHref";
-    # p $exonPosHref;
     #limitation of the below API; we need to copy $posHref
     #thankfully, we needed to do this anyway.
     #we push them in order, so the first position in the
     #https://ideone.com/wq0YJO (dereferencing not strictly necessary, but I think clearer)
     push @sequencePositions, @$exonPosHref;
-
-    # say "sequence positions are";
-    # p @sequencePositions;
 
     # As a result of modifying the reference, each position in exonPosHref
     # now has database data, or undefined
@@ -258,11 +251,6 @@ sub _buildTranscript {
     #Ref tracks always return a scalar, a single base, since that's the only
     #thing that they could return
 
-    #This doesn't work for some reason.
-    #https://ideone.com/1sJC69
-    #$txSequence .= reduce { ref $a ? $refTrack->get($a) : $a . $refTrack->get($b) } @$dAref (@$exonPosHref)
-    # say "length is " . scalar @$dAref (@$exonPosHref);
-    # exit;
     for ( my $y = 0; $y < scalar @$exonPosHref; $y++ ) {
       my $refBase = $refTrack->get( $exonPosHref->[$y] );
 

--- a/perl/lib/Seq/Tracks/Gene/Site.pm
+++ b/perl/lib/Seq/Tracks/Gene/Site.pm
@@ -17,7 +17,6 @@ package Seq::Tracks::Gene::Site;
 
 use Mouse 2;
 use Scalar::Util qw/looks_like_number/;
-use DDP;
 
 use Seq::Tracks::Gene::Site::SiteTypeMap;
 use Seq::Tracks::Gene::Site::CodonMap;

--- a/perl/lib/Seq/Tracks/Gene/Site/CodonMap.pm
+++ b/perl/lib/Seq/Tracks/Gene/Site/CodonMap.pm
@@ -7,7 +7,7 @@ use warnings;
 
 # Safe for use when instantiated to static variable; no set - able properties
 package Seq::Tracks::Gene::Site::CodonMap;
-use DDP;
+
 use Mouse 2;
 use namespace::autoclean;
 

--- a/perl/lib/Seq/Tracks/Gene/Site/SiteTypeMap.pm
+++ b/perl/lib/Seq/Tracks/Gene/Site/SiteTypeMap.pm
@@ -6,7 +6,6 @@ package Seq::Tracks::Gene::Site::SiteTypeMap;
 
 use Mouse 2;
 use Mouse::Util::TypeConstraints;
-use DDP;
 # Define allowable types
 
 # Safe for use when instantiated to static variable; no set - able properties

--- a/perl/lib/Seq/Tracks/Get.pm
+++ b/perl/lib/Seq/Tracks/Get.pm
@@ -8,7 +8,7 @@ package Seq::Tracks::Get;
 our $VERSION = '0.001';
 
 use Mouse 2;
-use DDP;
+
 extends 'Seq::Tracks::Base';
 
 use Seq::Headers;

--- a/perl/lib/Seq/Tracks/Nearest.pm
+++ b/perl/lib/Seq/Tracks/Nearest.pm
@@ -21,7 +21,6 @@ our $VERSION = '0.001';
 use Mouse 2;
 
 use namespace::autoclean;
-use DDP;
 
 extends 'Seq::Tracks::Base';
 with 'Seq::Tracks::Region::RegionTrackPath';

--- a/perl/lib/Seq/Tracks/Nearest/Build.pm
+++ b/perl/lib/Seq/Tracks/Nearest/Build.pm
@@ -28,7 +28,7 @@ use namespace::autoclean;
 
 use Parallel::ForkManager;
 use Scalar::Util qw/looks_like_number/;
-use DDP;
+
 use List::Util qw/max min/;
 # http://fastcompression.blogspot.com/2014/07/xxhash-wider-64-bits.html
 # much faster than md5, no cryptographic guarantee should suffice for our use

--- a/perl/lib/Seq/Tracks/Reference.pm
+++ b/perl/lib/Seq/Tracks/Reference.pm
@@ -10,7 +10,6 @@ our $VERSION = '0.001';
 # VERSION
 
 use Mouse 2;
-use DDP;
 
 use namespace::autoclean;
 

--- a/perl/lib/Seq/Tracks/Reference/Build.pm
+++ b/perl/lib/Seq/Tracks/Reference/Build.pm
@@ -16,7 +16,6 @@ extends 'Seq::Tracks::Build';
 use Seq::Tracks::Reference::MapBases;
 
 use Parallel::ForkManager;
-use DDP;
 
 my $baseMapper = Seq::Tracks::Reference::MapBases->new();
 

--- a/perl/lib/Seq/Tracks/Score/Build.pm
+++ b/perl/lib/Seq/Tracks/Score/Build.pm
@@ -13,7 +13,6 @@ use Mouse 2;
 
 use namespace::autoclean;
 use Parallel::ForkManager;
-use DDP;
 
 extends 'Seq::Tracks::Build';
 

--- a/perl/lib/Seq/Tracks/Sparse/Build.pm
+++ b/perl/lib/Seq/Tracks/Sparse/Build.pm
@@ -22,8 +22,6 @@ use List::MoreUtils qw/firstidx/;
 use Parallel::ForkManager;
 use Scalar::Util qw/looks_like_number/;
 
-use DDP;
-
 extends 'Seq::Tracks::Build';
 
 # We assume sparse tracks have at least one feature; can remove this requirement

--- a/perl/lib/Seq/Tracks/Vcf/Build.pm
+++ b/perl/lib/Seq/Tracks/Vcf/Build.pm
@@ -30,7 +30,6 @@ use Scalar::Util qw/looks_like_number/;
 use Seq::Output::Delimiters;
 use Seq::Tracks::Base::Types;
 use Scalar::Util qw/looks_like_number/;
-use DDP;
 
 use Seq::Tracks;
 extends 'Seq::Tracks::Build';

--- a/perl/lib/Utils/Fetch.pm
+++ b/perl/lib/Utils/Fetch.pm
@@ -21,8 +21,6 @@ use YAML::XS qw/Dump/;
 
 use Utils::SqlWriter;
 
-use DDP;
-
 # The sql connection config
 has sql         => ( is => 'ro', isa => 'Maybe[Str]' );
 has remoteFiles => ( is => 'ro', isa => 'Maybe[ArrayRef]' );

--- a/perl/lib/Utils/FilterCadd.pm
+++ b/perl/lib/Utils/FilterCadd.pm
@@ -16,7 +16,6 @@ use Scalar::Util      qw/looks_like_number/;
 
 use Seq::Tracks::Build::LocalFilesPaths;
 
-use DDP;
 use Parallel::ForkManager;
 
 use Seq::DBManager;
@@ -71,8 +70,6 @@ sub go {
   $trackConfig{assembly}    = $self->_decodedConfig->{assembly};
   $trackConfig{chromosomes} = $self->_decodedConfig->{chromosomes};
 
-  # p %trackConfig;
-  # exit;
   my $caddGetter = Seq::Tracks::Cadd->new( \%trackConfig );
 
   my $rounder = Seq::Tracks::Score::Build::Round->new(

--- a/perl/lib/Utils/LiftOverCadd.pm
+++ b/perl/lib/Utils/LiftOverCadd.pm
@@ -16,7 +16,6 @@ use Path::Tiny        qw/path/;
 
 use Seq::Tracks::Build::LocalFilesPaths;
 
-use DDP;
 use Parallel::ForkManager;
 
 # Exports: _localFilesDir, _decodedConfig, compress, _wantedTrack, _setConfig, logPath, use_absolute_path

--- a/perl/lib/Utils/RefGeneXdbnsfp.pm
+++ b/perl/lib/Utils/RefGeneXdbnsfp.pm
@@ -14,7 +14,7 @@ use Parallel::ForkManager;
 use Seq::Role::IO;
 use Seq::Output::Delimiters;
 use Seq::Tracks::Build::LocalFilesPaths;
-use DDP;
+
 use List::Util qw/uniq/;
 
 # Exports: _localFilesDir, _decodedConfig, compress, _wantedTrack, _setConfig, logPath, use_absolute_path
@@ -40,8 +40,6 @@ sub BUILD {
   if ( !@{ $self->{_localFiles} } ) {
     $self->log( 'fatal', "Require some local files" );
   }
-
-  p $self->{_localFiles};
 }
 
 # TODO: error check opening of file handles, write tests

--- a/perl/lib/Utils/RenameTrack.pm
+++ b/perl/lib/Utils/RenameTrack.pm
@@ -12,8 +12,6 @@ use Mouse 2;
 use namespace::autoclean;
 use Path::Tiny qw/path/;
 
-use DDP;
-
 use Seq::Tracks::Build::LocalFilesPaths;
 use Seq::Tracks::Base::MapTrackNames;
 use List::MoreUtils qw/first_index/;

--- a/perl/lib/Utils/SortCadd.pm
+++ b/perl/lib/Utils/SortCadd.pm
@@ -12,8 +12,6 @@ use Mouse 2;
 use namespace::autoclean;
 use Path::Tiny qw/path/;
 
-use DDP;
-
 use Seq::Tracks::Build::LocalFilesPaths;
 use Parallel::ForkManager;
 

--- a/perl/t/tracks/build/ref_cannot_be_skipped.t
+++ b/perl/t/tracks/build/ref_cannot_be_skipped.t
@@ -30,6 +30,8 @@ my $config_file = PrepareConfigWithTempdirs(
 
 my $config = YAML::XS::LoadFile($config_file);
 
-throws_ok { Seq::Build->new_with_config( { config => $config_file } ) } qr/Reference track is marked as no_build, but must be built/, 'Reference tracks must be built';
+throws_ok { Seq::Build->new_with_config( { config => $config_file } ) }
+qr/Reference track is marked as no_build, but must be built/,
+  'Reference tracks must be built';
 
 done_testing();

--- a/perl/t/tracks/build/ref_cannot_be_skipped.t
+++ b/perl/t/tracks/build/ref_cannot_be_skipped.t
@@ -31,7 +31,6 @@ my $config_file = PrepareConfigWithTempdirs(
 my $config = YAML::XS::LoadFile($config_file);
 
 throws_ok { Seq::Build->new_with_config( { config => $config_file } ) }
-qr/Reference track is marked as no_build, but must be built/,
-  'Reference tracks must be built';
+qr/Reference track cannot have `no_build` set/, 'Reference tracks must be built';
 
 done_testing();

--- a/perl/t/tracks/build/ref_cannot_be_skipped.t
+++ b/perl/t/tracks/build/ref_cannot_be_skipped.t
@@ -1,0 +1,35 @@
+use 5.10.0;
+use strict;
+use warnings;
+
+package MockBuilder;
+use Mouse;
+extends 'Seq::Base';
+
+1;
+
+use Test::More;
+use Test::Exception;
+use lib 't/lib';
+use TestUtils qw/ PrepareConfigWithTempdirs /;
+
+use Path::Tiny   qw/path/;
+use Scalar::Util qw/looks_like_number/;
+use YAML::XS     qw/DumpFile/;
+
+use Seq::Build;
+# create temp directories
+my $dir = Path::Tiny->tempdir();
+
+# prepare temp directory and make test config file
+my $config_file = PrepareConfigWithTempdirs(
+  't/tracks/build/ref_cannot_be_skipped.yml',
+  't/tracks/gene/db/raw', [ 'database_dir', 'files_dir', 'temp_dir' ],
+  'files_dir',            $dir->stringify
+);
+
+my $config = YAML::XS::LoadFile($config_file);
+
+throws_ok { Seq::Build->new_with_config( { config => $config_file } ) } qr/Reference track is marked as no_build, but must be built/, 'Reference tracks must be built';
+
+done_testing();

--- a/perl/t/tracks/build/ref_cannot_be_skipped.yml
+++ b/perl/t/tracks/build/ref_cannot_be_skipped.yml
@@ -1,0 +1,12 @@
+---
+assembly: hg19
+chromosomes:
+  - chrM
+database_dir: ~
+files_dir: ~
+temp_dir: ~
+tracks:
+  tracks:
+    - name: ref
+      type: reference
+      no_build: true

--- a/perl/t/tracks/gene/join_no_build.t
+++ b/perl/t/tracks/gene/join_no_build.t
@@ -1,3 +1,6 @@
+# This test demonstrates that we can join a track that is not built
+# Here, we join the "clinvar" track's data on refSeq, but don't build the individual clinvar track
+
 use 5.10.0;
 use strict;
 use warnings;
@@ -18,10 +21,8 @@ use Seq::Build;
 use Seq::Tracks::Gene::Site::SiteTypeMap;
 use Seq::Tracks::Reference::MapBases;
 
-# create temp directories
 my $dir = Path::Tiny->tempdir();
 
-# prepare temp directory and make test config file
 my $config_file = PrepareConfigWithTempdirs(
   't/tracks/gene/join_no_build.yml',
   't/tracks/gene/db/raw', [ 'database_dir', 'files_dir', 'temp_dir' ],

--- a/perl/t/tracks/gene/join_no_build.t
+++ b/perl/t/tracks/gene/join_no_build.t
@@ -1,0 +1,128 @@
+use 5.10.0;
+use strict;
+use warnings;
+
+package MockBuilder;
+use Mouse;
+extends 'Seq::Base';
+
+use Test::More;
+use lib 't/lib';
+use TestUtils qw/ PrepareConfigWithTempdirs /;
+
+use Path::Tiny   qw/path/;
+use Scalar::Util qw/looks_like_number/;
+use YAML::XS     qw/DumpFile/;
+
+use Seq::Build;
+use Seq::Tracks::Gene::Site::SiteTypeMap;
+use Seq::Tracks::Reference::MapBases;
+use DDP;
+
+# create temp directories
+my $dir = Path::Tiny->tempdir();
+
+# prepare temp directory and make test config file
+my $config_file = PrepareConfigWithTempdirs(
+  't/tracks/gene/join_no_build.yml',
+  't/tracks/gene/db/raw', [ 'database_dir', 'files_dir', 'temp_dir' ],
+  'files_dir',            $dir->stringify
+);
+
+my $config = YAML::XS::LoadFile($config_file);
+
+
+my $dbPath = path( $config->{database_dir} );
+$dbPath->remove_tree( { keep_root => 1 } );
+
+my $builder = Seq::Build->new_with_config( { config => $config_file } );
+
+my $tracks = $builder->tracksObj;
+
+my $baseMapper = Seq::Tracks::Reference::MapBases->new();
+my $siteTypes  = Seq::Tracks::Gene::Site::SiteTypeMap->new();
+
+my $refGetter     = $tracks->getRefTrackGetter();
+my $geneGetter    = $tracks->getTrackGetterByName('refSeq');
+my $clinvarGetter = $tracks->getTrackGetterByName('clinvar');
+
+my $siteTypeDbName = $geneGetter->getFieldDbName('siteType');
+my $funcDbName     = $geneGetter->getFieldDbName('exonicAlleleFunction');
+
+my $db = Seq::DBManager->new();
+
+my $mainDbAref     = $db->dbReadAll('chrM');
+my $regionDataAref = $db->dbReadAll('refSeq/chrM');
+
+my $geneDbName = $geneGetter->dbName;
+my $header     = Seq::Headers->new();
+
+my $features = $header->getParentFeatures('refSeq');
+
+my ( $siteTypeIdx, $funcIdx, $alleleIdIdx );
+
+# Check that join track successfully built
+for ( my $i = 0; $i < @$features; $i++ ) {
+  my $feat = $features->[$i];
+
+  if ( $feat eq 'siteType' ) {
+    $siteTypeIdx = $i;
+    next;
+  }
+
+  if ( $feat eq 'exonicAlleleFunction' ) {
+    $funcIdx = $i;
+    next;
+  }
+
+  if ( $feat eq 'clinvar.alleleID' ) {
+    $alleleIdIdx = $i;
+  }
+}
+
+my $hasGeneCount = 0;
+my $inGeneCount  = 0;
+
+# We still reserve an index for all specified tracks, even if they are not built
+# Therefore, to minimize database space, such tracks should be specified last
+ok( defined $clinvarGetter->dbName,
+  'clinvar track has dbName despite not being built' );
+
+for my $pos ( 0 .. $#$mainDbAref ) {
+  my $dbData = $mainDbAref->[$pos];
+
+  ok( defined $dbData, 'We have data for position ' . $pos );
+  ok(
+    !defined $dbData->[ $clinvarGetter->dbName ],
+    'No clinvar data built for position ' . $pos
+  );
+
+  my @out;
+  # not an indel
+  my $posIdx = 0;
+  $geneGetter->get( $dbData, 'chrM', $refGetter->get($dbData), 'A', $posIdx, \@out );
+
+  if ( $pos >= 1672 && $pos < 3230 ) {
+    $inGeneCount++;
+
+    my $alleleIDs = $out[$posIdx][$alleleIdIdx];
+    my $s         = join( ",", @{ $out[$alleleIdIdx] } );
+
+    ok( join( ",", @{ $out[$alleleIdIdx] } ) eq '24587', 'Found the clinvar record' );
+    ok( join( ",", @{ $out[$siteTypeIdx] } ) eq $siteTypes->ncRNAsiteType,
+      'ncRNA site type' );
+    ok( !defined $out[$funcIdx][0], 'ncRNA has no exonicAlleleFunction' );
+  }
+
+  if ( defined $dbData->[$geneDbName] ) {
+    $hasGeneCount++;
+  }
+}
+
+ok( $inGeneCount == $hasGeneCount,
+  "We have a refSeq record for every position from txStart to txEnd" );
+
+$db->cleanUp();
+$dbPath->remove_tree( { keep_root => 1 } );
+
+done_testing();

--- a/perl/t/tracks/gene/join_no_build.t
+++ b/perl/t/tracks/gene/join_no_build.t
@@ -31,7 +31,6 @@ my $config_file = PrepareConfigWithTempdirs(
 
 my $config = YAML::XS::LoadFile($config_file);
 
-
 my $dbPath = path( $config->{database_dir} );
 $dbPath->remove_tree( { keep_root => 1 } );
 

--- a/perl/t/tracks/gene/join_no_build.yml
+++ b/perl/t/tracks/gene/join_no_build.yml
@@ -1,0 +1,78 @@
+---
+assembly: hg19
+chromosomes:
+  - chrM
+database_dir: t/tracks/gene/db/index
+files_dir: t/tracks/gene/db/raw
+temp_dir: /mnt/annotator/bystro-dev/tmp
+tracks:
+  tracks:
+    - local_files:
+        - chrM.fa.gz
+      name: ref
+      type: reference
+    - features:
+        - kgID
+        - mRNA
+        - spID
+        - spDisplayID
+        - protAcc
+        - description
+        - rfamAcc
+        - name
+        - name2
+      local_files:
+        - hg19.refGene.chrM
+      name: refSeq
+      type: gene
+      join:
+        features:
+          - alleleID
+          - phenotypeList
+          - clinicalSignificance
+          - type
+          - origin
+          - numberSubmitters
+          - reviewStatus
+          - chromStart
+          - chromEnd
+        track: clinvar
+    - based: 1
+      no_build: 1
+      build_field_transformations:
+        chrom: chr .
+        clinicalSignificance: split [;]
+        origin: split [;]
+        phenotypeList: split [;]
+        reviewStatus: split [;]
+        type: split [;]
+      build_row_filters:
+        Assembly: == GRCh38
+      features:
+        - alleleID: number
+        - phenotypeList
+        - clinicalSignificance
+        - type
+        - origin
+        - numberSubmitters: number
+        - reviewStatus
+        - referenceAllele
+        - alternateAllele
+      fieldMap:
+        "#AlleleID": alleleID
+        AlternateAllele: alternateAllele
+        Chromosome: chrom
+        ClinicalSignificance: clinicalSignificance
+        NumberSubmitters: numberSubmitters
+        Origin: origin
+        PhenotypeIDS: phenotypeIDs
+        PhenotypeList: phenotypeList
+        ReferenceAllele: referenceAllele
+        ReviewStatus: reviewStatus
+        Start: chromStart
+        Stop: chromEnd
+        Type: type
+      local_files:
+        - variant_summary.txt.MT.1600_3250.gz
+      name: clinvar
+      type: sparse


### PR DESCRIPTION
* Add no_build option which allows tracks to be skipped
* Cleans up unnecessary DDP imports

This is necessary, because in some cases, like join tracks, we may not want to build the track referenced in the join definition. This comes up with clinvar, which defines large variants and small in the tsv output, but not in the vcf output. So we define a joint track "refSeq.clinvar" to show those large structural variants that intersect with refSeq, but do not want to build the small variants in the actual clinvar track, because those are inexact in position (we instead now have an exact match clinvar2).