### PR TITLE
[annotator] Move the discordant field, and have `inputRef` next to `alt`

### DIFF
--- a/perl/lib/Seq/Output/Fields.pm
+++ b/perl/lib/Seq/Output/Fields.pm
@@ -8,6 +8,7 @@ use Mouse::Role 2;
 has chromField          => ( is => 'ro', default => 'chrom',          lazy => 1 );
 has posField            => ( is => 'ro', default => 'pos',            lazy => 1 );
 has typeField           => ( is => 'ro', default => 'type',           lazy => 1 );
+has inputRefField       => ( is => 'ro', default => 'inputRef',       lazy => 1 );
 has discordantField     => ( is => 'ro', default => 'discordant',     lazy => 1 );
 has altField            => ( is => 'ro', default => 'alt',            lazy => 1 );
 has trTvField           => ( is => 'ro', default => 'trTv',           lazy => 1 );


### PR DESCRIPTION
* The 3rd field is now inputRef, the input reference coming from the file preprocessor
* The discordant field is now the first non-preprocessor field

This PR addresses Dave's suggestion that we move the ref next to the alt. Because our 'ref' is the reference track, in this implementation we name the ref coming from the input file 'inputRef'.

Example output attached, as well as before the change

After:
[after_ALL_chr1_annotation.annotation.100lines.tsv.zip](https://github.com/bystrogenomics/bystro/files/13344390/after_ALL_chr1_annotation.annotation.100lines.tsv.zip)

Before:
[before_ALL_chr1_annotation.annotation.100lines_v1.tsv.zip](https://github.com/bystrogenomics/bystro/files/13344410/before_ALL_chr1_annotation.annotation.100lines_v1.tsv.zip)

Dave / Thomas like the placement of discordant and inputRef