### PR TITLE
Improve indexing performance

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -27,6 +27,9 @@ index_settings:
     refresh_interval: -1
     number_of_replicas: 0
     codec: best_compression
+    mapping:
+      total_fields:
+        limit: 5000
   analysis:
     normalizer:
       lowercase_normalizer:
@@ -378,7 +381,6 @@ mappings:
               type: integer
             chromEnd:
               type: integer
-
     nearest:
       properties:
         refSeq:
@@ -403,153 +405,66 @@ mappings:
               normalizer: uppercase_normalizer
             dist:
               type: integer
-    phastCons:
-      type: scaled_float
-      scaling_factor: 100
-    phyloP:
-      type: scaled_float
-      scaling_factor: 100
     cadd:
       type: scaled_float
       scaling_factor: 10
+    caddIndel:
+      properties:
+        alt:
+          type: keyword
+        PHRED:
+          type: scaled_float
+          scaling_factor: 10
+    clinvarVcf:
+      properties:
+        RS:
+          type: keyword
     dbSNP:
       properties:
-        name:
-          type: keyword
-          normalizer: lowercase_normalizer
-        strand:
-          type: keyword
-        observed:
-          type: keyword
-          normalizer: uppercase_normalizer
-        class:
-          type: text
-          analyzer: autocomplete_english
-          search_analyzer: search_english_class
-          fields:
-            exact:
-              type: keyword
-              normalizer: lowercase_normalizer
-        func:
-          type: text
-          analyzer: autocomplete_english
-          search_analyzer: search_english_func
-          fields:
-            exact:
-              type: keyword
-              normalizer: lowercase_normalizer
-        alleles:
-          type: keyword
-          normalizer: uppercase_normalizer
-        alleleNs:
-          type: integer
-          coerce: true
-        alleleFreqs:
+        TOMMO:
           type: half_float
-    clinvar:
-      properties:
-        alleleID:
-          type: integer
-        phenotypeList:
-          type: text
-          analyzer: autocomplete_english_split
-          search_analyzer: search_english_description_synonyms
-          fields:
-            exact:
-              type: keyword
-              normalizer: lowercase_normalizer
-        clinicalSignificance:
-          type: text
-          analyzer: autocomplete_english_split
-          search_analyzer: search_english_split
-          fields:
-            exact:
-              type: keyword
-              normalizer: lowercase_normalizer
-        type:
-          type: text
-          analyzer: autocomplete_english
-          search_analyzer: search_english_class
-          fields:
-            exact:
-              type: keyword
-              normalizer: lowercase_normalizer
-        origin:
-          type: text
-          analyzer: autocomplete_english_split
-          search_analyzer: search_english_split
-        numberSubmitters:
-          type: short
-        reviewStatus:
-          type: text
-          analyzer: autocomplete_english_split
-          search_analyzer: search_english_split
-        referenceAllele:
-          type: keyword
-          normalizer: uppercase_normalizer
-        alternateAllele:
-          type: keyword
-          normalizer: uppercase_normalizer
-        match:
-          properties:
-            alt:
-              type: keyword
-            variation_id:
-              type: keyword
-            allele_id:
-              type: keyword
-            strand:
-              type: keyword
-            rcv:
-              type: keyword
-            scv:
-              type: keyword
-            hgvs_c:
-              type: keyword
-            hgvs_p:
-              type: keyword
-            traits:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-            molecular_consequence:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-            clinical_significance:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-            pathogenic:
-              type: short
-            likely_pathogenic:
-              type: short
-            uncertain_significance:
-              type: short
-            likely_benign:
-              type: short
-            benign:
-              type: short
-            review_status:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-            last_evaluated:
-              type: keyword #TODO: make date
-            submitters:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-            pmids:
-              type: keyword
-            origin:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-            xrefs:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
+        ExAC:
+          type: half_float
+        GnomAD:
+          type: half_float
+        Korea1K:
+          type: half_float
+        GoNL:
+          type: half_float
+        KOREAN:
+          type: half_float
+        TWINSUK:
+          type: half_float
+        Vietnamese:
+          type: half_float
+        GENOME_DK:
+          type: half_float
+        GoESP:
+          type: half_float
+        GnomAD_exomes:
+          type: half_float
+        Siberian:
+          type: half_float
+        PRJEB37584:
+          type: half_float
+        SGDP_PRJ:
+          type: half_float
+        1000Genomes:
+          type: half_float
+        dbGaP_PopFreq:
+          type: half_float
+        NorthernSweden:
+          type: half_float
+        HapMap:
+          type: half_float
+        TOPMED:
+          type: half_float
+        ALSPAC:
+          type: half_float
+        Qatari:
+          type: half_float
+        MGP:
+          type: half_float
     gnomad:
       properties:
         genomes:
@@ -560,69 +475,603 @@ mappings:
             id:
               type: keyword
               normalizer: lowercase_normalizer
-            trTv:
-              type: byte
-            af:
+            AN:
+              type: integer
+            AF:
               type: half_float
-            ac:
-              type: short
-            ac_afr:
-              type: short
-            ac_amr:
-              type: short
-            ac_asj:
-              type: short
-            ac_eas:
-              type: short
-            ac_fin:
-              type: short
-            ac_nfe:
-              type: short
-            ac_oth:
-              type: short
-            ac_sas:
-              type: short
-            ac_male:
-              type: short
-            ac_female:
-              type: short
-            an:
-              type: short
-            an_afr:
-              type: short
-            an_amr:
-              type: short
-            an_asj:
-              type: short
-            an_eas:
-              type: short
-            an_fin:
-              type: short
-            an_nfe:
-              type: short
-            an_oth:
-              type: short
-            an_male:
-              type: short
-            an_female:
-              type: short
-            af_afr:
+            AN_nfe_seu:
+              type: integer
+            AF_nfe_seu:
               type: half_float
-            af_amr:
+            nhomalt_nfe_seu:
+              type: integer
+            controls_AN_afr_male:
+              type: integer
+            controls_AF_afr_male:
               type: half_float
-            af_asj:
+            controls_nhomalt_afr_male:
               type: half_float
-            af_eas:
+            non_topmed_AN_amr:
+              type: integer
+            non_topmed_AF_amr:
               type: half_float
-            af_fin:
+            non_topmed_nhomalt_amr:
+              type: integer
+            AN_raw:
+              type: integer
+            AF_raw:
               type: half_float
-            af_nfe:
+            nhomalt_raw:
+              type: integer
+            AN_fin_female:
+              type: integer
+            AF_fin_female:
               type: half_float
-            af_oth:
+            nhomalt_fin_female:
+              type: integer
+            non_neuro_AN_asj_female:
+              type: integer
+            non_neuro_AF_asj_female:
               type: half_float
-            af_male:
+            non_neuro_nhomalt_asj_female:
+              type: integer
+            non_neuro_AN_afr_male:
+              type: integer
+            non_neuro_AF_afr_male:
               type: half_float
-            af_female:
+            non_neuro_nhomalt_afr_male:
+              type: half_float
+            AN_afr_male:
+              type: integer
+            AF_afr_male:
+              type: half_float
+            nhomalt_afr_male:
+              type: half_float
+            AN_afr:
+              type: integer
+            AF_afr:
+              type: half_float
+            nhomalt_afr:
+              type: half_float
+            non_neuro_AN_afr_female:
+              type: integer
+            non_neuro_AF_afr_female:
+              type: half_float
+            non_neuro_nhomalt_afr_female:
+              type: half_float
+            non_topmed_AN_amr_female:
+              type: integer
+            non_topmed_AF_amr_female:
+              type: half_float
+            non_topmed_nhomalt_amr_female:
+              type: integer
+            non_topmed_AN_oth_female:
+              type: integer
+            non_topmed_AF_oth_female:
+              type: half_float
+            non_topmed_nhomalt_oth_female:
+              type: integer
+            AN_eas_female:
+              type: integer
+            AF_eas_female:
+              type: half_float
+            nhomalt_eas_female:
+              type: integer
+            AN_afr_female:
+              type: integer
+            AF_afr_female:
+              type: half_float
+            nhomalt_afr_female:
+              type: half_float
+            non_neuro_AN_female:
+              type: integer
+            non_neuro_AF_female:
+              type: half_float
+            non_neuro_nhomalt_female:
+              type: integer
+            controls_AN_afr:
+              type: integer
+            controls_AF_afr:
+              type: half_float
+            controls_nhomalt_afr:
+              type: half_float
+            AN_nfe_onf:
+              type: integer
+            AF_nfe_onf:
+              type: half_float
+            nhomalt_nfe_onf:
+              type: integer
+            controls_AN_fin_male:
+              type: integer
+            controls_AF_fin_male:
+              type: half_float
+            controls_nhomalt_fin_male:
+              type: integer
+            non_neuro_AN_nfe_nwe:
+              type: integer
+            non_neuro_AF_nfe_nwe:
+              type: half_float
+            non_neuro_nhomalt_nfe_nwe:
+              type: integer
+            AN_fin_male:
+              type: integer
+            AF_fin_male:
+              type: half_float
+            nhomalt_fin_male:
+              type: integer
+            AN_nfe_female:
+              type: integer
+            AF_nfe_female:
+              type: half_float
+            nhomalt_nfe_female:
+              type: integer
+            AN_amr:
+              type: integer
+            AF_amr:
+              type: half_float
+            nhomalt_amr:
+              type: integer
+            non_topmed_AN_nfe_male:
+              type: integer
+            non_topmed_AF_nfe_male:
+              type: half_float
+            non_topmed_nhomalt_nfe_male:
+              type: integer
+            AN_eas:
+              type: integer
+            AF_eas:
+              type: half_float
+            nhomalt_eas:
+              type: integer
+            nhomalt:
+              type: integer
+            non_neuro_AN_nfe_female:
+              type: integer
+            non_neuro_AF_nfe_female:
+              type: half_float
+            non_neuro_nhomalt_nfe_female:
+              type: integer
+            non_neuro_AN_afr:
+              type: integer
+            non_neuro_AF_afr:
+              type: half_float
+            non_neuro_nhomalt_afr:
+              type: half_float
+            controls_AN_raw:
+              type: integer
+            controls_AF_raw:
+              type: half_float
+            controls_nhomalt_raw:
+              type: integer
+            controls_AN_male:
+              type: integer
+            controls_AF_male:
+              type: half_float
+            controls_nhomalt_male:
+              type: integer
+            non_topmed_AN_male:
+              type: integer
+            non_topmed_AF_male:
+              type: half_float
+            non_topmed_nhomalt_male:
+              type: integer
+            controls_AN_nfe_female:
+              type: integer
+            controls_AF_nfe_female:
+              type: half_float
+            controls_nhomalt_nfe_female:
+              type: integer
+            non_neuro_AN_amr:
+              type: integer
+            non_neuro_AF_amr:
+              type: half_float
+            non_neuro_nhomalt_amr:
+              type: integer
+            non_neuro_AN_eas_female:
+              type: integer
+            non_neuro_AF_eas_female:
+              type: half_float
+            non_neuro_nhomalt_eas_female:
+              type: integer
+            AN_asj_male:
+              type: integer
+            AF_asj_male:
+              type: half_float
+            nhomalt_asj_male:
+              type: integer
+            controls_AN_nfe_male:
+              type: integer
+            controls_AF_nfe_male:
+              type: half_float
+            controls_nhomalt_nfe_male:
+              type: integer
+            non_neuro_AN_fin:
+              type: integer
+            non_neuro_AF_fin:
+              type: half_float
+            non_neuro_nhomalt_fin:
+              type: integer
+            AN_oth_female:
+              type: integer
+            AF_oth_female:
+              type: half_float
+            nhomalt_oth_female:
+              type: integer
+            controls_AN_nfe:
+              type: integer
+            controls_AF_nfe:
+              type: half_float
+            controls_nhomalt_nfe:
+              type: integer
+            controls_AN_oth_female:
+              type: integer
+            controls_AF_oth_female:
+              type: half_float
+            controls_nhomalt_oth_female:
+              type: integer
+            controls_AN_asj:
+              type: integer
+            controls_AF_asj:
+              type: half_float
+            controls_nhomalt_asj:
+              type: integer
+            non_neuro_AN_amr_male:
+              type: integer
+            non_neuro_AF_amr_male:
+              type: half_float
+            non_neuro_nhomalt_amr_male:
+              type: integer
+            controls_AN_nfe_nwe:
+              type: integer
+            controls_AF_nfe_nwe:
+              type: half_float
+            controls_nhomalt_nfe_nwe:
+              type: integer
+            AN_nfe_nwe:
+              type: integer
+            AF_nfe_nwe:
+              type: half_float
+            nhomalt_nfe_nwe:
+              type: integer
+            controls_AN_nfe_seu:
+              type: integer
+            controls_AF_nfe_seu:
+              type: half_float
+            controls_nhomalt_nfe_seu:
+              type: integer
+            non_neuro_AN_amr_female:
+              type: integer
+            non_neuro_AF_amr_female:
+              type: half_float
+            non_neuro_nhomalt_amr_female:
+              type: integer
+            non_neuro_AN_nfe_onf:
+              type: integer
+            non_neuro_AF_nfe_onf:
+              type: half_float
+            non_neuro_nhomalt_nfe_onf:
+              type: integer
+            non_topmed_AN_eas_male:
+              type: integer
+            non_topmed_AF_eas_male:
+              type: half_float
+            non_topmed_nhomalt_eas_male:
+              type: integer
+            controls_AN_amr_female:
+              type: integer
+            controls_AF_amr_female:
+              type: half_float
+            controls_nhomalt_amr_female:
+              type: integer
+            non_neuro_AN_fin_male:
+              type: integer
+            non_neuro_AF_fin_male:
+              type: half_float
+            non_neuro_nhomalt_fin_male:
+              type: integer
+            AN_female:
+              type: integer
+            AF_female:
+              type: half_float
+            nhomalt_female:
+              type: integer
+            non_neuro_AN_oth_male:
+              type: integer
+            non_neuro_AF_oth_male:
+              type: half_float
+            non_neuro_nhomalt_oth_male:
+              type: integer
+            non_topmed_AN_nfe_est:
+              type: integer
+            non_topmed_AF_nfe_est:
+              type: half_float
+            non_topmed_nhomalt_nfe_est:
+              type: integer
+            non_topmed_AN_nfe_nwe:
+              type: integer
+            non_topmed_AF_nfe_nwe:
+              type: half_float
+            non_topmed_nhomalt_nfe_nwe:
+              type: integer
+            non_topmed_AN_amr_male:
+              type: integer
+            non_topmed_AF_amr_male:
+              type: half_float
+            non_topmed_nhomalt_amr_male:
+              type: integer
+            non_topmed_AN_nfe_onf:
+              type: integer
+            non_topmed_AF_nfe_onf:
+              type: half_float
+            non_topmed_nhomalt_nfe_onf:
+              type: integer
+            controls_AN_eas_male:
+              type: integer
+            controls_AF_eas_male:
+              type: half_float
+            controls_nhomalt_eas_male:
+              type: integer
+            controls_AN_oth_male:
+              type: integer
+            controls_AF_oth_male:
+              type: half_float
+            controls_nhomalt_oth_male:
+              type: integer
+            non_topmed_AN:
+              type: integer
+            non_topmed_AF:
+              type: half_float
+            non_topmed_nhomalt:
+              type: integer
+            controls_AN_fin:
+              type: integer
+            controls_AF_fin:
+              type: half_float
+            controls_nhomalt_fin:
+              type: integer
+            non_neuro_AN_nfe:
+              type: integer
+            non_neuro_AF_nfe:
+              type: half_float
+            non_neuro_nhomalt_nfe:
+              type: integer
+            non_neuro_AN_fin_female:
+              type: integer
+            non_neuro_AF_fin_female:
+              type: half_float
+            non_neuro_nhomalt_fin_female:
+              type: integer
+            non_topmed_AN_nfe_seu:
+              type: integer
+            non_topmed_AF_nfe_seu:
+              type: half_float
+            non_topmed_nhomalt_nfe_seu:
+              type: integer
+            controls_AN_eas_female:
+              type: integer
+            controls_AF_eas_female:
+              type: half_float
+            controls_nhomalt_eas_female:
+              type: integer
+            non_topmed_AN_asj:
+              type: integer
+            non_topmed_AF_asj:
+              type: half_float
+            non_topmed_nhomalt_asj:
+              type: integer
+            controls_AN_nfe_onf:
+              type: integer
+            controls_AF_nfe_onf:
+              type: half_float
+            controls_nhomalt_nfe_onf:
+              type: integer
+            non_neuro_AN:
+              type: integer
+            non_neuro_AF:
+              type: half_float
+            non_neuro_nhomalt:
+              type: integer
+            non_topmed_AN_nfe:
+              type: integer
+            non_topmed_AF_nfe:
+              type: half_float
+            non_topmed_nhomalt_nfe:
+              type: integer
+            non_topmed_AN_raw:
+              type: integer
+            non_topmed_AF_raw:
+              type: half_float
+            non_topmed_nhomalt_raw:
+              type: integer
+            non_neuro_AN_nfe_est:
+              type: integer
+            non_neuro_AF_nfe_est:
+              type: half_float
+            non_neuro_nhomalt_nfe_est:
+              type: integer
+            non_topmed_AN_oth_male:
+              type: integer
+            non_topmed_AF_oth_male:
+              type: half_float
+            non_topmed_nhomalt_oth_male:
+              type: integer
+            AN_nfe_est:
+              type: integer
+            AF_nfe_est:
+              type: half_float
+            nhomalt_nfe_est:
+              type: integer
+            non_topmed_AN_afr_male:
+              type: integer
+            non_topmed_AF_afr_male:
+              type: half_float
+            non_topmed_nhomalt_afr_male:
+              type: half_float
+            AN_eas_male:
+              type: integer
+            AF_eas_male:
+              type: half_float
+            nhomalt_eas_male:
+              type: integer
+            controls_AN_eas:
+              type: integer
+            controls_AF_eas:
+              type: half_float
+            controls_nhomalt_eas:
+              type: integer
+            non_neuro_AN_eas_male:
+              type: integer
+            non_neuro_AF_eas_male:
+              type: half_float
+            non_neuro_nhomalt_eas_male:
+              type: integer
+            non_neuro_AN_asj_male:
+              type: integer
+            non_neuro_AF_asj_male:
+              type: half_float
+            non_neuro_nhomalt_asj_male:
+              type: integer
+            controls_AN_oth:
+              type: integer
+            controls_AF_oth:
+              type: half_float
+            controls_nhomalt_oth:
+              type: integer
+            AN_nfe:
+              type: integer
+            AF_nfe:
+              type: half_float
+            nhomalt_nfe:
+              type: integer
+            non_topmed_AN_female:
+              type: integer
+            non_topmed_AF_female:
+              type: half_float
+            non_topmed_nhomalt_female:
+              type: integer
+            non_neuro_AN_asj:
+              type: integer
+            non_neuro_AF_asj:
+              type: half_float
+            non_neuro_nhomalt_asj:
+              type: integer
+            non_topmed_AN_eas_female:
+              type: integer
+            non_topmed_AF_eas_female:
+              type: half_float
+            non_topmed_nhomalt_eas_female:
+              type: integer
+            non_neuro_AN_raw:
+              type: integer
+            non_neuro_AF_raw:
+              type: half_float
+            non_neuro_nhomalt_raw:
+              type: integer
+            non_topmed_AN_eas:
+              type: integer
+            non_topmed_AF_eas:
+              type: half_float
+            non_topmed_nhomalt_eas:
+              type: integer
+            non_topmed_AN_fin_male:
+              type: integer
+            non_topmed_AF_fin_male:
+              type: half_float
+            non_topmed_nhomalt_fin_male:
+              type: integer
+            AN_fin:
+              type: integer
+            AF_fin:
+              type: half_float
+            nhomalt_fin:
+              type: integer
+            AN_nfe_male:
+              type: integer
+            AF_nfe_male:
+              type: half_float
+            nhomalt_nfe_male:
+              type: integer
+            controls_AN_amr_male:
+              type: integer
+            controls_AF_amr_male:
+              type: half_float
+            controls_nhomalt_amr_male:
+              type: integer
+            controls_AN_afr_female:
+              type: integer
+            controls_AF_afr_female:
+              type: half_float
+            controls_nhomalt_afr_female:
+              type: half_float
+            controls_AN_amr:
+              type: integer
+            controls_AF_amr:
+              type: half_float
+            controls_nhomalt_amr:
+              type: integer
+            AN_asj_female:
+              type: integer
+            AF_asj_female:
+              type: half_float
+            nhomalt_asj_female:
+              type: integer
+            non_neuro_AN_eas:
+              type: integer
+            non_neuro_AF_eas:
+              type: half_float
+            non_neuro_nhomalt_eas:
+              type: integer
+            non_neuro_AN_male:
+              type: integer
+            non_neuro_AF_male:
+              type: half_float
+            non_neuro_nhomalt_male:
+              type: integer
+            AN_asj:
+              type: integer
+            AF_asj:
+              type: half_float
+            nhomalt_asj:
+              type: integer
+            controls_AN_nfe_est:
+              type: integer
+            controls_AF_nfe_est:
+              type: half_float
+            controls_nhomalt_nfe_est:
+              type: integer
+            non_topmed_AN_asj_female:
+              type: integer
+            non_topmed_AF_asj_female:
+              type: half_float
+            non_topmed_nhomalt_asj_female:
+              type: integer
+            non_topmed_AN_oth:
+              type: integer
+            non_topmed_AF_oth:
+              type: half_float
+            non_topmed_nhomalt_oth:
+              type: integer
+            non_topmed_AN_fin_female:
+              type: integer
+            non_topmed_AF_fin_female:
+              type: half_float
+            non_topmed_nhomalt_fin_female:
+              type: integer
+            AN_oth:
+              type: integer
+            AF_oth:
+              type: half_float
+            nhomalt_oth:
+              type: integer
+            non_neuro_AN_nfe_male:
+              type: integer
+            non_neuro_AF_nfe_male:
+              type: half_float
+            non_neuro_nhomalt_nfe_male:
+              type: integer
+            controls_AN_female:
+              type: integer
+            controls_AF_female:
               type: half_float
         exomes:
           properties:
@@ -632,68 +1081,600 @@ mappings:
             id:
               type: keyword
               normalizer: lowercase_normalizer
-            trTv:
-              type: byte
-            ac:
-                type: integer
-            af:
-              type: half_float
-            an:
+            AN:
               type: integer
-            ac_afr:
-                type: integer
-            ac_amr:
-                type: integer
-            ac_asj:
-                type: integer
-            ac_eas:
-                type: integer
-            ac_fin:
-                type: integer
-            ac_nfe:
-                type: integer
-            ac_oth:
-                type: integer
-            ac_male:
-                type: integer
-            ac_female:
-                type: integer
-            an_afr:
-              type: integer
-            an_amr:
-              type: integer
-            an_asj:
-              type: integer
-            an_eas:
-              type: integer
-            an_fin:
-              type: integer
-            an_nfe:
-              type: integer
-            an_oth:
-              type: integer
-            an_male:
-              type: integer
-            an_female:
-              type: integer
-            af_afr:
+            AF:
               type: half_float
-            af_amr:
+            AN_nfe_seu:
+              type: integer
+            AF_nfe_seu:
               type: half_float
-            af_asj:
+            nhomalt_nfe_seu:
+              type: integer
+            controls_AN_afr_male:
+              type: integer
+            controls_AF_afr_male:
               type: half_float
-            af_eas:
+            controls_nhomalt_afr_male:
               type: half_float
-            af_fin:
+            non_neuro_AN_eas_kor:
+              type: integer
+            non_neuro_AF_eas_kor:
               type: half_float
-            af_nfe:
+            non_neuro_nhomalt_eas_kor:
+              type: integer
+            non_topmed_AN_amr:
+              type: integer
+            non_topmed_AF_amr:
               type: half_float
-            af_oth:
+            non_topmed_nhomalt_amr:
+              type: integer
+            non_cancer_AN_asj_female:
+              type: integer
+            non_cancer_AF_asj_female:
+              type: integer
+            non_cancer_nhomalt_asj_female:
+              type: integer
+            AN_raw:
+              type: integer
+            AF_raw:
               type: half_float
-            af_male:
+            nhomalt_raw:
+              type: integer
+            AN_fin_female:
+              type: integer
+            AF_fin_female:
               type: half_float
-            af_female:
+            nhomalt_fin_female:
+              type: integer
+            non_cancer_AN_oth_female:
+              type: integer
+            non_cancer_AF_oth_female:
+              type: integer
+            non_cancer_nhomalt_oth_female:
+              type: integer
+            AN_nfe_bgr:
+              type: integer
+            AF_nfe_bgr:
               type: half_float
+            nhomalt_nfe_bgr:
+              type: integer
+            non_neuro_AN_asj_female:
+              type: integer
+            non_neuro_AF_asj_female:
+              type: half_float
+            non_neuro_nhomalt_asj_female:
+              type: integer
+            AN_sas_male:
+              type: integer
+            AF_sas_male:
+              type: half_float
+            nhomalt_sas_male:
+              type: integer
+            non_neuro_AN_afr_male:
+              type: integer
+            non_neuro_AF_afr_male:
+              type: half_float
+            non_neuro_nhomalt_afr_male:
+              type: half_float
+            AN_afr_male:
+              type: integer
+            AF_afr_male:
+              type: half_float
+            nhomalt_afr_male:
+              type: half_float
+            AN_afr:
+              type: integer
+            AF_afr:
+              type: half_float
+            nhomalt_afr:
+              type: half_float
+            controls_AN_nfe_swe:
+              type: integer
+            controls_AF_nfe_swe:
+              type: half_float
+            controls_nhomalt_nfe_swe:
+              type: integer
+            non_neuro_AN_afr_female:
+              type: integer
+            non_neuro_AF_afr_female:
+              type: half_float
+            non_neuro_nhomalt_afr_female:
+              type: half_float
+            non_topmed_AN_amr_female:
+              type: integer
+            non_topmed_AF_amr_female:
+              type: half_float
+            non_topmed_nhomalt_amr_female:
+              type: integer
+            non_cancer_AN_female:
+              type: integer
+            non_cancer_AF_female:
+              type: integer
+            non_cancer_nhomalt_female:
+              type: integer
+            non_cancer_AN_nfe_onf:
+              type: integer
+            non_cancer_AF_nfe_onf:
+              type: integer
+            non_cancer_nhomalt_nfe_onf:
+              type: integer
+            non_cancer_AN_male:
+              type: integer
+            non_cancer_AF_male:
+              type: integer
+            non_cancer_nhomalt_male:
+              type: integer
+            non_topmed_AN_oth_female:
+              type: integer
+            non_topmed_AF_oth_female:
+              type: half_float
+            non_topmed_nhomalt_oth_female:
+              type: integer
+            AN_eas_female:
+              type: integer
+            AF_eas_female:
+              type: half_float
+            nhomalt_eas_female:
+              type: integer
+            non_cancer_AN_sas_female:
+              type: integer
+            non_cancer_AF_sas_female:
+              type: integer
+            non_cancer_nhomalt_sas_female:
+              type: integer
+            AN_afr_female:
+              type: integer
+            AF_afr_female:
+              type: half_float
+            nhomalt_afr_female:
+              type: half_float
+            AN_sas:
+              type: integer
+            AF_sas:
+              type: half_float
+            nhomalt_sas:
+              type: integer
+            non_neuro_AN_female:
+              type: integer
+            non_neuro_AF_female:
+              type: half_float
+            non_neuro_nhomalt_female:
+              type: integer
+            controls_AN_afr:
+              type: integer
+            controls_AF_afr:
+              type: half_float
+            controls_nhomalt_afr:
+              type: half_float
+            non_neuro_AN_eas_jpn:
+              type: integer
+            non_neuro_AF_eas_jpn:
+              type: half_float
+            non_neuro_nhomalt_eas_jpn:
+              type: integer
+            AN_nfe_onf:
+              type: integer
+            AF_nfe_onf:
+              type: half_float
+            nhomalt_nfe_onf:
+              type: integer
+            non_cancer_AN_amr_male:
+              type: integer
+            non_cancer_AF_amr_male:
+              type: integer
+            non_cancer_nhomalt_amr_male:
+              type: integer
+            controls_AN_fin_male:
+              type: integer
+            controls_AF_fin_male:
+              type: half_float
+            controls_nhomalt_fin_male:
+              type: integer
+            non_neuro_AN_nfe_nwe:
+              type: integer
+            non_neuro_AF_nfe_nwe:
+              type: half_float
+            non_neuro_nhomalt_nfe_nwe:
+              type: integer
+            AN_fin_male:
+              type: integer
+            AF_fin_male:
+              type: half_float
+            nhomalt_fin_male:
+              type: integer
+            AN_nfe_female:
+              type: integer
+            AF_nfe_female:
+              type: half_float
+            nhomalt_nfe_female:
+              type: integer
+            AN_amr:
+              type: integer
+            AF_amr:
+              type: half_float
+            nhomalt_amr:
+              type: integer
+            non_topmed_AN_nfe_male:
+              type: integer
+            non_topmed_AF_nfe_male:
+              type: half_float
+            non_topmed_nhomalt_nfe_male:
+              type: integer
+            non_neuro_AN_sas:
+              type: integer
+            non_neuro_AF_sas:
+              type: half_float
+            non_neuro_nhomalt_sas:
+              type: integer
+            non_cancer_AN_fin_male:
+              type: integer
+            non_cancer_AF_fin_male:
+              type: integer
+            non_cancer_nhomalt_fin_male:
+              type: integer
+            non_cancer_AN_nfe_seu:
+              type: integer
+            non_cancer_AF_nfe_seu:
+              type: integer
+            non_cancer_nhomalt_nfe_seu:
+              type: integer
+            AN_eas:
+              type: integer
+            AF_eas:
+              type: half_float
+            nhomalt_eas:
+              type: integer
+            nhomalt:
+              type: integer
+            non_neuro_AN_nfe_female:
+              type: integer
+            non_neuro_AF_nfe_female:
+              type: half_float
+            non_neuro_nhomalt_nfe_female:
+              type: integer
+            non_neuro_AN_afr:
+              type: integer
+            non_neuro_AF_afr:
+              type: half_float
+            non_neuro_nhomalt_afr:
+              type: half_float
+            controls_AN_raw:
+              type: integer
+            controls_AF_raw:
+              type: half_float
+            controls_nhomalt_raw:
+              type: integer
+            non_cancer_AN_eas:
+              type: integer
+            non_cancer_AF_eas:
+              type: integer
+            non_cancer_nhomalt_eas:
+              type: integer
+            non_cancer_AN_amr_female:
+              type: integer
+            non_cancer_AF_amr_female:
+              type: integer
+            non_cancer_nhomalt_amr_female:
+              type: integer
+            non_neuro_AN_nfe_swe:
+              type: integer
+            non_neuro_AF_nfe_swe:
+              type: half_float
+            non_neuro_nhomalt_nfe_swe:
+              type: integer
+            controls_AN_male:
+              type: integer
+            controls_AF_male:
+              type: half_float
+            controls_nhomalt_male:
+              type: integer
+            non_topmed_AN_male:
+              type: integer
+            non_topmed_AF_male:
+              type: half_float
+            non_topmed_nhomalt_male:
+              type: integer
+            controls_AN_eas_jpn:
+              type: integer
+            controls_AF_eas_jpn:
+              type: half_float
+            controls_nhomalt_eas_jpn:
+              type: integer
+            controls_AN_nfe_female:
+              type: integer
+            controls_AF_nfe_female:
+              type: half_float
+            controls_nhomalt_nfe_female:
+              type: integer
+            non_neuro_AN_amr:
+              type: integer
+            non_neuro_AF_amr:
+              type: half_float
+            non_neuro_nhomalt_amr:
+              type: integer
+            non_neuro_AN_eas_female:
+              type: integer
+            non_neuro_AF_eas_female:
+              type: half_float
+            non_neuro_nhomalt_eas_female:
+              type: integer
+            AN_asj_male:
+              type: integer
+            AF_asj_male:
+              type: half_float
+            nhomalt_asj_male:
+              type: integer
+            controls_AN_nfe_male:
+              type: integer
+            controls_AF_nfe_male:
+              type: half_float
+            controls_nhomalt_nfe_male:
+              type: integer
+            non_neuro_AN_fin:
+              type: integer
+            non_neuro_AF_fin:
+              type: half_float
+            non_neuro_nhomalt_fin:
+              type: integer
+            non_topmed_AN_sas:
+              type: integer
+            non_topmed_AF_sas:
+              type: half_float
+            non_topmed_nhomalt_sas:
+              type: integer
+            non_cancer_AN_nfe_female:
+              type: integer
+            non_cancer_AF_nfe_female:
+              type: integer
+            non_cancer_nhomalt_nfe_female:
+              type: integer
+            AN_oth_female:
+              type: integer
+            AF_oth_female:
+              type: half_float
+            nhomalt_oth_female:
+              type: integer
+            non_cancer_AN_asj:
+              type: integer
+            non_cancer_AF_asj:
+              type: integer
+            non_cancer_nhomalt_asj:
+              type: integer
+            AN_nfe_swe:
+              type: integer
+            AF_nfe_swe:
+              type: half_float
+            nhomalt_nfe_swe:
+              type: integer
+            controls_AN_nfe:
+              type: integer
+            controls_AF_nfe:
+              type: half_float
+            controls_nhomalt_nfe:
+              type: integer
+            controls_AN_oth_female:
+              type: integer
+            controls_AF_oth_female:
+              type: half_float
+            controls_nhomalt_oth_female:
+              type: integer
+            controls_AN_asj:
+              type: integer
+            controls_AF_asj:
+              type: half_float
+            controls_nhomalt_asj:
+              type: integer
+            non_neuro_AN_amr_male:
+              type: integer
+            non_neuro_AF_amr_male:
+              type: half_float
+            non_neuro_nhomalt_amr_male:
+              type: integer
+            controls_AN_nfe_nwe:
+              type: integer
+            controls_AF_nfe_nwe:
+              type: half_float
+            controls_nhomalt_nfe_nwe:
+              type: integer
+            AN_nfe_nwe:
+              type: integer
+            AF_nfe_nwe:
+              type: half_float
+            nhomalt_nfe_nwe:
+              type: integer
+            controls_AN_nfe_seu:
+              type: integer
+            controls_AF_nfe_seu:
+              type: half_float
+            controls_nhomalt_nfe_seu:
+              type: integer
+            controls_AN_sas_female:
+              type: integer
+            controls_AF_sas_female:
+              type: half_float
+            controls_nhomalt_sas_female:
+              type: integer
+            non_neuro_AN_amr_female:
+              type: integer
+            non_neuro_AF_amr_female:
+              type: half_float
+            non_neuro_nhomalt_amr_female:
+              type: integer
+            non_cancer_AN_eas_jpn:
+              type: integer
+            non_cancer_AF_eas_jpn:
+              type: integer
+            non_cancer_nhomalt_eas_jpn:
+              type: integer
+            non_neuro_AN_nfe_onf:
+              type: integer
+            non_neuro_AF_nfe_onf:
+              type: half_float
+            non_neuro_nhomalt_nfe_onf:
+              type: integer
+            non_topmed_AN_eas_male:
+              type: integer
+            non_topmed_AF_eas_male:
+              type: half_float
+            non_topmed_nhomalt_eas_male:
+              type: integer
+            AN_eas_jpn:
+              type: integer
+            AF_eas_jpn:
+              type: half_float
+            nhomalt_eas_jpn:
+              type: integer
+            non_cancer_AN_afr_male:
+              type: integer
+            non_cancer_AF_afr_male:
+              type: integer
+            non_cancer_nhomalt_afr_male:
+              type: integer
+            non_cancer_AN_afr:
+              type: integer
+            non_cancer_AF_afr:
+              type: integer
+            non_cancer_nhomalt_afr:
+              type: integer
+            controls_AN_amr_female:
+              type: integer
+            controls_AF_amr_female:
+              type: half_float
+            controls_nhomalt_amr_female:
+              type: integer
+            non_neuro_AN_fin_male:
+              type: integer
+            non_neuro_AF_fin_male:
+              type: half_float
+            non_neuro_nhomalt_fin_male:
+              type: integer
+            AN_female:
+              type: integer
+            AF_female:
+              type: half_float
+            nhomalt_female:
+              type: integer
+            non_neuro_AN_nfe_bgr:
+              type: integer
+            non_neuro_AF_nfe_bgr:
+              type: half_float
+            non_neuro_nhomalt_nfe_bgr:
+              type: integer
+            non_neuro_AN_oth_male:
+              type: integer
+            non_neuro_AF_oth_male:
+              type: half_float
+            non_neuro_nhomalt_oth_male:
+              type: integer
+            non_topmed_AN_nfe_est:
+              type: integer
+            non_topmed_AF_nfe_est:
+              type: half_float
+            non_topmed_nhomalt_nfe_est:
+              type: integer
+            non_topmed_AN_nfe_nwe:
+              type: integer
+            non_topmed_AF_nfe_nwe:
+              type: half_float
+            non_topmed_nhomalt_nfe_nwe:
+              type: integer
+            non_topmed_AN_amr_male:
+              type: integer
+            non_topmed_AF_amr_male:
+              type: half_float
+            non_topmed_nhomalt_amr_male:
+              type: integer
+            non_cancer_AN_amr:
+              type: integer
+            non_cancer_AF_amr:
+              type: integer
+            non_cancer_nhomalt_amr:
+              type: integer
+            non_topmed_AN_nfe_swe:
+              type: integer
+            non_topmed_AF_nfe_swe:
+              type: half_float
+            non_topmed_nhomalt_nfe_swe:
+              type: integer
+            non_topmed_AN_nfe_onf:
+              type: integer
+            non_topmed_AF_nfe_onf:
+              type: half_float
+            non_topmed_nhomalt_nfe_onf:
+              type: integer
+            controls_AN_eas_kor:
+              type: integer
+            controls_AF_eas_kor:
+              type: half_float
+            controls_nhomalt_eas_kor:
+              type: integer
+            non_topmed_AN_eas_oea:
+              type: integer
+            non_topmed_AF_eas_oea:
+              type: half_float
+            non_topmed_nhomalt_eas_oea:
+              type: integer
+            controls_AN_eas_male:
+              type: integer
+            controls_AF_eas_male:
+              type: half_float
+            controls_nhomalt_eas_male:
+              type: integer
+            controls_AN_oth_male:
+              type: integer
+            controls_AF_oth_male:
+              type: half_float
+            controls_nhomalt_oth_male:
+              type: integer
+            non_topmed_AN:
+              type: integer
+            non_topmed_AF:
+              type: half_float
+            non_topmed_nhomalt:
+              type: integer
+            controls_AN_fin:
+              type: integer
+            controls_AF_fin:
+              type: half_float
+            controls_nhomalt_fin:
+              type: integer
+            AN_eas_kor:
+              type: integer
+            AF_eas_kor:
+              type: half_float
+            nhomalt_eas_kor:
+              type: integer
+            non_neuro_AN_nfe:
+              type: integer
+            non_neuro_AF_nfe:
+              type: half_float
+            non_neuro_nhomalt_nfe:
+              type: integer
+            non_neuro_AN_fin_female:
+              type: integer
+            non_neuro_AF_fin_female:
+              type: half_float
+            non_neuro_nhomalt_fin_female:
+              type: integer
+            non_cancer_AN_nfe_male:
+              type: integer
+            non_cancer_AF_nfe_male:
+              type: integer
+            non_cancer_nhomalt_nfe_male:
+              type: integer
+            controls_AN_eas_oea:
+              type: integer
+            controls_AF_eas_oea:
+              type: half_float
+            controls_nhomalt_eas_oea:
+              type: integer
+            non_topmed_AN_nfe_seu:
+              type: integer
+            non_topmed_AF_nfe_seu:
+              type: half_float
+            non_topmed_nhomalt_nfe_seu:
+              type: integer
     cosmic:
       properties:
         coding:

--- a/install/install-perl-libs.sh
+++ b/install/install-perl-libs.sh
@@ -22,6 +22,7 @@ cpanm install Cpanel::JSON::XS
 cpanm install Mouse::Meta::Attribute::Custom::Trait::Array
 cpanm install Net::HTTP
 cpanm install Math::SigFigs
+cpanm install Search::Elasticsearch@7.713
 # For now we use our own library
 # Avoid issues with system liblmdb
 env ALIEN_INSTALL_TYPE=share cpanm Alien::LMDB

--- a/perl/bin/bystro-index-server.pl
+++ b/perl/bin/bystro-index-server.pl
@@ -31,34 +31,36 @@ use SeqElastic;
 
 # usage
 # Debug like verbose, but isn't passed through to SeqElastic
-my ($verbose, $queueConfigPath, $connectionConfigPath, $maxThreads, $debug);
+my ( $verbose, $queueConfigPath, $connectionConfigPath, $maxThreads, $debug );
 
 GetOptions(
-  'v|verbose=i'   => \$verbose,
-  'd|debug'      => \$debug,
-  'q|queueConfig=s'   => \$queueConfigPath,
-  'c|connectionConfig=s' => \$connectionConfigPath,
-  'm|maxThreads=i' => \$maxThreads,
+    'v|verbose=i'          => \$verbose,
+    'd|debug'              => \$debug,
+    'q|queueConfig=s'      => \$queueConfigPath,
+    'c|connectionConfig=s' => \$connectionConfigPath,
+    'm|maxThreads=i'       => \$maxThreads,
 );
 
-if ( !($queueConfigPath && $connectionConfigPath) ) {
-  # Generate a help strings taht shows the arguments
-  say "\nUsage: perl $0 -q <queueConfigPath> -c <connectionConfigPath> --maxThreads <maxThreads> --verbose <level> --debug\n";
-  exit 1;
+if ( !( $queueConfigPath && $connectionConfigPath ) ) {
+
+    # Generate a help strings taht shows the arguments
+    say
+"\nUsage: perl $0 -q <queueConfigPath> -c <connectionConfigPath> --maxThreads <maxThreads> --verbose <level> --debug\n";
+    exit 1;
 }
 
-my $conf = LoadFile($queueConfigPath);
+my $conf             = LoadFile($queueConfigPath);
 my $connectionConfig = LoadFile($connectionConfigPath);
 
 # Beanstalk servers will be sharded
-my $beanstalkHost  = $conf->{beanstalk_host_1};
-my $beanstalkPort  = $conf->{beanstalk_port_1};
+my $beanstalkHost = $conf->{beanstalk_host_1};
+my $beanstalkPort = $conf->{beanstalk_port_1};
 
 # Required fields
 # The annotation_file_path is constructed from inputDir, inputFileNames by SeqElastic
 my @requiredJobFields = qw/indexName inputDir inputFileNames assembly/;
 
-my $configPathBaseDir = "config/";
+my $configPathBaseDir  = "config/";
 my $configFilePathHref = {};
 use DDP;
 
@@ -69,193 +71,204 @@ my $FAILED    = "failed";
 my $STARTED   = "started";
 my $COMPLETED = "completed";
 
-my $beanstalk = Beanstalk::Client->new({
-  server    => $conf->{beanstalkd}{addresses}[0],
-  default_tube => $queueConfig->{submission},
-  connect_timeout => 1,
-  encoder => sub { encode_json(\@_) },
-  decoder => sub { @{decode_json(shift)} },
-});
+my $beanstalk = Beanstalk::Client->new(
+    {
+        server          => $conf->{beanstalkd}{addresses}[0],
+        default_tube    => $queueConfig->{submission},
+        connect_timeout => 1,
+        encoder         => sub { encode_json( \@_ ) },
+        decoder         => sub { @{ decode_json(shift) } },
+    }
+);
 
-my $beanstalkEvents = Beanstalk::Client->new({
-  server    => $conf->{beanstalkd}{addresses}[0],
-  default_tube => $queueConfig->{events},
-  connect_timeout => 1,
-  encoder => sub { encode_json(\@_) },
-  decoder => sub { @{decode_json(shift)} },
-});
+my $beanstalkEvents = Beanstalk::Client->new(
+    {
+        server          => $conf->{beanstalkd}{addresses}[0],
+        default_tube    => $queueConfig->{events},
+        connect_timeout => 1,
+        encoder         => sub { encode_json( \@_ ) },
+        decoder         => sub { @{ decode_json(shift) } },
+    }
+);
 
 my $events = $conf->{beanstalkd}{events};
 
-while(my $job = $beanstalk->reserve) {
-  # Parallel ForkManager used only to throttle number of jobs run in parallel
-  # cannot use run_on_finish with blocking reserves, use try catch instead
-  # Also using forks helps clean up leaked memory from LMDB_File
-  # Unfortunately, parallel fork manager doesn't play nicely with try tiny
-  # prevents anything within the try from executing
+while ( my $job = $beanstalk->reserve ) {
 
-  my $jobDataHref;
-  my ($err, $fieldNames, $searchConfigHashRef);
+    # Parallel ForkManager used only to throttle number of jobs run in parallel
+    # cannot use run_on_finish with blocking reserves, use try catch instead
+    # Also using forks helps clean up leaked memory from LMDB_File
+    # Unfortunately, parallel fork manager doesn't play nicely with try tiny
+    # prevents anything within the try from executing
 
-  try {
-    $jobDataHref = decode_json( $job->data );
+    my $jobDataHref;
+    my ( $err, $fieldNames, $searchConfigHashRef );
 
-    $beanstalkEvents->put(
-      {
-        priority => 0,
-        data     => encode_json(
-          {
-            event        => $STARTED,
-            submissionID => $jobDataHref->{submissionID},
-            queueID      => $job->id,
-          }
-        )
-      }
-    );
+    try {
+        $jobDataHref = decode_json( $job->data );
 
-    ($err, $fieldNames, $searchConfigHashRef) = handleJob($jobDataHref, $job->id);
+        $beanstalkEvents->put(
+            {
+                priority => 0,
+                data     => encode_json(
+                    {
+                        event        => $STARTED,
+                        submissionID => $jobDataHref->{submissionID},
+                        queueID      => $job->id,
+                    }
+                )
+            }
+        );
 
-  } catch {      
-    # Don't store the stack
-    $err = $_; #substr($_, 0, index($_, 'at'));
-  };
+        ( $err, $fieldNames, $searchConfigHashRef ) =
+          handleJob( $jobDataHref, $job->id );
 
-  if ($err) {
-    if(defined $verbose || defined $debug) {
-      say "job ". $job->id . " failed due to found error";
-      p $err;
     }
-
-    my $message;
-
-    if(ref $err eq 'Search::Elasticsearch::Error::Request') {
-      $message = $err->{vars}{body}{error}{reason};
-    }
-
-    my $data = {
-      event        => $FAILED,
-      reason       => $err,
-      queueID      => $job->id,
-      submissionID => $jobDataHref->{submissionID},
+    catch {
+        # Don't store the stack
+        $err = $_;    #substr($_, 0, index($_, 'at'));
     };
+
+    if ($err) {
+        if ( defined $verbose || defined $debug ) {
+            say "job " . $job->id . " failed due to found error";
+            p $err;
+        }
+
+        my $message;
+
+        if ( ref $err eq 'Search::Elasticsearch::Error::Request' ) {
+            $message = $err->{vars}{body}{error}{reason};
+        }
+
+        my $data = {
+            event        => $FAILED,
+            reason       => $err,
+            queueID      => $job->id,
+            submissionID => $jobDataHref->{submissionID},
+        };
+
+        $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
+
+        $job->bury;
+
+        next;
+    }
+
+    # Signal completion before completion actually occurs via delete
+    # To be conservative; since after delete message is lost
+    my $data = {
+        event        => $COMPLETED,
+        queueID      => $job->id,
+        submissionID => $jobDataHref->{submissionID},
+        results      => {
+            fieldNames  => $fieldNames,
+            indexConfig => $searchConfigHashRef,
+        }
+    };
+
+    if ( defined $debug ) {
+        say STDERR "putting completiong event";
+        p $data;
+    }
 
     $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
 
-    $job->bury; 
+    $job->delete();
 
-    next;
-  }
-
-  # Signal completion before completion actually occurs via delete
-  # To be conservative; since after delete message is lost
-  my $data = {
-    event        => $COMPLETED,
-    queueID      => $job->id,
-    submissionID => $jobDataHref->{submissionID},
-    results => {
-        fieldNames => $fieldNames,
-        indexConfig => $searchConfigHashRef,
-    }
-  };
- 
- if ( defined $debug ) {
-    say STDERR "putting completiong event";
-    p $data;
-  }
-
-  $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
-
-  $job->delete();
-
-  say "completed job with queue id " . $job->id;
+    say "completed job with queue id " . $job->id;
 }
 
 sub handleJob {
-  my $submittedJob = shift;
-  my $queueID = shift;
+    my $submittedJob = shift;
+    my $queueID      = shift;
 
-  my $failed;
+    my $failed;
 
-  my ($err, $inputHref) = coerceInputs($submittedJob);
+    my ( $err, $inputHref ) = coerceInputs($submittedJob);
 
-  if($err) {
-    say STDERR $err;
-    return ($err, undef);
-  }
+    if ($err) {
+        say STDERR $err;
+        return ( $err, undef );
+    }
 
-  my $log_name = join '.', 'index', 'indexName', $inputHref->{indexName}, 'log';
-  my $logPath = File::Spec->rel2abs( ".", $log_name );
+    my $log_name = join '.', 'index', 'indexName', $inputHref->{indexName},
+      'log';
+    my $logPath = File::Spec->rel2abs( ".", $log_name );
 
-  if($maxThreads) {
-    $inputHref->{max_threads} = $maxThreads;
-  }
+    if ($maxThreads) {
+        $inputHref->{max_threads} = $maxThreads;
+    }
 
-  $inputHref->{logPath} = $logPath;
-  $inputHref->{verbose} = $verbose;
-  $inputHref->{debug} = $debug;
-  $inputHref->{publisher} = {
-      server      => $conf->{beanstalkd}{addresses}[0],
-      queue       => $queueConfig->{events},
-      messageBase => {
-        event        => $PROGRESS,
-        queueID      => $queueID,
-        submissionID => $submittedJob->{submissionID},
-        data         => undef,
-      }
+    $inputHref->{logPath}   = $logPath;
+    $inputHref->{verbose}   = $verbose;
+    $inputHref->{debug}     = $debug;
+    $inputHref->{publisher} = {
+        server      => $conf->{beanstalkd}{addresses}[0],
+        queue       => $queueConfig->{events},
+        messageBase => {
+            event        => $PROGRESS,
+            queueID      => $queueID,
+            submissionID => $submittedJob->{submissionID},
+            data         => undef,
+        }
     };
 
-  if(defined $verbose || defined $debug) {
-    say "in handle job, jobData is";
-    p $submittedJob;
-    say "writing beanstalk index queue log file here: $logPath";
-  }
+    if ( defined $verbose || defined $debug ) {
+        say "in handle job, jobData is";
+        p $submittedJob;
+        say "writing beanstalk index queue log file here: $logPath";
+    }
 
-  # create the annotator
-  my $indexer = SeqElastic->new($inputHref);
+    # create the annotator
+    my $indexer = SeqElastic->new($inputHref);
 
-  return $indexer->go;
+    return $indexer->go;
 }
 
 #Here we may wish to read a json or yaml file containing argument mappings
 sub coerceInputs {
-  my $jobDetailsHref = shift;
+    my $jobDetailsHref = shift;
 
-  my %return;
-  for my $fieldName (@requiredJobFields) {
-    if(!defined $jobDetailsHref->{$fieldName}) {
-      say STDERR "$fieldName required";
-      return ("$fieldName required", undef);
+    my %return;
+    for my $fieldName (@requiredJobFields) {
+        if ( !defined $jobDetailsHref->{$fieldName} ) {
+            say STDERR "$fieldName required";
+            return ( "$fieldName required", undef );
+        }
+
+        $return{$fieldName} = $jobDetailsHref->{$fieldName};
     }
 
-    $return{$fieldName} = $jobDetailsHref->{$fieldName};
-  }
+    $return{indexConfig} = LoadFile(
+        $configPathBaseDir . $jobDetailsHref->{assembly} . '.mapping.yml' );
+    %return = ( %return, %$connectionConfig );
 
-  $return{indexConfig} = LoadFile($configPathBaseDir . $jobDetailsHref->{assembly} . '.mapping.yml');
-  %return = (%return, %$connectionConfig);
-
-  return (undef, \%return);
+    return ( undef, \%return );
 }
 
 sub getConfigFilePath {
-  my $assembly = shift;
+    my $assembly = shift;
 
-  if ( exists $configFilePathHref->{$assembly} ) {
-    return $configFilePathHref->{$assembly};
-  }
-  else {
-    my @maybePath = glob( $configPathBaseDir . $assembly . ".y*ml" );
-    if ( scalar @maybePath ) {
-      if ( scalar @maybePath > 1 ) {
-        #should log
-        say "\n\nMore than 1 config path found, choosing first";
-      }
-
-      return $maybePath[0];
+    if ( exists $configFilePathHref->{$assembly} ) {
+        return $configFilePathHref->{$assembly};
     }
+    else {
+        my @maybePath = glob( $configPathBaseDir . $assembly . ".y*ml" );
+        if ( scalar @maybePath ) {
+            if ( scalar @maybePath > 1 ) {
 
-    die "\n\nNo config path found for the assembly $assembly. Exiting\n\n";
-    #throws the error
-    #should log here
-  }
+                #should log
+                say "\n\nMore than 1 config path found, choosing first";
+            }
+
+            return $maybePath[0];
+        }
+
+        die "\n\nNo config path found for the assembly $assembly. Exiting\n\n";
+
+        #throws the error
+        #should log here
+    }
 }
 1;

--- a/perl/bin/bystro-index-server.pl
+++ b/perl/bin/bystro-index-server.pl
@@ -1,0 +1,261 @@
+#!/usr/bin/env perl
+# Name:           snpfile_annotate_mongo_redis_queue.pl
+# Description:
+# Date Created:   Wed Dec 24
+# By:             Alex Kotlar
+# Requires: Snpfile::AnnotatorBase
+
+#Todo: Handle job expiration (what happens when job:id expired; make sure no other job operations happen, let Node know via sess:?)
+#There may be much more performant ways of handling this without loss of reliability; loook at just storing entire message in perl, and relying on decode_json
+#Todo: (Probably in Node.js): add failed jobs, and those stuck in processingJobs list for too long, back into job queue, for N attempts (stored in jobs:jobID)
+use 5.10.0;
+use Cpanel::JSON::XS;
+
+use strict;
+use warnings;
+
+use Try::Tiny;
+
+use lib './lib';
+
+use Log::Any::Adapter;
+use File::Basename;
+use Getopt::Long;
+use DDP;
+
+use Beanstalk::Client;
+
+use YAML::XS qw/LoadFile/;
+
+use SeqElastic;
+
+# usage
+# Debug like verbose, but isn't passed through to SeqElastic
+my ($verbose, $queueConfigPath, $connectionConfigPath, $maxThreads, $debug);
+
+GetOptions(
+  'v|verbose=i'   => \$verbose,
+  'd|debug'      => \$debug,
+  'q|queueConfig=s'   => \$queueConfigPath,
+  'c|connectionConfig=s' => \$connectionConfigPath,
+  'm|maxThreads=i' => \$maxThreads,
+);
+
+if ( !($queueConfigPath && $connectionConfigPath) ) {
+  # Generate a help strings taht shows the arguments
+  say "\nUsage: perl $0 -q <queueConfigPath> -c <connectionConfigPath> --maxThreads <maxThreads> --verbose <level> --debug\n";
+  exit 1;
+}
+
+my $conf = LoadFile($queueConfigPath);
+my $connectionConfig = LoadFile($connectionConfigPath);
+
+# Beanstalk servers will be sharded
+my $beanstalkHost  = $conf->{beanstalk_host_1};
+my $beanstalkPort  = $conf->{beanstalk_port_1};
+
+# Required fields
+# The annotation_file_path is constructed from inputDir, inputFileNames by SeqElastic
+my @requiredJobFields = qw/indexName inputDir inputFileNames assembly/;
+
+my $configPathBaseDir = "config/";
+my $configFilePathHref = {};
+use DDP;
+
+my $queueConfig = $conf->{beanstalkd}{tubes}{'index'};
+
+my $PROGRESS  = "progress";
+my $FAILED    = "failed";
+my $STARTED   = "started";
+my $COMPLETED = "completed";
+
+my $beanstalk = Beanstalk::Client->new({
+  server    => $conf->{beanstalkd}{addresses}[0],
+  default_tube => $queueConfig->{submission},
+  connect_timeout => 1,
+  encoder => sub { encode_json(\@_) },
+  decoder => sub { @{decode_json(shift)} },
+});
+
+my $beanstalkEvents = Beanstalk::Client->new({
+  server    => $conf->{beanstalkd}{addresses}[0],
+  default_tube => $queueConfig->{events},
+  connect_timeout => 1,
+  encoder => sub { encode_json(\@_) },
+  decoder => sub { @{decode_json(shift)} },
+});
+
+my $events = $conf->{beanstalkd}{events};
+
+while(my $job = $beanstalk->reserve) {
+  # Parallel ForkManager used only to throttle number of jobs run in parallel
+  # cannot use run_on_finish with blocking reserves, use try catch instead
+  # Also using forks helps clean up leaked memory from LMDB_File
+  # Unfortunately, parallel fork manager doesn't play nicely with try tiny
+  # prevents anything within the try from executing
+
+  my $jobDataHref;
+  my ($err, $fieldNames, $searchConfigHashRef);
+
+  try {
+    $jobDataHref = decode_json( $job->data );
+
+    $beanstalkEvents->put(
+      {
+        priority => 0,
+        data     => encode_json(
+          {
+            event        => $STARTED,
+            submissionID => $jobDataHref->{submissionID},
+            queueID      => $job->id,
+          }
+        )
+      }
+    );
+
+    ($err, $fieldNames, $searchConfigHashRef) = handleJob($jobDataHref, $job->id);
+
+  } catch {      
+    # Don't store the stack
+    $err = $_; #substr($_, 0, index($_, 'at'));
+  };
+
+  if ($err) {
+    if(defined $verbose || defined $debug) {
+      say "job ". $job->id . " failed due to found error";
+      p $err;
+    }
+
+    my $message;
+
+    if(ref $err eq 'Search::Elasticsearch::Error::Request') {
+      $message = $err->{vars}{body}{error}{reason};
+    }
+
+    my $data = {
+      event        => $FAILED,
+      reason       => $err,
+      queueID      => $job->id,
+      submissionID => $jobDataHref->{submissionID},
+    };
+
+    $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
+
+    $job->bury; 
+
+    next;
+  }
+
+  # Signal completion before completion actually occurs via delete
+  # To be conservative; since after delete message is lost
+  my $data = {
+    event        => $COMPLETED,
+    queueID      => $job->id,
+    submissionID => $jobDataHref->{submissionID},
+    results => {
+        fieldNames => $fieldNames,
+        indexConfig => $searchConfigHashRef,
+    }
+  };
+ 
+ if ( defined $debug ) {
+    say STDERR "putting completiong event";
+    p $data;
+  }
+
+  $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
+
+  $job->delete();
+
+  say "completed job with queue id " . $job->id;
+}
+
+sub handleJob {
+  my $submittedJob = shift;
+  my $queueID = shift;
+
+  my $failed;
+
+  my ($err, $inputHref) = coerceInputs($submittedJob);
+
+  if($err) {
+    say STDERR $err;
+    return ($err, undef);
+  }
+
+  my $log_name = join '.', 'index', 'indexName', $inputHref->{indexName}, 'log';
+  my $logPath = File::Spec->rel2abs( ".", $log_name );
+
+  if($maxThreads) {
+    $inputHref->{max_threads} = $maxThreads;
+  }
+
+  $inputHref->{logPath} = $logPath;
+  $inputHref->{verbose} = $verbose;
+  $inputHref->{debug} = $debug;
+  $inputHref->{publisher} = {
+      server      => $conf->{beanstalkd}{addresses}[0],
+      queue       => $queueConfig->{events},
+      messageBase => {
+        event        => $PROGRESS,
+        queueID      => $queueID,
+        submissionID => $submittedJob->{submissionID},
+        data         => undef,
+      }
+    };
+
+  if(defined $verbose || defined $debug) {
+    say "in handle job, jobData is";
+    p $submittedJob;
+    say "writing beanstalk index queue log file here: $logPath";
+  }
+
+  # create the annotator
+  my $indexer = SeqElastic->new($inputHref);
+
+  return $indexer->go;
+}
+
+#Here we may wish to read a json or yaml file containing argument mappings
+sub coerceInputs {
+  my $jobDetailsHref = shift;
+
+  my %return;
+  for my $fieldName (@requiredJobFields) {
+    if(!defined $jobDetailsHref->{$fieldName}) {
+      say STDERR "$fieldName required";
+      return ("$fieldName required", undef);
+    }
+
+    $return{$fieldName} = $jobDetailsHref->{$fieldName};
+  }
+
+  $return{indexConfig} = LoadFile($configPathBaseDir . $jobDetailsHref->{assembly} . '.mapping.yml');
+  %return = (%return, %$connectionConfig);
+
+  return (undef, \%return);
+}
+
+sub getConfigFilePath {
+  my $assembly = shift;
+
+  if ( exists $configFilePathHref->{$assembly} ) {
+    return $configFilePathHref->{$assembly};
+  }
+  else {
+    my @maybePath = glob( $configPathBaseDir . $assembly . ".y*ml" );
+    if ( scalar @maybePath ) {
+      if ( scalar @maybePath > 1 ) {
+        #should log
+        say "\n\nMore than 1 config path found, choosing first";
+      }
+
+      return $maybePath[0];
+    }
+
+    die "\n\nNo config path found for the assembly $assembly. Exiting\n\n";
+    #throws the error
+    #should log here
+  }
+}
+1;

--- a/perl/bin/bystro-server.pl
+++ b/perl/bin/bystro-server.pl
@@ -37,6 +37,12 @@ GetOptions(
   'maxThreads=i'         => \$maxThreads,
 );
 
+if ( !($queueConfigPath && $connectionConfigPath) ) {
+  # Generate a help strings that shows the arguments
+  say "\nUsage: perl $0 -q <queueConfigPath> -c <connectionConfigPath> --maxThreads <maxThreads>\n";
+  exit 1;
+}
+
 my $type = 'annotation';
 
 my $PROGRESS  = "progress";
@@ -85,8 +91,6 @@ my $beanstalkEvents = Beanstalk::Client->new(
     decoder         => sub { @{ decode_json(shift) } },
   }
 );
-
-my $events = $conf->{beanstalkd}{events};
 
 while ( my $job = $beanstalk->reserve ) {
   # Parallel ForkManager used only to throttle number of jobs run in parallel

--- a/perl/bin/bystro-server.pl
+++ b/perl/bin/bystro-server.pl
@@ -30,17 +30,19 @@ use Path::Tiny qw/path/;
 my ( $verbose, $queueConfigPath, $connectionConfigPath, $maxThreads, $debug );
 
 GetOptions(
-  'v|verbose=i'          => \$verbose,
-  'd|debug'              => \$debug,
-  'q|queueConfig=s'      => \$queueConfigPath,
-  'c|connectionConfig=s' => \$connectionConfigPath,
-  'maxThreads=i'         => \$maxThreads,
+    'v|verbose=i'          => \$verbose,
+    'd|debug'              => \$debug,
+    'q|queueConfig=s'      => \$queueConfigPath,
+    'c|connectionConfig=s' => \$connectionConfigPath,
+    'maxThreads=i'         => \$maxThreads,
 );
 
-if ( !($queueConfigPath && $connectionConfigPath) ) {
-  # Generate a help strings that shows the arguments
-  say "\nUsage: perl $0 -q <queueConfigPath> -c <connectionConfigPath> --maxThreads <maxThreads>\n";
-  exit 1;
+if ( !( $queueConfigPath && $connectionConfigPath ) ) {
+
+    # Generate a help strings that shows the arguments
+    say
+"\nUsage: perl $0 -q <queueConfigPath> -c <connectionConfigPath> --maxThreads <maxThreads>\n";
+    exit 1;
 }
 
 my $type = 'annotation';
@@ -54,8 +56,8 @@ my $conf = LoadFile($queueConfigPath);
 
 # The properties that we accept from the worker caller
 my %requiredForAll = (
-  output_file_base => 'outputBasePath',
-  assembly         => 'assembly',
+    output_file_base => 'outputBasePath',
+    assembly         => 'assembly',
 );
 
 my $requiredForType = { input_file => 'inputFilePath' };
@@ -68,247 +70,252 @@ my $configFilePathHref = {};
 my $queueConfig = $conf->{beanstalkd}{tubes}{$type};
 
 if ( !$queueConfig ) {
-  die "Queue config format not recognized. Options are "
-    . ( join( ', ', @{ keys %{ $conf->{beanstalkd}{tubes} } } ) );
+    die "Queue config format not recognized. Options are "
+      . ( join( ', ', @{ keys %{ $conf->{beanstalkd}{tubes} } } ) );
 }
 
 my $beanstalk = Beanstalk::Client->new(
-  {
-    server          => $conf->{beanstalkd}{addresses}[0],
-    default_tube    => $queueConfig->{submission},
-    connect_timeout => 1,
-    encoder         => sub { encode_json( \@_ ) },
-    decoder         => sub { @{ decode_json(shift) } },
-  }
+    {
+        server          => $conf->{beanstalkd}{addresses}[0],
+        default_tube    => $queueConfig->{submission},
+        connect_timeout => 1,
+        encoder         => sub { encode_json( \@_ ) },
+        decoder         => sub { @{ decode_json(shift) } },
+    }
 );
 
 my $beanstalkEvents = Beanstalk::Client->new(
-  {
-    server          => $conf->{beanstalkd}{addresses}[0],
-    default_tube    => $queueConfig->{events},
-    connect_timeout => 1,
-    encoder         => sub { encode_json( \@_ ) },
-    decoder         => sub { @{ decode_json(shift) } },
-  }
+    {
+        server          => $conf->{beanstalkd}{addresses}[0],
+        default_tube    => $queueConfig->{events},
+        connect_timeout => 1,
+        encoder         => sub { encode_json( \@_ ) },
+        decoder         => sub { @{ decode_json(shift) } },
+    }
 );
 
 while ( my $job = $beanstalk->reserve ) {
-  # Parallel ForkManager used only to throttle number of jobs run in parallel
-  # cannot use run_on_finish with blocking reserves, use try catch instead
-  # Also using forks helps clean up leaked memory from LMDB_File
-  # Unfortunately, parallel fork manager doesn't play nicely with try tiny
-  # prevents anything within the try from executing
 
-  my $jobDataHref;
-  my ( $err, $outputFileNamesHashRef );
+    # Parallel ForkManager used only to throttle number of jobs run in parallel
+    # cannot use run_on_finish with blocking reserves, use try catch instead
+    # Also using forks helps clean up leaked memory from LMDB_File
+    # Unfortunately, parallel fork manager doesn't play nicely with try tiny
+    # prevents anything within the try from executing
 
-  try {
-    $jobDataHref = decode_json( $job->data );
+    my $jobDataHref;
+    my ( $err, $outputFileNamesHashRef );
 
-    if ( defined $debug ) {
-      say "Reserved job with id " . $job->id . " which contains:";
-      p $jobDataHref;
+    try {
+        $jobDataHref = decode_json( $job->data );
 
-      my $stats = $job->stats();
-      say "stats are";
-      p $stats;
+        if ( defined $debug ) {
+            say "Reserved job with id " . $job->id . " which contains:";
+            p $jobDataHref;
+
+            my $stats = $job->stats();
+            say "stats are";
+            p $stats;
+        }
+
+        ( $err, my $inputHref ) = coerceInputs( $jobDataHref, $job->id );
+
+        if ($err) {
+            die $err;
+        }
+
+        my $configData = LoadFile( $inputHref->{config} );
+
+        # Hide the server paths in the config we send back;
+        # Those represent a security concern
+        $configData->{files_dir} = 'hidden';
+
+        if ( $configData->{temp_dir} ) {
+            $configData->{temp_dir} = 'hidden';
+        }
+
+        $configData->{database_dir} = 'hidden';
+
+        my $trackConfig;
+        if ( ref $configData->{tracks} eq 'ARRAY' ) {
+            $trackConfig = $configData->{tracks};
+        }
+        else {
+            # New version
+            $trackConfig = $configData->{tracks}{tracks};
+        }
+
+        for my $track (@$trackConfig) {
+
+            # Strip local_files of their directory names, for security reasons
+            $track->{local_files} =
+              [ map { !$_ ? "" : path($_)->basename }
+                  @{ $track->{local_files} } ];
+        }
+
+        $beanstalkEvents->put(
+            {
+                priority => 0,
+                data     => encode_json(
+                    {
+                        event        => $STARTED,
+                        jobConfig    => $configData,
+                        submissionID => $jobDataHref->{submissionID},
+                        queueID      => $job->id,
+                    }
+                )
+            }
+        );
+
+        if ($debug) {
+            say STDERR "job " . $job->id . " starting with inputHref:";
+            p $inputHref;
+        }
+
+        my $annotate_instance = Seq->new_with_config($inputHref);
+
+        ( $err, $outputFileNamesHashRef ) = $annotate_instance->annotate();
+
+        if ( defined $debug ) {
+            p $err;
+        }
     }
-
-    ( $err, my $inputHref ) = coerceInputs( $jobDataHref, $job->id );
-
-    if ($err) {
-      die $err;
-    }
-
-    my $configData = LoadFile( $inputHref->{config} );
-
-    # Hide the server paths in the config we send back;
-    # Those represent a security concern
-    $configData->{files_dir} = 'hidden';
-
-    if ( $configData->{temp_dir} ) {
-      $configData->{temp_dir} = 'hidden';
-    }
-
-    $configData->{database_dir} = 'hidden';
-
-    my $trackConfig;
-    if ( ref $configData->{tracks} eq 'ARRAY' ) {
-      $trackConfig = $configData->{tracks};
-    }
-    else {
-      # New version
-      $trackConfig = $configData->{tracks}{tracks};
-    }
-
-    for my $track (@$trackConfig) {
-      # Strip local_files of their directory names, for security reasons
-      $track->{local_files} =
-        [ map { !$_ ? "" : path($_)->basename } @{ $track->{local_files} } ];
-    }
-
-    $beanstalkEvents->put(
-      {
-        priority => 0,
-        data     => encode_json(
-          {
-            event        => $STARTED,
-            jobConfig    => $configData,
-            submissionID => $jobDataHref->{submissionID},
-            queueID      => $job->id,
-          }
-        )
-      }
-    );
-
-    if ($debug) {
-      say STDERR "job " . $job->id . " starting with inputHref:";
-      p $inputHref;
-    }
-
-    my $annotate_instance = Seq->new_with_config($inputHref);
-
-    ( $err, $outputFileNamesHashRef ) = $annotate_instance->annotate();
-
-    if ( defined $debug ) {
-      p $err;
-    }
-  }
-  catch {
-    $err = $_;
-  };
-
-  if ( defined $debug ) {
-    p $err;
-  }
-
-  if ($err) {
-    $err =~ s/\sat\s\w+\/\w+.*\sline\s\d+.*//;
-
-    say "job " . $job->id . " failed";
-
-    my $data = {
-      event        => $FAILED,
-      reason       => $err,
-      queueID      => $job->id,
-      submissionID => $jobDataHref->{submissionID},
+    catch {
+        $err = $_;
     };
 
+    if ( defined $debug ) {
+        p $err;
+    }
+
+    if ($err) {
+        $err =~ s/\sat\s\w+\/\w+.*\sline\s\d+.*//;
+
+        say "job " . $job->id . " failed";
+
+        my $data = {
+            event        => $FAILED,
+            reason       => $err,
+            queueID      => $job->id,
+            submissionID => $jobDataHref->{submissionID},
+        };
+
+        $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
+
+        $job->delete();
+
+        if ( $beanstalkEvents->error && defined $debug ) {
+            say STDERR "Beanstalkd last error:";
+            p $beanstalkEvents->error;
+        }
+
+        next;
+    }
+
+    my $data = {
+        event        => $COMPLETED,
+        queueID      => $job->id,
+        submissionID => $jobDataHref->{submissionID},
+        results      => { outputFileNames => $outputFileNamesHashRef, }
+    };
+
+    if ( defined $debug ) {
+        say STDERR "putting completiong event";
+        p $data;
+    }
+
+    # Signal completion before completion actually occurs via delete
+    # To be conservative; since after delete message is lost
     $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
 
     $job->delete();
 
     if ( $beanstalkEvents->error && defined $debug ) {
-      say STDERR "Beanstalkd last error:";
-      p $beanstalkEvents->error;
+        say "Beanstalkd last error:";
+        p $beanstalkEvents->error;
     }
 
-    next;
-  }
-
-  my $data = {
-    event        => $COMPLETED,
-    queueID      => $job->id,
-    submissionID => $jobDataHref->{submissionID},
-    results      => { outputFileNames => $outputFileNamesHashRef, }
-  };
-
-  if ( defined $debug ) {
-    say STDERR "putting completiong event";
-    p $data;
-  }
-
-  # Signal completion before completion actually occurs via delete
-  # To be conservative; since after delete message is lost
-  $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
-
-  $job->delete();
-
-  if ( $beanstalkEvents->error && defined $debug ) {
-    say "Beanstalkd last error:";
-    p $beanstalkEvents->error;
-  }
-
-  say "completed job with queue id " . $job->id;
+    say "completed job with queue id " . $job->id;
 }
 
 sub coerceInputs {
-  my $jobDetailsHref = shift;
-  my $queueId        = shift;
+    my $jobDetailsHref = shift;
+    my $queueId        = shift;
 
-  my %args;
-  my $err;
+    my %args;
+    my $err;
 
-  my %jobSpecificArgs;
-  for my $key ( keys %requiredForAll ) {
-    if ( !defined $jobDetailsHref->{ $requiredForAll{$key} } ) {
-      $err = "Missing required key: $key in job message";
-      return ( $err, undef );
+    my %jobSpecificArgs;
+    for my $key ( keys %requiredForAll ) {
+        if ( !defined $jobDetailsHref->{ $requiredForAll{$key} } ) {
+            $err = "Missing required key: $key in job message";
+            return ( $err, undef );
+        }
+
+        $jobSpecificArgs{$key} = $jobDetailsHref->{ $requiredForAll{$key} };
     }
 
-    $jobSpecificArgs{$key} = $jobDetailsHref->{ $requiredForAll{$key} };
-  }
+    for my $key ( keys %$requiredForType ) {
+        if ( !defined $jobDetailsHref->{ $requiredForType->{$key} } ) {
+            $err = "Missing required key: $key in job message";
+            return ( $err, undef );
+        }
 
-  for my $key ( keys %$requiredForType ) {
-    if ( !defined $jobDetailsHref->{ $requiredForType->{$key} } ) {
-      $err = "Missing required key: $key in job message";
-      return ( $err, undef );
+        $jobSpecificArgs{$key} = $jobDetailsHref->{ $requiredForType->{$key} };
     }
 
-    $jobSpecificArgs{$key} = $jobDetailsHref->{ $requiredForType->{$key} };
-  }
+    my $configFilePath = getConfigFilePath( $jobSpecificArgs{assembly} );
 
-  my $configFilePath = getConfigFilePath( $jobSpecificArgs{assembly} );
+    if ( !$configFilePath ) {
+        $err =
+"Assembly $jobSpecificArgs{assembly} doesn't have corresponding config file";
+        return ( $err, undef );
+    }
 
-  if ( !$configFilePath ) {
-    $err = "Assembly $jobSpecificArgs{assembly} doesn't have corresponding config file";
-    return ( $err, undef );
-  }
+    my %commmonArgs = (
+        config    => $configFilePath,
+        publisher => {
+            server      => $conf->{beanstalkd}{addresses}[0],
+            queue       => $queueConfig->{events},
+            messageBase => {
+                event        => $PROGRESS,
+                queueID      => $queueId,
+                submissionID => $jobDetailsHref->{submissionID},
+                data         => undef,
+            }
+        },
+        compress       => 1,
+        archive        => 1,
+        verbose        => $verbose,
+        run_statistics => 1,
+    );
 
-  my %commmonArgs = (
-    config    => $configFilePath,
-    publisher => {
-      server      => $conf->{beanstalkd}{addresses}[0],
-      queue       => $queueConfig->{events},
-      messageBase => {
-        event        => $PROGRESS,
-        queueID      => $queueId,
-        submissionID => $jobDetailsHref->{submissionID},
-        data         => undef,
-      }
-    },
-    compress       => 1,
-    archive        => 1,
-    verbose        => $verbose,
-    run_statistics => 1,
-  );
+    if ($maxThreads) {
+        $commmonArgs{maxThreads} = $maxThreads;
+    }
 
-  if ($maxThreads) {
-    $commmonArgs{maxThreads} = $maxThreads;
-  }
+    my %combined = ( %commmonArgs, %jobSpecificArgs );
 
-  my %combined = ( %commmonArgs, %jobSpecificArgs );
-
-  return ( undef, \%combined );
+    return ( undef, \%combined );
 }
 
 sub getConfigFilePath {
-  my $assembly = shift;
+    my $assembly = shift;
 
-  if ( exists $configFilePathHref->{$assembly} ) {
-    return $configFilePathHref->{$assembly};
-  }
-  else {
-    my @maybePath = glob( $configPathBaseDir . $assembly . ".y*ml" );
-    if ( scalar @maybePath ) {
-      if ( scalar @maybePath > 1 ) {
-        #should log
-        say "\n\nMore than 1 config path found, choosing first";
-      }
-
-      return $maybePath[0];
+    if ( exists $configFilePathHref->{$assembly} ) {
+        return $configFilePathHref->{$assembly};
     }
+    else {
+        my @maybePath = glob( $configPathBaseDir . $assembly . ".y*ml" );
+        if ( scalar @maybePath ) {
+            if ( scalar @maybePath > 1 ) {
 
-    die "\n\nNo config path found for the assembly $assembly. Exiting\n\n";
-  }
+                #should log
+                say "\n\nMore than 1 config path found, choosing first";
+            }
+
+            return $maybePath[0];
+        }
+
+        die "\n\nNo config path found for the assembly $assembly. Exiting\n\n";
+    }
 }

--- a/perl/lib/Seq/Role/IO.pm
+++ b/perl/lib/Seq/Role/IO.pm
@@ -1,6 +1,7 @@
 use 5.10.0;
 use strict;
 use warnings;
+
 # TODO: Also support reading zipped files (right now only gzip files)
 package Seq::Role::IO;
 
@@ -21,23 +22,24 @@ use Try::Tiny;
 use DDP;
 use Scalar::Util qw/looks_like_number/;
 with 'Seq::Role::Message';
+
 # tried various ways of assigning this to an attrib, with the intention that
 # one could change the taint checking characters allowed but this is the simpliest
 # one that worked; wanted it precompiled to improve the speed of checking
 my $taintCheckRegex = qr{\A([\+\,\.\-\=\:\/\t\|\s\w\d/]+)\z};
 
 has taintCheckRegex => (
-  is       => 'ro',
-  lazy     => 1,
-  init_arg => undef,
-  default  => sub { $taintCheckRegex },
+    is       => 'ro',
+    lazy     => 1,
+    init_arg => undef,
+    default  => sub { $taintCheckRegex },
 );
 
 has delimiter => (
-  is      => 'ro',
-  lazy    => 1,
-  default => '\t',
-  writer  => '_setDelimiter',
+    is      => 'ro',
+    lazy    => 1,
+    default => '\t',
+    writer  => '_setDelimiter',
 );
 
 my $tar  = which('tar');
@@ -51,526 +53,561 @@ my $lz4  = which('lz4');
 # For compression, tradeoff still worth it
 my $gzipDcmpArgs = '-d -c';
 if ( $gzip =~ /pigz/ ) {
-  $gzipDcmpArgs = "-p 1 $gzipDcmpArgs";
+    $gzipDcmpArgs = "-p 1 $gzipDcmpArgs";
 }
 elsif ( $gzip =~ /bgzip/ ) {
-  $gzipDcmpArgs = "--threads " . Sys::CpuAffinity::getNumCpus() . " $gzipDcmpArgs";
+    $gzipDcmpArgs =
+      "--threads " . Sys::CpuAffinity::getNumCpus() . " $gzipDcmpArgs";
 }
 
 my $gzipCmpArgs = '-c';
 if ( $gzip =~ /bgzip/ ) {
-  $gzipCmpArgs = "--threads " . Sys::CpuAffinity::getNumCpus();
+    $gzipCmpArgs = "--threads " . Sys::CpuAffinity::getNumCpus();
 }
 
 my $tarCompressedGzip = "$tar --use-compress-program=$gzip";
 my $tarCompressedLZ4  = "$tar --use-compress-program=$lz4";
 
 has gzip => (
-  is       => 'ro',
-  isa      => 'Str',
-  init_arg => undef,
-  lazy     => 1,
-  default  => sub { $gzip }
+    is       => 'ro',
+    isa      => 'Str',
+    init_arg => undef,
+    lazy     => 1,
+    default  => sub { $gzip }
 );
 has decompressArgs => (
-  is       => 'ro',
-  isa      => 'Str',
-  init_arg => undef,
-  lazy     => 1,
-  default  => sub { $gzipDcmpArgs }
+    is       => 'ro',
+    isa      => 'Str',
+    init_arg => undef,
+    lazy     => 1,
+    default  => sub { $gzipDcmpArgs }
 );
 
 sub getReadArgs {
-  my ( $self, $filePath ) = @_;
+    my ( $self, $filePath ) = @_;
 
-  my ( $remoteCpCmd, $remoteFileSizeCmd ) = $self->getRemoteProg($filePath);
-  my $outerCommand = $self->getCompressProgWithArgs($filePath);
+    my ( $remoteCpCmd, $remoteFileSizeCmd ) = $self->getRemoteProg($filePath);
+    my $outerCommand = $self->getCompressProgWithArgs($filePath);
 
-  if ($remoteCpCmd) {
-    if ($outerCommand) {
-      $outerCommand = "$remoteCpCmd | $outerCommand -";
+    if ($remoteCpCmd) {
+        if ($outerCommand) {
+            $outerCommand = "$remoteCpCmd | $outerCommand -";
+        }
+        else {
+            $outerCommand = "$remoteCpCmd";
+        }
     }
-    else {
-      $outerCommand = "$remoteCpCmd";
+    elsif ($outerCommand) {
+        $outerCommand = "$outerCommand $filePath";
     }
-  }
-  elsif ($outerCommand) {
-    $outerCommand = "$outerCommand $filePath";
-  }
 
-  return $outerCommand;
+    return $outerCommand;
 }
+
 #@param {Path::Tiny} $file : the Path::Tiny object representing a single input file
 #@param {Str} $errCode : what log level to use if we can't open the file
 #@return file handle
 sub getReadFh {
-  my ( $self, $file, $errCode ) = @_;
+    my ( $self, $file, $errCode ) = @_;
 
-  # By default, we'll return an error, rather than die-ing with log
-  # We wont be able to catch pipe errors however
-  if ( !$errCode ) {
-    $errCode = 'error';
-  }
+    # By default, we'll return an error, rather than die-ing with log
+    # We wont be able to catch pipe errors however
+    if ( !$errCode ) {
+        $errCode = 'error';
+    }
 
-  my $filePath;
-  if ( ref $file eq 'Path::Tiny' ) {
-    $filePath = $file->stringify;
-  }
-  else {
-    $filePath = $file;
-  }
+    my $filePath;
+    if ( ref $file eq 'Path::Tiny' ) {
+        $filePath = $file->stringify;
+    }
+    else {
+        $filePath = $file;
+    }
 
-  my $outerCommand = $self->getReadArgs($filePath);
+    my $outerCommand = $self->getReadArgs($filePath);
 
-  my ( $err, $fh );
+    my ( $err, $fh );
 
-  if ($outerCommand) {
-    $err = $self->safeOpen( $fh, '-|', "$outerCommand", $errCode );
-  }
-  else {
-    $err = $self->safeOpen( $fh, '<', $filePath, $errCode );
-  }
+    if ($outerCommand) {
+        $err = $self->safeOpen( $fh, '-|', "$outerCommand", $errCode );
+    }
+    else {
+        $err = $self->safeOpen( $fh, '<', $filePath, $errCode );
+    }
 
-  my $compressed = !!$outerCommand;
+    my $compressed = !!$outerCommand;
 
-  return ( $err, $compressed, $fh );
+    return ( $err, $compressed, $fh );
 }
-
 
 # Get a filehandle from within a tarball
 sub getTarballInnerFh {
-  my ( $self, $file, $innerFile) = @_;
-  my $fh;
+    my ( $self, $file, $innerFile ) = @_;
+    my $fh;
 
-  if(ref $file ne 'Path::Tiny' ) {
-    $file = path($file)->absolute;
-  }
-
-  my $filePath = $file->stringify;
-
-  if (!$file->is_file) {
-    $self->log('fatal', "$filePath does not exist for reading");
-    die;
-  }
-
-  my $compressed = 0;
-  my $err;
-  if($innerFile) {
-    $compressed = $innerFile =~ /\.gz$/ || $innerFile =~ /\.bgz$/ || $innerFile =~ /\.zip$/;
-
-    my $innerCommand = $compressed ? "\"$innerFile\" | $gzip $gzipDcmpArgs -" : "\"$innerFile\"";
-    # We do this because we have not built in error handling from opening streams
-
-    my $command;
-    my $outerCompressed;
-    if($filePath =~ /\.tar.gz$/) {
-      $outerCompressed = 1;
-      $command = "$tarCompressedGzip -O -xf \"$filePath\" $innerCommand";
-    } elsif($filePath =~ /\.tar$/) {
-      $command = "$tar -O -xf \"$filePath\" $innerCommand";
-    } else {
-      $self->log('fatal', "When inner file provided, must provde a parent file.tar or file.tar.gz");
-      die;
+    if ( ref $file ne 'Path::Tiny' ) {
+        $file = path($file)->absolute;
     }
 
-    open ($fh, '-|', $command) or $self->log('fatal', "Failed to open $filePath ($innerFile) due to $!");
+    my $filePath = $file->stringify;
 
-    # From a size standpoint a tarball and a tar file whose inner annotation is compressed are similar
-    # since the annotation dominate
-    $compressed = $compressed || $outerCompressed;
-    # If an innerFile is passed, we assume that $file is a path to a tarball
-  } elsif($filePath =~ /\.gz$/ || $filePath =~ /\.bgz$/ || $filePath =~ /\.zip$/) {
-    $compressed = 1;
-    #PerlIO::gzip doesn't seem to play nicely with MCE, reads random number of lines
-    #and then exits, so use gunzip, standard on linux, and faster
-    open ($fh, '-|', "$gzip $gzipDcmpArgs \"$filePath\"") or $self->log('fatal', "Failed to open $filePath due to $!");
-  } else {
-    open ($fh, '-|', "cat \"$filePath\"") or $self->log('fatal', "Failed to open $filePath due to $!");
-  };
+    if ( !$file->is_file ) {
+        $self->log( 'fatal', "$filePath does not exist for reading" );
+        die;
+    }
 
-  # TODO: return errors, rather than dying
-  return ($err, $compressed, $fh);
+    my $compressed = 0;
+    my $err;
+    if ($innerFile) {
+        $compressed =
+             $innerFile =~ /\.gz$/
+          || $innerFile =~ /\.bgz$/
+          || $innerFile =~ /\.zip$/;
+
+        my $innerCommand =
+          $compressed
+          ? "\"$innerFile\" | $gzip $gzipDcmpArgs -"
+          : "\"$innerFile\"";
+
+   # We do this because we have not built in error handling from opening streams
+
+        my $command;
+        my $outerCompressed;
+        if ( $filePath =~ /\.tar.gz$/ ) {
+            $outerCompressed = 1;
+            $command = "$tarCompressedGzip -O -xf \"$filePath\" $innerCommand";
+        }
+        elsif ( $filePath =~ /\.tar$/ ) {
+            $command = "$tar -O -xf \"$filePath\" $innerCommand";
+        }
+        else {
+            $self->log( 'fatal',
+"When inner file provided, must provde a parent file.tar or file.tar.gz"
+            );
+            die;
+        }
+
+        open( $fh, '-|', $command )
+          or $self->log( 'fatal',
+            "Failed to open $filePath ($innerFile) due to $!" );
+
+# From a size standpoint a tarball and a tar file whose inner annotation is compressed are similar
+# since the annotation dominate
+        $compressed = $compressed || $outerCompressed;
+
+        # If an innerFile is passed, we assume that $file is a path to a tarball
+    }
+    elsif ($filePath =~ /\.gz$/
+        || $filePath =~ /\.bgz$/
+        || $filePath =~ /\.zip$/ )
+    {
+        $compressed = 1;
+
+#PerlIO::gzip doesn't seem to play nicely with MCE, reads random number of lines
+#and then exits, so use gunzip, standard on linux, and faster
+        open( $fh, '-|', "$gzip $gzipDcmpArgs \"$filePath\"" )
+          or $self->log( 'fatal', "Failed to open $filePath due to $!" );
+    }
+    else {
+        open( $fh, '-|', "cat \"$filePath\"" )
+          or $self->log( 'fatal', "Failed to open $filePath due to $!" );
+    }
+
+    # TODO: return errors, rather than dying
+    return ( $err, $compressed, $fh );
 }
 
 sub getRemoteProg {
-  my ( $self, $filePath ) = @_;
+    my ( $self, $filePath ) = @_;
 
-  if ( $filePath =~ /^s3:\/\// ) {
-    return ( "aws s3 cp $filePath -", "" );
-  }
+    if ( $filePath =~ /^s3:\/\// ) {
+        return ( "aws s3 cp $filePath -", "" );
+    }
 
-  if ( $filePath =~ /^gs:\/\// ) {
-    return ( "gsutil cp $filePath -", "" );
-  }
+    if ( $filePath =~ /^gs:\/\// ) {
+        return ( "gsutil cp $filePath -", "" );
+    }
 
-  return "";
+    return "";
 }
 
 sub getInnerFileCommand {
-  my ( $self, $filePath, $innerFile, $errCode ) = @_;
+    my ( $self, $filePath, $innerFile, $errCode ) = @_;
 
-  if ( !$errCode ) {
-    $errCode = 'error';
-  }
+    if ( !$errCode ) {
+        $errCode = 'error';
+    }
 
-  my $compressed =
-       $innerFile =~ /[.]gz$/
-    || $innerFile =~ /[.]bgz$/
-    || $innerFile =~ /[.]zip$/
-    || $filePath  =~ /[.]lz4$/;
+    my $compressed =
+         $innerFile =~ /[.]gz$/
+      || $innerFile =~ /[.]bgz$/
+      || $innerFile =~ /[.]zip$/
+      || $filePath  =~ /[.]lz4$/;
 
-  my $innerCommand;
-  if ( $filePath =~ /[.]lz4$/ ) {
-    $innerCommand = $compressed ? "\"$innerFile\" | $lz4 -d -c -" : "\"$innerFile\"";
-  }
-  else {
-    $innerCommand =
-      $compressed ? "\"$innerFile\" | $gzip $gzipDcmpArgs -" : "\"$innerFile\"";
-  }
+    my $innerCommand;
+    if ( $filePath =~ /[.]lz4$/ ) {
+        $innerCommand =
+          $compressed ? "\"$innerFile\" | $lz4 -d -c -" : "\"$innerFile\"";
+    }
+    else {
+        $innerCommand =
+          $compressed
+          ? "\"$innerFile\" | $gzip $gzipDcmpArgs -"
+          : "\"$innerFile\"";
+    }
 
-  # We do this because we have not built in error handling from opening streams
+   # We do this because we have not built in error handling from opening streams
 
-  my $err;
-  my $command;
-  my $outerCompressed;
+    my $err;
+    my $command;
+    my $outerCompressed;
 
-  if ( $filePath =~ /[.]tar/ ) {
-    $command = "$tar -O -xf - $innerCommand";
-  }
-  else {
-    $err = "When inner file provided, must provde a parent file.tar or file.tar.gz";
+    if ( $filePath =~ /[.]tar/ ) {
+        $command = "$tar -O -xf - $innerCommand";
+    }
+    else {
+        $err =
+"When inner file provided, must provde a parent file.tar or file.tar.gz";
 
-    $self->log( $errCode, $err );
+        $self->log( $errCode, $err );
 
-    return ( $err, undef, undef );
-  }
+        return ( $err, undef, undef );
+    }
 
-  # If an innerFile is passed, we assume that $file is a path to a tarball
+    # If an innerFile is passed, we assume that $file is a path to a tarball
 
-  return ( $err, $compressed, $command );
+    return ( $err, $compressed, $command );
 }
 
 # Is the file a single compressed file
 sub isCompressedSingle {
-  my ( $self, $filePath ) = @_;
+    my ( $self, $filePath ) = @_;
 
-  my $basename = path($filePath)->basename();
+    my $basename = path($filePath)->basename();
 
-  if ( $basename =~ /tar[.]gz$/ ) {
-    return 0;
-  }
+    if ( $basename =~ /tar[.]gz$/ ) {
+        return 0;
+    }
 
-  if ( $basename =~ /[.]gz$/ || $basename =~ /[.]bgz$/ || $basename =~ /[.]zip$/ ) {
-    return "gzip";
-  }
+    if (   $basename =~ /[.]gz$/
+        || $basename =~ /[.]bgz$/
+        || $basename =~ /[.]zip$/ )
+    {
+        return "gzip";
+    }
 
-  if ( $basename =~ /[.]lz4$/ ) {
-    return "lz4";
-  }
+    if ( $basename =~ /[.]lz4$/ ) {
+        return "lz4";
+    }
 
-  return "";
+    return "";
 }
 
 sub getCompressProgWithArgs {
-  my ( $self, $filePath ) = @_;
+    my ( $self, $filePath ) = @_;
 
-  my $ext = $self->isCompressedSingle($filePath);
+    my $ext = $self->isCompressedSingle($filePath);
 
-  if ( !$ext ) {
-    return "";
-  }
-  if ( $ext eq 'gzip' ) {
-    return "$gzip $gzipDcmpArgs";
-  }
-  if ( $ext eq 'lz4' ) {
-    return "$lz4 -d -c";
-  }
+    if ( !$ext ) {
+        return "";
+    }
+    if ( $ext eq 'gzip' ) {
+        return "$gzip $gzipDcmpArgs";
+    }
+    if ( $ext eq 'lz4' ) {
+        return "$lz4 -d -c";
+    }
 }
 
 # TODO: return error if failed
 sub getWriteFh {
-  my ( $self, $file, $compress, $errCode ) = @_;
+    my ( $self, $file, $compress, $errCode ) = @_;
 
-  # By default, we'll return an error, rather than die-ing with log
-  # We wont be able to catch pipe errors however
-  if ( !$errCode ) {
-    $errCode = 'error';
-  }
+    # By default, we'll return an error, rather than die-ing with log
+    # We wont be able to catch pipe errors however
+    if ( !$errCode ) {
+        $errCode = 'error';
+    }
 
-  my $err;
+    my $err;
 
-  if ( !$file ) {
-    $err = 'get_fh() expected a filename';
-    $self->log( $errCode, $err );
+    if ( !$file ) {
+        $err = 'get_fh() expected a filename';
+        $self->log( $errCode, $err );
 
-    return ( $err, undef );
-  }
+        return ( $err, undef );
+    }
 
-  my $fh;
-  my $hasGz  = $file =~ /[.]gz$/ || $file =~ /[.]bgz$/ || $file =~ /[.]zip$/;
-  my $hasLz4 = $file =~ /[.]lz4$/;
-  if ( $hasGz || $hasLz4 || $compress ) {
-    if ( $hasLz4 || ( $compress && $compress =~ /[.]lz4$/ ) ) {
-      $err = $self->safeOpen( $fh, "|-", "$lz4 -c > $file", $errCode );
+    my $fh;
+    my $hasGz  = $file =~ /[.]gz$/ || $file =~ /[.]bgz$/ || $file =~ /[.]zip$/;
+    my $hasLz4 = $file =~ /[.]lz4$/;
+    if ( $hasGz || $hasLz4 || $compress ) {
+        if ( $hasLz4 || ( $compress && $compress =~ /[.]lz4$/ ) ) {
+            $err = $self->safeOpen( $fh, "|-", "$lz4 -c > $file", $errCode );
+        }
+        else {
+            $err = $self->safeOpen( $fh, "|-", "$gzip $gzipCmpArgs > $file",
+                $errCode );
+        }
+
     }
     else {
-      $err = $self->safeOpen( $fh, "|-", "$gzip $gzipCmpArgs > $file", $errCode );
+        $err = $self->safeOpen( $fh, ">", $file, $errCode );
     }
 
-  }
-  else {
-    $err = $self->safeOpen( $fh, ">", $file, $errCode );
-  }
-
-  return ( $err, $fh );
+    return ( $err, $fh );
 }
 
 # Allows user to return an error; dies with logging by default
 sub safeOpen {
-  #my ($self, $fh, $operator, $operand, $errCode) = @_;
-  #    $_[0], $_[1], $_[2],   $_[3], $_[4]
 
-  # In some cases, file attempting to be read may not have been flushed
-  # Clearest case is Log::Fast
-  my $err = $_[0]->safeSystem('sync');
+    #my ($self, $fh, $operator, $operand, $errCode) = @_;
+    #    $_[0], $_[1], $_[2],   $_[3], $_[4]
 
-  # Modifies $fh/$_[1] by reference
-  if ( $err || !open( $_[1], $_[2], $_[3] ) ) {
-    $err = $err || $!;
+    # In some cases, file attempting to be read may not have been flushed
+    # Clearest case is Log::Fast
+    my $err = $_[0]->safeSystem('sync');
 
-    #$self    #$errCode                      #$operand
-    $_[0]->log( $_[4] || 'debug', "Couldn't open $_[3]: $err ($?)" );
-    return $err;
-  }
+    # Modifies $fh/$_[1] by reference
+    if ( $err || !open( $_[1], $_[2], $_[3] ) ) {
+        $err = $err || $!;
 
-  return;
+        #$self    #$errCode                      #$operand
+        $_[0]->log( $_[4] || 'debug', "Couldn't open $_[3]: $err ($?)" );
+        return $err;
+    }
+
+    return;
 }
 
 sub safeClose {
-  my ( $self, $fh, $errCode ) = @_;
+    my ( $self, $fh, $errCode ) = @_;
 
-  my $err = $self->safeSystem('sync');
+    my $err = $self->safeSystem('sync');
 
-  if ($err) {
-    $self->log( $errCode || 'debug', "Couldn't sync before close due to: $err" );
-    return $err;
-  }
+    if ($err) {
+        $self->log( $errCode || 'debug',
+            "Couldn't sync before close due to: $err" );
+        return $err;
+    }
 
-  if ( !close($fh) ) {
-    $self->log( $errCode || 'debug', "Couldn't close due to: $! ($?)" );
-    return $!;
-  }
+    if ( !close($fh) ) {
+        $self->log( $errCode || 'debug', "Couldn't close due to: $! ($?)" );
+        return $!;
+    }
 
-  return;
+    return;
 }
 
 sub getCleanFields {
-  my ( $self, $line ) = @_;
+    my ( $self, $line ) = @_;
 
-  chomp $line;
-  if ( $line =~ m/$taintCheckRegex/xm ) {
-    my @out;
+    chomp $line;
+    if ( $line =~ m/$taintCheckRegex/xm ) {
+        my @out;
 
-    push @out, split $self->delimiter, $1;
+        push @out, split $self->delimiter, $1;
 
-    return \@out;
-  }
+        return \@out;
+    }
 
-  return undef;
+    return undef;
 }
 
 sub getLineEndings {
-  return $/;
+    return $/;
 }
 
 sub setLineEndings {
-  my ( $self, $firstLine ) = @_;
+    my ( $self, $firstLine ) = @_;
 
-  if ( $firstLine =~ /\r\n$/ ) {
-    $/ = "\r\n";
-  }
-  elsif ( $firstLine =~ /\n$/ ) {
-    $/ = "\n";
-  }
-  elsif ( $firstLine =~ /\015/ ) {
-    # Match ^M (MacOS style line endings, which Excel outputs on Macs)
-    $/ = "\015";
-  }
-  else {
-    return "Cannot discern line endings: Not Mac, Unix, or Windows style";
-  }
+    if ( $firstLine =~ /\r\n$/ ) {
+        $/ = "\r\n";
+    }
+    elsif ( $firstLine =~ /\n$/ ) {
+        $/ = "\n";
+    }
+    elsif ( $firstLine =~ /\015/ ) {
 
-  return "";
+        # Match ^M (MacOS style line endings, which Excel outputs on Macs)
+        $/ = "\015";
+    }
+    else {
+        return "Cannot discern line endings: Not Mac, Unix, or Windows style";
+    }
+
+    return "";
 }
 
 sub checkDelimiter {
-  my ( $self, $line ) = @_;
+    my ( $self, $line ) = @_;
 
-  if ( $line =~ /^\s*\S+\t\S+/ ) {
-    return 1;
-  }
+    if ( $line =~ /^\s*\S+\t\S+/ ) {
+        return 1;
+    }
 
-  return 0;
+    return 0;
 }
 
 sub safeSystem {
-  my ( $self, $cmd, $errCode ) = @_;
+    my ( $self, $cmd, $errCode ) = @_;
 
-  my $return = system($cmd);
+    my $return = system($cmd);
 
-  if ( $return > 0 ) {
-    $self->log( $errCode || 'debug',
-      "Failed to execute $cmd. Return: $return, due to: $! ($?)" );
-    return $!;
-  }
+    if ( $return > 0 ) {
+        $self->log( $errCode || 'debug',
+            "Failed to execute $cmd. Return: $return, due to: $! ($?)" );
+        return $!;
+    }
 
-  return;
+    return;
 }
 
 sub setDelimiter {
-  my ( $self, $line ) = @_;
+    my ( $self, $line ) = @_;
 
-  if ( $line =~ /^\s*\S+\t\S+/ ) {
-    $self->_setDelimiter('\t');
-  }
-  elsif ( $line =~ /^\s*\S+,\S+/ ) {
-    $self->_setDelimiter(',');
-  }
-  else {
-    return "Line is not tab or comma delimited";
-  }
+    if ( $line =~ /^\s*\S+\t\S+/ ) {
+        $self->_setDelimiter('\t');
+    }
+    elsif ( $line =~ /^\s*\S+,\S+/ ) {
+        $self->_setDelimiter(',');
+    }
+    else {
+        return "Line is not tab or comma delimited";
+    }
 
-  return "";
+    return "";
 }
 
 sub makeTarballName {
-  my ( $self, $baseName, $compress ) = @_;
+    my ( $self, $baseName, $compress ) = @_;
 
-  return $baseName . ( $compress ? '.tar.gz' : '.tar' );
+    return $baseName . ( $compress ? '.tar.gz' : '.tar' );
 }
 
 # Assumes if ref's are passed for dir, baseName, or compressedName, they are path tiny
 sub compressDirIntoTarball {
-  my ( $self, $dir, $tarballName ) = @_;
+    my ( $self, $dir, $tarballName ) = @_;
 
-  if ( !$tar ) {
-    $self->log( 'warn', 'No tar program found' );
-    return 'No tar program found';
-  }
+    if ( !$tar ) {
+        $self->log( 'warn', 'No tar program found' );
+        return 'No tar program found';
+    }
 
-  if ( ref $dir ) {
-    $dir = $dir->stringify;
-  }
+    if ( ref $dir ) {
+        $dir = $dir->stringify;
+    }
 
-  if ( !$tarballName ) {
-    $self->log( 'warn', 'must provide baseName or tarballName' );
-    return 'Must provide baseName or tarballName';
-  }
+    if ( !$tarballName ) {
+        $self->log( 'warn', 'must provide baseName or tarballName' );
+        return 'Must provide baseName or tarballName';
+    }
 
-  if ( ref $tarballName ) {
-    $tarballName = $tarballName->stringify;
-  }
+    if ( ref $tarballName ) {
+        $tarballName = $tarballName->stringify;
+    }
 
-  $self->log( 'info', 'Compressing all output files' );
+    $self->log( 'info', 'Compressing all output files' );
 
-  my @files = glob $dir;
+    my @files = glob $dir;
 
-  if ( !@files ) {
-    $self->log( 'warn', "Directory is empty" );
-    return 'Directory is empty';
-  }
+    if ( !@files ) {
+        $self->log( 'warn', "Directory is empty" );
+        return 'Directory is empty';
+    }
 
-  my $tarProg =
-      $tarballName =~ /tar.gz$/
-    ? $tarCompressedGzip
-    : ( $tarballName =~ /tar.lz4$/ ? $tarCompressedLZ4 : "tar" );
-  my $tarCommand = sprintf(
-    "cd %s; $tarProg --exclude '.*' --exclude %s -cf %s * --remove-files",
-    $dir,
-    $tarballName, #and don't include our new compressed file in our tarball
-    $tarballName, # the name of our tarball
-  );
+    my $tarProg =
+        $tarballName =~ /tar.gz$/
+      ? $tarCompressedGzip
+      : ( $tarballName =~ /tar.lz4$/ ? $tarCompressedLZ4 : "tar" );
+    my $tarCommand = sprintf(
+        "cd %s; $tarProg --exclude '.*' --exclude %s -cf %s * --remove-files",
+        $dir,
+        $tarballName,  #and don't include our new compressed file in our tarball
+        $tarballName,  # the name of our tarball
+    );
 
-  $self->log( 'debug', "compress command: $tarCommand" );
+    $self->log( 'debug', "compress command: $tarCommand" );
 
-  my $err = $self->safeSystem($tarCommand);
+    my $err = $self->safeSystem($tarCommand);
 
-  return $err;
+    return $err;
 }
 
 sub getCompressedFileSize {
-  my ( $self, $filePath ) = @_;
+    my ( $self, $filePath ) = @_;
 
-  my $extType = $self->isCompressedSingle($filePath);
-  if ( !$extType ) {
-    return ( 'Expect compressed file', undef );
-  }
+    my $extType = $self->isCompressedSingle($filePath);
+    if ( !$extType ) {
+        return ( 'Expect compressed file', undef );
+    }
 
-  my $gzProg = $extType eq 'gzip' ? $gzip : $lz4;
+    my $gzProg = $extType eq 'gzip' ? $gzip : $lz4;
 
-  my $err =
-    $self->safeOpen( my $fh, "-|", "$gzProg -l " . path($filePath)->stringify );
+    my $err =
+      $self->safeOpen( my $fh, "-|",
+        "$gzProg -l " . path($filePath)->stringify );
 
-  if ($err) {
-    return ( $err, undef );
-  }
+    if ($err) {
+        return ( $err, undef );
+    }
 
-  <$fh>;
-  my $sizeLine = <$fh>;
+    <$fh>;
+    my $sizeLine = <$fh>;
 
-  chomp $sizeLine;
-  my @sizes = split( " ", $sizeLine );
+    chomp $sizeLine;
+    my @sizes = split( " ", $sizeLine );
 
-  #pigz return 0? when file is larger than 4GB, gzip returns 0
-  if ( !$sizes[1] || !looks_like_number( $sizes[1] ) ) {
-    return ( undef, 0 );
-  }
+    #pigz return 0? when file is larger than 4GB, gzip returns 0
+    if ( !$sizes[1] || !looks_like_number( $sizes[1] ) ) {
+        return ( undef, 0 );
+    }
 
-  return ( undef, $sizes[1] );
+    return ( undef, $sizes[1] );
 }
 
 # returns chunk size in kbytes
 sub getChunkSize {
-  my ( $self, $filePath, $parts, $min, $max ) = @_;
+    my ( $self, $filePath, $parts, $min, $max ) = @_;
 
-  # If given 0
-  $parts ||= 1;
+    # If given 0
+    $parts ||= 1;
 
-  if ( !$min ) {
-    $min = 512;
-  }
+    if ( !$min ) {
+        $min = 512;
+    }
 
-  if ( !$max ) {
-    $max = 32768;
-  }
+    if ( !$max ) {
+        $max = 32768;
+    }
 
-  my $size = path($filePath)->stat()->size;
+    my $size = path($filePath)->stat()->size;
 
   # Files range from ~ 10 - 60x compression ratios; but large files don't report
   # correct ratios (> 4GB)
   # If file is < 4GB it will be reported correctly
-  if ( $self->isCompressedSingle($filePath) ) {
-    my ( $err, $compressedSize ) = $self->getCompressedFileSize($filePath);
+    if ( $self->isCompressedSingle($filePath) ) {
+        my ( $err, $compressedSize ) = $self->getCompressedFileSize($filePath);
 
-    if ($err) {
-      return ( $err, undef );
+        if ($err) {
+            return ( $err, undef );
+        }
+
+        $size = $compressedSize == 0 ? $size * 30 : $compressedSize;
     }
 
-    $size = $compressedSize == 0 ? $size * 30 : $compressedSize;
-  }
+    my $chunkSize = CORE::int( $size / ( $parts * 4096 ) );
 
-  my $chunkSize = CORE::int( $size / ( $parts * 4096 ) );
+    if ( $chunkSize < $min ) {
+        return ( undef, $min );
+    }
 
-  if ( $chunkSize < $min ) {
-    return ( undef, $min );
-  }
+    # Cap to make sure memory usage doesn't grow uncontrollably
+    if ( $chunkSize > $max ) {
+        return ( undef, $max );
+    }
 
-  # Cap to make sure memory usage doesn't grow uncontrollably
-  if ( $chunkSize > $max ) {
-    return ( undef, $max );
-  }
-
-  return ( undef, $chunkSize );
+    return ( undef, $chunkSize );
 }
 
 no Mouse::Role;

--- a/perl/lib/SeqElastic.pm
+++ b/perl/lib/SeqElastic.pm
@@ -1,0 +1,465 @@
+use 5.10.0;
+use strict;
+use warnings;
+
+package SeqElastic;
+use Search::Elasticsearch 7.713;
+
+use Path::Tiny;
+use Types::Path::Tiny qw/AbsFile AbsPath AbsDir/;
+use Mouse 2;
+use List::MoreUtils qw/first_index/;
+use Sys::CpuAffinity;
+use POSIX qw/ceil/;
+use DDP;
+
+our $VERSION = '0.001';
+
+# ABSTRACT: Index an annotated snpfil
+
+use namespace::autoclean;
+
+use Seq::Output::Delimiters;
+use MCE::Loop;
+use MCE::Shared;
+use Try::Tiny;
+
+with 'Seq::Role::IO', 'Seq::Role::Message', 'MouseX::Getopt';
+
+# An archive, containing an "annotation" file
+has annotatedFilePath => (is => 'ro', isa => AbsFile, coerce => 1,
+  writer => '_setAnnotatedFilePath');
+
+has indexConfig => (is => 'ro', isa=> 'HashRef', coerce => 1, required => 1);
+
+has connection => (is => 'ro', isa=> 'HashRef', coerce => 1, required => 1);
+
+has publisher => (is => 'ro');
+
+has logPath => (is => 'ro', isa => AbsPath, coerce => 1);
+
+has debug => (is => 'ro');
+
+has verbose => (is => 'ro');
+
+# Probably the user id
+has indexName => (is => 'ro', required => 1);
+
+has dryRun => (is => 'ro');
+
+# has commitEvery => (is => 'ro', default => 1000);
+
+# If inputFileNames provided, inputDir is required
+has inputDir => (is => 'ro', isa => AbsDir, coerce => 1);
+
+# The user may have given some header fields already
+# If so, this is a re-indexing job, and we will want to append the header fields
+has headerFields => (is => 'ro', isa => 'ArrayRef');
+
+# The user may have given some additional files
+# We accept only an array of bed file here
+# TODO: implement
+has addedFiles => (is => 'ro', isa => 'ArrayRef');
+
+# IF the user gives us an annotated file path, we will first index from
+# The annotation file wihin that archive
+#@ params
+# <Object> filePaths @params:
+  # <String> compressed : the name of the compressed folder holding annotation, stats, etc (only if $self->compress)
+  # <String> converted : the name of the converted folder
+  # <String> annnotation : the name of the annotation file
+  # <String> log : the name of the log file
+  # <Object> stats : the { statType => statFileName } object
+# Allows us to use all to to extract just the file we're interested from the compressed tarball
+has inputFileNames => (is => 'ro', isa => 'HashRef');
+
+has max_threads => (is => 'ro', isa => 'Int', lazy => 1, default => sub {
+  return 8;
+});
+
+sub getBooleanMappings {
+  my ($mapRef, $parentName) = @_;
+
+  my @booleanMappings;
+
+  my $pVal;
+  for my $property (keys %{$mapRef->{properties}}) {
+    $pVal = $mapRef->{properties}{$property};
+
+    if(exists $pVal->{fields}) {
+      for my $subProp (keys %{$pVal->{fields}}) {
+        if(exists $pVal->{fields}{$subProp}{type} && $pVal->{fields}{$subProp}{type} eq 'boolean') {
+          push @booleanMappings, "$property.$subProp";
+        }
+      }
+    } elsif(exists $pVal->{properties}) {
+      push @booleanMappings, getBooleanMappings($pVal, $property);
+    } elsif(exists $pVal->{type} && $pVal->{type} eq 'boolean') {
+      push @booleanMappings, $property;
+    }
+  }
+
+  return @booleanMappings;
+}
+
+sub getBooleanHeaders {
+  my ($headerAref, $mapping) = @_;
+
+  my %booleanValues = map { $_ => 1 } getBooleanMappings($mapping);
+
+  my @booleanHeaders = map { $booleanValues{$_} ? 1 : 0 } @$headerAref;
+
+  return @booleanHeaders;
+}
+
+sub go {
+  my $self = shift; $self->log( 'info', 'Beginning indexing' );
+
+  my ($filePath, $annotationFileInCompressed) = $self->_getFilePath();
+
+  my $fileSize = -s $filePath;
+
+  my $nIndices = int(ceil($fileSize / 10e9));
+
+  $self->indexConfig->{index_settings}{index}{number_of_shards} = $nIndices;
+
+  (my $err, undef, my $fh) = $self->getTarballInnerFh($filePath, $annotationFileInCompressed);
+
+  if($err) {
+    $self->_errorWithCleanup($!);
+    return ($!, undef);
+  }
+
+  my $fieldSeparator = $self->delimiter;
+
+  my $firstLine = <$fh>;
+
+  chomp $firstLine;
+
+  my $taintCheckRegex = $self->taintCheckRegex;
+
+  my @headerFields;
+  if ( $firstLine =~ m/$taintCheckRegex/xm ) {
+    @headerFields = split $fieldSeparator, $1;
+  } else {
+    return ("First line of input file has illegal characters", undef);
+  }
+
+  my @paths = @headerFields;
+  for (my $i = 0; $i < @paths; $i++) {
+    if( index($paths[$i], '.') > -1 ) {
+      $paths[$i] = [ split(/\./, $paths[$i]) ];
+    }
+  }
+
+  # ES since > 5.2 deprecates lenient boolean
+  my @booleanHeaders = getBooleanHeaders(\@headerFields, $self->indexConfig->{mappings});
+
+  my $delimiters = Seq::Output::Delimiters->new();
+
+  my $overlapDelimiter = $delimiters->overlapDelimiter;
+  my $positionDelimiter = $delimiters->positionDelimiter;
+  my $valueDelimiter = $delimiters->valueDelimiter;
+
+  my $emptyFieldChar = $delimiters->emptyFieldChar;
+
+  # We need to flush at the end of each chunk read; so chunk size directly
+  # controls bulk request size, as long as bulk request doesnt hit
+  # max_count and max_size thresholds
+  my $chunkSize = $self->getChunkSize($filePath, $self->max_threads);
+  if($chunkSize < 5000) {
+    $chunkSize = 5000;
+  } elsif($chunkSize > 10000) {
+    $chunkSize = 10000;
+  }
+
+  # Report every 10k lines; to avoid oversaturating receiver
+  my $progressFunc = $self->makeLogProgress(1e4);
+
+  MCE::Loop::init {
+    max_workers => 8, use_slurpio => 1, #Disable on shared storage: parallel_io => 1,
+    chunk_size => $chunkSize . 'K',
+    gather => $progressFunc,
+  };
+
+  # TODO: can use connection pool sniffing as well, not doing so atm
+  # because not sure if connection sniffing issue exists here as in
+  # elasticjs library
+  my $es = Search::Elasticsearch->new($self->connection);
+
+  if($es->indices->exists(index => $self->indexName) ) {
+    $es->indices->delete(index => $self->indexName);
+  }
+
+  say STDERR "CREATING INDEX NAME " .$self->indexName;
+
+  $es->indices->create(index => $self->indexName, body => {settings => $self->indexConfig->{index_settings}});
+
+  $es->indices->put_mapping(
+    index => $self->indexName,
+    body => $self->indexConfig->{mappings},
+  );
+
+  my $m1 = MCE::Mutex->new;
+  tie my $abortErr, 'MCE::Shared', '';
+
+  my $bulk = $es->bulk_helper(
+    index       => $self->indexName,
+    max_count   => 5000,
+    max_size    => 10000000,
+    on_error    => sub {
+      my ($action, $response, $i) = @_;
+      $self->log('warn', "Index error: $action ; $response ; $i");
+      p @_;
+      $m1->synchronize(sub{ $abortErr = $response} );
+    },           # optional
+    on_conflict => sub {
+      my ($action,$response,$i,$version) = @_;
+      $self->log('warn', "Index conflict: $action ; $response ; $i ; $version");
+    },           # optional
+  );
+
+  mce_loop_f {
+    my ($mce, $slurp_ref, $chunk_id) = @_;
+
+    my @lines;
+
+    if($abortErr) {
+      say "abort error found";
+      $mce->abort();
+    }
+
+    open my $MEM_FH, '<', $slurp_ref; binmode $MEM_FH, ':raw';
+
+    my $idxCount = 0;
+    while ( my $line = $MEM_FH->getline() ) {
+      chomp $line;
+
+      my @fields = split $fieldSeparator, $line;
+
+      my %rowDocument;
+      my $colIdx = 0;
+      my $foundWeird = 0;
+      my $valueIdx;
+      my $overlapIdx;
+      my $posIdx;
+      my $isBool;
+
+      # We use Perl's in-place modification / reference of looped-over variables
+      # http://ideone.com/HNgMf7
+      OUTER: for (my $i = 0; $i < @fields; $i++) {
+        my $field = $fields[$i];
+
+        #Every value is stored @ [alleleIdx][positionIdx]
+        my @out;
+
+        if($field ne $emptyFieldChar) {
+          # ES since > 5.2 deprecates lenient boolean
+          $valueIdx = 0;
+          $posIdx = 0;
+          $overlapIdx = 0;
+            POS_LOOP: for my $posValue ( split("\\$positionDelimiter", $field) ) {
+              if ($posValue eq $emptyFieldChar || $posValue eq "!") {
+                $out[$posIdx] = [[undef]];
+
+                $posIdx++;
+                next;
+              }
+
+              # ES since > 5.2 deprecates lenient boolean
+              for my $value ( split("\\$valueDelimiter", $posValue) ) {
+                if($value eq $emptyFieldChar || $value eq "!") {
+                  $out[$posIdx][$valueIdx]= [undef];
+
+                  $valueIdx++;
+                  next;
+                }
+                
+                for my $allele ( split("\\$overlapDelimiter", $value) ) {
+                  if($allele eq $emptyFieldChar || $allele eq "!") {
+                    $out[$posIdx][$valueIdx][$overlapIdx] = undef;
+
+                    $overlapIdx++;
+                    next;
+                  }
+
+                  $out[$posIdx][$valueIdx][$overlapIdx] = $allele;
+                  $overlapIdx++;
+                }
+
+                $valueIdx++;
+              }
+
+              $posIdx++;
+          }
+          
+          $rowDocument{$headerFields[$i]} = \@out;
+        }
+      }
+
+      $bulk->index({
+        index => $self->indexName,
+        source => \%rowDocument
+      });
+
+      $idxCount++;
+    }
+
+    # Without this, I cannot get all documents to show...
+    $bulk->flush();
+
+    MCE->gather($idxCount);
+  } $fh;
+
+  # Flush
+  &$progressFunc(0, 1);
+
+  MCE::Loop::finish();
+
+  # Disabled for now, we have many abort errors 
+  if($abortErr) {
+    MCE::Shared::stop();
+    say "Error creating index";
+    return ("Error creating index", undef, undef);
+  }
+
+  #Re-enable replicas
+  $es->indices->put_settings(
+    index => $self->indexName,
+    body => $self->indexConfig->{post_index_settings},
+  );
+
+  $es->indices->refresh(
+    index => $self->indexName,
+  );
+
+  $self->log('info', "finished indexing");
+
+  return (undef, \@headerFields, $self->indexConfig);
+}
+
+sub makeLogProgress {
+  my $self = shift;
+  my $throttleThreshold = shift;
+
+  my $total = 0;
+
+  my $hasPublisher = $self->hasPublisher;
+
+  if(!$hasPublisher) {
+    # noop
+    return sub{};
+  }
+
+  if(!$throttleThreshold) {
+    $throttleThreshold = 1e4;
+  }
+
+  my $throttleIndicator = 0;
+  return sub {
+    #my $progress, $flush = shift;
+    ##    $_[0]  , $_[1]
+
+    # send messages only every $throttleThreshold, to avoid overloading publishing server
+    if(defined $_[0]) {
+      $throttleIndicator += $_[0];
+
+      if($_[1] || $throttleIndicator >= $throttleThreshold) {
+        $total += $throttleIndicator;
+
+        $self->publishProgress($total);
+
+        $throttleIndicator = 0;
+      }
+    }
+  }
+}
+
+sub _getFilePath {
+  my $self = shift;
+
+  if($self->inputFileNames && $self->inputDir) {
+    # The user wants us to make the annotation_file_path
+    if(defined $self->inputFileNames->{archived}) {
+      # The user had compressed this file (see Seq.pm)
+      # This is expected to be a tarball, which we will extract, but only
+      # to stream the annotation file within the tarball package
+      my $path = $self->inputDir->child($self->inputFileNames->{archived});
+
+      return ($path, $self->inputFileNames->{annotation})
+    }
+
+    if($self->debug) {
+      say "in _getFilePath inputFileNames";
+      p $self->inputFileNames;
+      p $self->inputDir;
+    }
+
+    my $path = $self->inputDir->child($self->inputFileNames->{annotation});
+
+    return ($path, undef);
+  }
+
+  return $self->annotatedFilePath;
+}
+
+sub BUILD {
+  my $self = shift;
+
+  Seq::Role::Message::initialize();
+
+  # Seq::Role::Message settings
+  # We manually set the publisher, logPath, verbosity, and debug, because
+  # Seq::Role::Message is meant to be consumed globally, but configured once
+  # Treating publisher, logPath, verbose, debug as instance variables
+  # would result in having to configure this class in every consuming class
+  if(defined $self->publisher) {
+    $self->setPublisher($self->publisher);
+  }
+
+  if(defined $self->logPath) {
+    $self->setLogPath($self->logPath);
+  }
+
+  if(defined $self->verbose) {
+    $self->setVerbosity($self->verbose);
+  }
+
+  #todo: finisih ;for now we have only one level
+  if ($self->debug) {
+    $self->setLogLevel('DEBUG');
+  } else {
+    $self->setLogLevel('INFO');
+  }
+
+  if(defined $self->inputFileNames) {
+    if(!defined $self->inputDir) {
+      $self->log('warn', "If inputFileNames provided, inputDir required");
+      return ("If inputFileNames provided, inputDir required", undef);
+    }
+
+    if(!defined $self->inputFileNames->{archived}
+    && !defined $self->inputFileNames->{annnotation}  ) {
+      $self->log('warn', "annotation key required in inputFileNames when compressed key has a value");
+      return ("annotation key required in inputFileNames when compressed key has a value", undef);
+    }
+  } elsif(!defined $self->annotatedFilePath) {
+    $self->log('warn', "if inputFileNames not provided, annotatedFilePath must be passed");
+    return ("if inputFileNames not provided, annotatedFilePath must be passed", undef);
+  }
+}
+
+sub _errorWithCleanup {
+  my ($self, $msg) = @_;
+
+  # To send a message to clean up files.
+  # TODO: Need somethign better
+  #MCE->gather(undef, undef, $msg);
+
+  $self->log('warn', $msg);
+  return $msg;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/perl/lib/SeqElastic.pm
+++ b/perl/lib/SeqElastic.pm
@@ -28,436 +28,492 @@ use Try::Tiny;
 with 'Seq::Role::IO', 'Seq::Role::Message', 'MouseX::Getopt';
 
 # An archive, containing an "annotation" file
-has annotatedFilePath => (is => 'ro', isa => AbsFile, coerce => 1,
-  writer => '_setAnnotatedFilePath');
+has annotatedFilePath => (
+    is     => 'ro',
+    isa    => AbsFile,
+    coerce => 1,
+    writer => '_setAnnotatedFilePath'
+);
 
-has indexConfig => (is => 'ro', isa=> 'HashRef', coerce => 1, required => 1);
+has indexConfig => ( is => 'ro', isa => 'HashRef', coerce => 1, required => 1 );
 
-has connection => (is => 'ro', isa=> 'HashRef', coerce => 1, required => 1);
+has connection => ( is => 'ro', isa => 'HashRef', coerce => 1, required => 1 );
 
-has publisher => (is => 'ro');
+has publisher => ( is => 'ro' );
 
-has logPath => (is => 'ro', isa => AbsPath, coerce => 1);
+has logPath => ( is => 'ro', isa => AbsPath, coerce => 1 );
 
-has debug => (is => 'ro');
+has debug => ( is => 'ro' );
 
-has verbose => (is => 'ro');
+has verbose => ( is => 'ro' );
 
 # Probably the user id
-has indexName => (is => 'ro', required => 1);
+has indexName => ( is => 'ro', required => 1 );
 
-has dryRun => (is => 'ro');
+has dryRun => ( is => 'ro' );
 
 # has commitEvery => (is => 'ro', default => 1000);
 
 # If inputFileNames provided, inputDir is required
-has inputDir => (is => 'ro', isa => AbsDir, coerce => 1);
+has inputDir => ( is => 'ro', isa => AbsDir, coerce => 1 );
 
 # The user may have given some header fields already
 # If so, this is a re-indexing job, and we will want to append the header fields
-has headerFields => (is => 'ro', isa => 'ArrayRef');
+has headerFields => ( is => 'ro', isa => 'ArrayRef' );
 
 # The user may have given some additional files
 # We accept only an array of bed file here
 # TODO: implement
-has addedFiles => (is => 'ro', isa => 'ArrayRef');
+has addedFiles => ( is => 'ro', isa => 'ArrayRef' );
 
 # IF the user gives us an annotated file path, we will first index from
 # The annotation file wihin that archive
 #@ params
 # <Object> filePaths @params:
-  # <String> compressed : the name of the compressed folder holding annotation, stats, etc (only if $self->compress)
-  # <String> converted : the name of the converted folder
-  # <String> annnotation : the name of the annotation file
-  # <String> log : the name of the log file
-  # <Object> stats : the { statType => statFileName } object
+# <String> compressed : the name of the compressed folder holding annotation, stats, etc (only if $self->compress)
+# <String> converted : the name of the converted folder
+# <String> annnotation : the name of the annotation file
+# <String> log : the name of the log file
+# <Object> stats : the { statType => statFileName } object
 # Allows us to use all to to extract just the file we're interested from the compressed tarball
-has inputFileNames => (is => 'ro', isa => 'HashRef');
+has inputFileNames => ( is => 'ro', isa => 'HashRef' );
 
-has max_threads => (is => 'ro', isa => 'Int', lazy => 1, default => sub {
-  return 8;
-});
+has max_threads => (
+    is      => 'ro',
+    isa     => 'Int',
+    lazy    => 1,
+    default => sub {
+        return 8;
+    }
+);
 
 sub getBooleanMappings {
-  my ($mapRef, $parentName) = @_;
+    my ( $mapRef, $parentName ) = @_;
 
-  my @booleanMappings;
+    my @booleanMappings;
 
-  my $pVal;
-  for my $property (keys %{$mapRef->{properties}}) {
-    $pVal = $mapRef->{properties}{$property};
+    my $pVal;
+    for my $property ( keys %{ $mapRef->{properties} } ) {
+        $pVal = $mapRef->{properties}{$property};
 
-    if(exists $pVal->{fields}) {
-      for my $subProp (keys %{$pVal->{fields}}) {
-        if(exists $pVal->{fields}{$subProp}{type} && $pVal->{fields}{$subProp}{type} eq 'boolean') {
-          push @booleanMappings, "$property.$subProp";
+        if ( exists $pVal->{fields} ) {
+            for my $subProp ( keys %{ $pVal->{fields} } ) {
+                if ( exists $pVal->{fields}{$subProp}{type}
+                    && $pVal->{fields}{$subProp}{type} eq 'boolean' )
+                {
+                    push @booleanMappings, "$property.$subProp";
+                }
+            }
         }
-      }
-    } elsif(exists $pVal->{properties}) {
-      push @booleanMappings, getBooleanMappings($pVal, $property);
-    } elsif(exists $pVal->{type} && $pVal->{type} eq 'boolean') {
-      push @booleanMappings, $property;
+        elsif ( exists $pVal->{properties} ) {
+            push @booleanMappings, getBooleanMappings( $pVal, $property );
+        }
+        elsif ( exists $pVal->{type} && $pVal->{type} eq 'boolean' ) {
+            push @booleanMappings, $property;
+        }
     }
-  }
 
-  return @booleanMappings;
+    return @booleanMappings;
 }
 
 sub getBooleanHeaders {
-  my ($headerAref, $mapping) = @_;
+    my ( $headerAref, $mapping ) = @_;
 
-  my %booleanValues = map { $_ => 1 } getBooleanMappings($mapping);
+    my %booleanValues = map { $_ => 1 } getBooleanMappings($mapping);
 
-  my @booleanHeaders = map { $booleanValues{$_} ? 1 : 0 } @$headerAref;
+    my @booleanHeaders = map { $booleanValues{$_} ? 1 : 0 } @$headerAref;
 
-  return @booleanHeaders;
+    return @booleanHeaders;
 }
 
 sub go {
-  my $self = shift; $self->log( 'info', 'Beginning indexing' );
+    my $self = shift;
+    $self->log( 'info', 'Beginning indexing' );
 
-  my ($filePath, $annotationFileInCompressed) = $self->_getFilePath();
+    my ( $filePath, $annotationFileInCompressed ) = $self->_getFilePath();
 
-  my $fileSize = -s $filePath;
+    my $fileSize = -s $filePath;
 
-  my $nIndices = int(ceil($fileSize / 10e9));
+    my $nIndices = int( ceil( $fileSize / 10e9 ) );
 
-  $self->indexConfig->{index_settings}{index}{number_of_shards} = $nIndices;
+    $self->indexConfig->{index_settings}{index}{number_of_shards} = $nIndices;
 
-  (my $err, undef, my $fh) = $self->getTarballInnerFh($filePath, $annotationFileInCompressed);
+    ( my $err, undef, my $fh ) =
+      $self->getTarballInnerFh( $filePath, $annotationFileInCompressed );
 
-  if($err) {
-    $self->_errorWithCleanup($!);
-    return ($!, undef);
-  }
-
-  my $fieldSeparator = $self->delimiter;
-
-  my $firstLine = <$fh>;
-
-  chomp $firstLine;
-
-  my $taintCheckRegex = $self->taintCheckRegex;
-
-  my @headerFields;
-  if ( $firstLine =~ m/$taintCheckRegex/xm ) {
-    @headerFields = split $fieldSeparator, $1;
-  } else {
-    return ("First line of input file has illegal characters", undef);
-  }
-
-  my @paths = @headerFields;
-  for (my $i = 0; $i < @paths; $i++) {
-    if( index($paths[$i], '.') > -1 ) {
-      $paths[$i] = [ split(/\./, $paths[$i]) ];
-    }
-  }
-
-  # ES since > 5.2 deprecates lenient boolean
-  my @booleanHeaders = getBooleanHeaders(\@headerFields, $self->indexConfig->{mappings});
-
-  my $delimiters = Seq::Output::Delimiters->new();
-
-  my $overlapDelimiter = $delimiters->overlapDelimiter;
-  my $positionDelimiter = $delimiters->positionDelimiter;
-  my $valueDelimiter = $delimiters->valueDelimiter;
-
-  my $emptyFieldChar = $delimiters->emptyFieldChar;
-
-  # We need to flush at the end of each chunk read; so chunk size directly
-  # controls bulk request size, as long as bulk request doesnt hit
-  # max_count and max_size thresholds
-  my $chunkSize = $self->getChunkSize($filePath, $self->max_threads);
-  if($chunkSize < 5000) {
-    $chunkSize = 5000;
-  } elsif($chunkSize > 10000) {
-    $chunkSize = 10000;
-  }
-
-  # Report every 10k lines; to avoid oversaturating receiver
-  my $progressFunc = $self->makeLogProgress(1e4);
-
-  MCE::Loop::init {
-    max_workers => 8, use_slurpio => 1, #Disable on shared storage: parallel_io => 1,
-    chunk_size => $chunkSize . 'K',
-    gather => $progressFunc,
-  };
-
-  # TODO: can use connection pool sniffing as well, not doing so atm
-  # because not sure if connection sniffing issue exists here as in
-  # elasticjs library
-  my $es = Search::Elasticsearch->new($self->connection);
-
-  if($es->indices->exists(index => $self->indexName) ) {
-    $es->indices->delete(index => $self->indexName);
-  }
-
-  say STDERR "CREATING INDEX NAME " .$self->indexName;
-
-  $es->indices->create(index => $self->indexName, body => {settings => $self->indexConfig->{index_settings}});
-
-  $es->indices->put_mapping(
-    index => $self->indexName,
-    body => $self->indexConfig->{mappings},
-  );
-
-  my $m1 = MCE::Mutex->new;
-  tie my $abortErr, 'MCE::Shared', '';
-
-  my $bulk = $es->bulk_helper(
-    index       => $self->indexName,
-    max_count   => 5000,
-    max_size    => 10000000,
-    on_error    => sub {
-      my ($action, $response, $i) = @_;
-      $self->log('warn', "Index error: $action ; $response ; $i");
-      p @_;
-      $m1->synchronize(sub{ $abortErr = $response} );
-    },           # optional
-    on_conflict => sub {
-      my ($action,$response,$i,$version) = @_;
-      $self->log('warn', "Index conflict: $action ; $response ; $i ; $version");
-    },           # optional
-  );
-
-  mce_loop_f {
-    my ($mce, $slurp_ref, $chunk_id) = @_;
-
-    my @lines;
-
-    if($abortErr) {
-      say "abort error found";
-      $mce->abort();
+    if ($err) {
+        $self->_errorWithCleanup($!);
+        return ( $!, undef );
     }
 
-    open my $MEM_FH, '<', $slurp_ref; binmode $MEM_FH, ':raw';
+    my $fieldSeparator = $self->delimiter;
 
-    my $idxCount = 0;
-    while ( my $line = $MEM_FH->getline() ) {
-      chomp $line;
+    my $firstLine = <$fh>;
 
-      my @fields = split $fieldSeparator, $line;
+    chomp $firstLine;
 
-      my %rowDocument;
-      my $colIdx = 0;
-      my $foundWeird = 0;
-      my $valueIdx;
-      my $overlapIdx;
-      my $posIdx;
-      my $isBool;
+    my $taintCheckRegex = $self->taintCheckRegex;
+
+    my @headerFields;
+    if ( $firstLine =~ m/$taintCheckRegex/xm ) {
+        @headerFields = split $fieldSeparator, $1;
+    }
+    else {
+        return ( "First line of input file has illegal characters", undef );
+    }
+
+    my @paths = @headerFields;
+    for ( my $i = 0 ; $i < @paths ; $i++ ) {
+        if ( index( $paths[$i], '.' ) > -1 ) {
+            $paths[$i] = [ split( /\./, $paths[$i] ) ];
+        }
+    }
+
+    # ES since > 5.2 deprecates lenient boolean
+    my @booleanHeaders =
+      getBooleanHeaders( \@headerFields, $self->indexConfig->{mappings} );
+
+    my $delimiters = Seq::Output::Delimiters->new();
+
+    my $overlapDelimiter  = $delimiters->overlapDelimiter;
+    my $positionDelimiter = $delimiters->positionDelimiter;
+    my $valueDelimiter    = $delimiters->valueDelimiter;
+
+    my $emptyFieldChar = $delimiters->emptyFieldChar;
+
+    # We need to flush at the end of each chunk read; so chunk size directly
+    # controls bulk request size, as long as bulk request doesnt hit
+    # max_count and max_size thresholds
+    my $chunkSize = $self->getChunkSize( $filePath, $self->max_threads );
+    if ( $chunkSize < 5000 ) {
+        $chunkSize = 5000;
+    }
+    elsif ( $chunkSize > 10000 ) {
+        $chunkSize = 10000;
+    }
+
+    # Report every 10k lines; to avoid oversaturating receiver
+    my $progressFunc = $self->makeLogProgress(1e4);
+
+    MCE::Loop::init {
+        max_workers => 8,
+        use_slurpio => 1,    #Disable on shared storage: parallel_io => 1,
+        chunk_size  => $chunkSize . 'K',
+        gather      => $progressFunc,
+    };
+
+    # TODO: can use connection pool sniffing as well, not doing so atm
+    # because not sure if connection sniffing issue exists here as in
+    # elasticjs library
+    my $es = Search::Elasticsearch->new( $self->connection );
+
+    if ( $es->indices->exists( index => $self->indexName ) ) {
+        $es->indices->delete( index => $self->indexName );
+    }
+
+    say STDERR "CREATING INDEX NAME " . $self->indexName;
+
+    $es->indices->create(
+        index => $self->indexName,
+        body  => { settings => $self->indexConfig->{index_settings} }
+    );
+
+    $es->indices->put_mapping(
+        index => $self->indexName,
+        body  => $self->indexConfig->{mappings},
+    );
+
+    my $m1 = MCE::Mutex->new;
+    tie my $abortErr, 'MCE::Shared', '';
+
+    my $bulk = $es->bulk_helper(
+        index     => $self->indexName,
+        max_count => 5000,
+        max_size  => 10000000,
+        on_error  => sub {
+            my ( $action, $response, $i ) = @_;
+            $self->log( 'warn', "Index error: $action ; $response ; $i" );
+            p @_;
+            $m1->synchronize( sub { $abortErr = $response } );
+        },    # optional
+        on_conflict => sub {
+            my ( $action, $response, $i, $version ) = @_;
+            $self->log( 'warn',
+                "Index conflict: $action ; $response ; $i ; $version" );
+        },    # optional
+    );
+
+    mce_loop_f {
+        my ( $mce, $slurp_ref, $chunk_id ) = @_;
+
+        my @lines;
+
+        if ($abortErr) {
+            say "abort error found";
+            $mce->abort();
+        }
+
+        open my $MEM_FH, '<', $slurp_ref;
+        binmode $MEM_FH, ':raw';
+
+        my $idxCount = 0;
+        while ( my $line = $MEM_FH->getline() ) {
+            chomp $line;
+
+            my @fields = split $fieldSeparator, $line;
+
+            my %rowDocument;
+            my $colIdx     = 0;
+            my $foundWeird = 0;
+            my $valueIdx;
+            my $overlapIdx;
+            my $posIdx;
+            my $isBool;
 
       # We use Perl's in-place modification / reference of looped-over variables
       # http://ideone.com/HNgMf7
-      OUTER: for (my $i = 0; $i < @fields; $i++) {
-        my $field = $fields[$i];
+          OUTER: for ( my $i = 0 ; $i < @fields ; $i++ ) {
+                my $field = $fields[$i];
 
-        #Every value is stored @ [alleleIdx][positionIdx]
-        my @out;
+                #Every value is stored @ [alleleIdx][positionIdx]
+                my @out;
 
-        if($field ne $emptyFieldChar) {
-          # ES since > 5.2 deprecates lenient boolean
-          $valueIdx = 0;
-          $posIdx = 0;
-          $overlapIdx = 0;
-            POS_LOOP: for my $posValue ( split("\\$positionDelimiter", $field) ) {
-              if ($posValue eq $emptyFieldChar) {
-                $out[$posIdx] = [[undef]];
+                if ( $field ne $emptyFieldChar ) {
 
-                $posIdx++;
-                next;
-              }
+                    # ES since > 5.2 deprecates lenient boolean
+                    $valueIdx   = 0;
+                    $posIdx     = 0;
+                    $overlapIdx = 0;
+                  POS_LOOP:
+                    for my $posValue ( split( "\\$positionDelimiter", $field ) )
+                    {
+                        if ( $posValue eq $emptyFieldChar ) {
+                            $out[$posIdx] = [ [undef] ];
 
-              for my $value ( split("\\$valueDelimiter", $posValue) ) {
-                if($value eq $emptyFieldChar) {
-                  $out[$posIdx][$valueIdx]= [undef];
+                            $posIdx++;
+                            next;
+                        }
 
-                  $valueIdx++;
-                  next;
+                        for
+                          my $value ( split( "\\$valueDelimiter", $posValue ) )
+                        {
+                            if ( $value eq $emptyFieldChar ) {
+                                $out[$posIdx][$valueIdx] = [undef];
+
+                                $valueIdx++;
+                                next;
+                            }
+
+                            for my $allele (
+                                split( "\\$overlapDelimiter", $value ) )
+                            {
+                                if ( $allele eq $emptyFieldChar ) {
+                                    $out[$posIdx][$valueIdx][$overlapIdx] =
+                                      undef;
+
+                                    $overlapIdx++;
+                                    next;
+                                }
+
+                                $out[$posIdx][$valueIdx][$overlapIdx] =
+                                  looks_like_number($allele)
+                                  ? $allele + 0
+                                  : $allele;
+                                $overlapIdx++;
+                            }
+
+                            $valueIdx++;
+                        }
+
+                        $posIdx++;
+                    }
+
+                    $rowDocument{ $headerFields[$i] } = \@out;
                 }
-                
-                for my $allele ( split("\\$overlapDelimiter", $value) ) {
-                  if($allele eq $emptyFieldChar) {
-                    $out[$posIdx][$valueIdx][$overlapIdx] = undef;
+            }
 
-                    $overlapIdx++;
-                    next;
-                  }
-
-                  $out[$posIdx][$valueIdx][$overlapIdx] = looks_like_number($allele) ? $allele + 0 : $allele;
-                  $overlapIdx++;
+            $bulk->index(
+                {
+                    index  => $self->indexName,
+                    source => \%rowDocument
                 }
+            );
 
-                $valueIdx++;
-              }
-
-              $posIdx++;
-          }
-          
-          $rowDocument{$headerFields[$i]} = \@out;
+            $idxCount++;
         }
-      }
 
-      $bulk->index({
-        index => $self->indexName,
-        source => \%rowDocument
-      });
+        # Without this, I cannot get all documents to show...
+        $bulk->flush();
 
-      $idxCount++;
+        MCE->gather($idxCount);
+    }
+    $fh;
+
+    # Flush
+    &$progressFunc( 0, 1 );
+
+    MCE::Loop::finish();
+
+    # Disabled for now, we have many abort errors
+    if ($abortErr) {
+        MCE::Shared::stop();
+        say "Error creating index";
+        return ( "Error creating index", undef, undef );
     }
 
-    # Without this, I cannot get all documents to show...
-    $bulk->flush();
+    #Re-enable replicas
+    $es->indices->put_settings(
+        index => $self->indexName,
+        body  => $self->indexConfig->{post_index_settings},
+    );
 
-    MCE->gather($idxCount);
-  } $fh;
+    $es->indices->refresh( index => $self->indexName, );
 
-  # Flush
-  &$progressFunc(0, 1);
+    $self->log( 'info', "finished indexing" );
 
-  MCE::Loop::finish();
-
-  # Disabled for now, we have many abort errors 
-  if($abortErr) {
-    MCE::Shared::stop();
-    say "Error creating index";
-    return ("Error creating index", undef, undef);
-  }
-
-  #Re-enable replicas
-  $es->indices->put_settings(
-    index => $self->indexName,
-    body => $self->indexConfig->{post_index_settings},
-  );
-
-  $es->indices->refresh(
-    index => $self->indexName,
-  );
-
-  $self->log('info', "finished indexing");
-
-  return (undef, \@headerFields, $self->indexConfig);
+    return ( undef, \@headerFields, $self->indexConfig );
 }
 
 sub makeLogProgress {
-  my $self = shift;
-  my $throttleThreshold = shift;
+    my $self              = shift;
+    my $throttleThreshold = shift;
 
-  my $total = 0;
+    my $total = 0;
 
-  my $hasPublisher = $self->hasPublisher;
+    my $hasPublisher = $self->hasPublisher;
 
-  if(!$hasPublisher) {
-    # noop
-    return sub{};
-  }
+    if ( !$hasPublisher ) {
 
-  if(!$throttleThreshold) {
-    $throttleThreshold = 1e4;
-  }
-
-  my $throttleIndicator = 0;
-  return sub {
-    #my $progress, $flush = shift;
-    ##    $_[0]  , $_[1]
-
-    # send messages only every $throttleThreshold, to avoid overloading publishing server
-    if(defined $_[0]) {
-      $throttleIndicator += $_[0];
-
-      if($_[1] || $throttleIndicator >= $throttleThreshold) {
-        $total += $throttleIndicator;
-
-        $self->publishProgress($total);
-
-        $throttleIndicator = 0;
-      }
+        # noop
+        return sub { };
     }
-  }
+
+    if ( !$throttleThreshold ) {
+        $throttleThreshold = 1e4;
+    }
+
+    my $throttleIndicator = 0;
+    return sub {
+
+        #my $progress, $flush = shift;
+        ##    $_[0]  , $_[1]
+
+# send messages only every $throttleThreshold, to avoid overloading publishing server
+        if ( defined $_[0] ) {
+            $throttleIndicator += $_[0];
+
+            if ( $_[1] || $throttleIndicator >= $throttleThreshold ) {
+                $total += $throttleIndicator;
+
+                $self->publishProgress($total);
+
+                $throttleIndicator = 0;
+            }
+        }
+    }
 }
 
 sub _getFilePath {
-  my $self = shift;
+    my $self = shift;
 
-  if($self->inputFileNames && $self->inputDir) {
-    # The user wants us to make the annotation_file_path
-    if(defined $self->inputFileNames->{archived}) {
-      # The user had compressed this file (see Seq.pm)
-      # This is expected to be a tarball, which we will extract, but only
-      # to stream the annotation file within the tarball package
-      my $path = $self->inputDir->child($self->inputFileNames->{archived});
+    if ( $self->inputFileNames && $self->inputDir ) {
 
-      return ($path, $self->inputFileNames->{annotation})
+        # The user wants us to make the annotation_file_path
+        if ( defined $self->inputFileNames->{archived} ) {
+
+            # The user had compressed this file (see Seq.pm)
+            # This is expected to be a tarball, which we will extract, but only
+            # to stream the annotation file within the tarball package
+            my $path =
+              $self->inputDir->child( $self->inputFileNames->{archived} );
+
+            return ( $path, $self->inputFileNames->{annotation} );
+        }
+
+        if ( $self->debug ) {
+            say "in _getFilePath inputFileNames";
+            p $self->inputFileNames;
+            p $self->inputDir;
+        }
+
+        my $path =
+          $self->inputDir->child( $self->inputFileNames->{annotation} );
+
+        return ( $path, undef );
     }
 
-    if($self->debug) {
-      say "in _getFilePath inputFileNames";
-      p $self->inputFileNames;
-      p $self->inputDir;
-    }
-
-    my $path = $self->inputDir->child($self->inputFileNames->{annotation});
-
-    return ($path, undef);
-  }
-
-  return $self->annotatedFilePath;
+    return $self->annotatedFilePath;
 }
 
 sub BUILD {
-  my $self = shift;
+    my $self = shift;
 
-  Seq::Role::Message::initialize();
+    Seq::Role::Message::initialize();
 
-  # Seq::Role::Message settings
-  # We manually set the publisher, logPath, verbosity, and debug, because
-  # Seq::Role::Message is meant to be consumed globally, but configured once
-  # Treating publisher, logPath, verbose, debug as instance variables
-  # would result in having to configure this class in every consuming class
-  if(defined $self->publisher) {
-    $self->setPublisher($self->publisher);
-  }
-
-  if(defined $self->logPath) {
-    $self->setLogPath($self->logPath);
-  }
-
-  if(defined $self->verbose) {
-    $self->setVerbosity($self->verbose);
-  }
-
-  #todo: finisih ;for now we have only one level
-  if ($self->debug) {
-    $self->setLogLevel('DEBUG');
-  } else {
-    $self->setLogLevel('INFO');
-  }
-
-  if(defined $self->inputFileNames) {
-    if(!defined $self->inputDir) {
-      $self->log('warn', "If inputFileNames provided, inputDir required");
-      return ("If inputFileNames provided, inputDir required", undef);
+    # Seq::Role::Message settings
+    # We manually set the publisher, logPath, verbosity, and debug, because
+    # Seq::Role::Message is meant to be consumed globally, but configured once
+    # Treating publisher, logPath, verbose, debug as instance variables
+    # would result in having to configure this class in every consuming class
+    if ( defined $self->publisher ) {
+        $self->setPublisher( $self->publisher );
     }
 
-    if(!defined $self->inputFileNames->{archived}
-    && !defined $self->inputFileNames->{annnotation}  ) {
-      $self->log('warn', "annotation key required in inputFileNames when compressed key has a value");
-      return ("annotation key required in inputFileNames when compressed key has a value", undef);
+    if ( defined $self->logPath ) {
+        $self->setLogPath( $self->logPath );
     }
-  } elsif(!defined $self->annotatedFilePath) {
-    $self->log('warn', "if inputFileNames not provided, annotatedFilePath must be passed");
-    return ("if inputFileNames not provided, annotatedFilePath must be passed", undef);
-  }
+
+    if ( defined $self->verbose ) {
+        $self->setVerbosity( $self->verbose );
+    }
+
+    #todo: finisih ;for now we have only one level
+    if ( $self->debug ) {
+        $self->setLogLevel('DEBUG');
+    }
+    else {
+        $self->setLogLevel('INFO');
+    }
+
+    if ( defined $self->inputFileNames ) {
+        if ( !defined $self->inputDir ) {
+            $self->log( 'warn',
+                "If inputFileNames provided, inputDir required" );
+            return ( "If inputFileNames provided, inputDir required", undef );
+        }
+
+        if (   !defined $self->inputFileNames->{archived}
+            && !defined $self->inputFileNames->{annnotation} )
+        {
+            $self->log( 'warn',
+"annotation key required in inputFileNames when compressed key has a value"
+            );
+            return (
+"annotation key required in inputFileNames when compressed key has a value",
+                undef
+            );
+        }
+    }
+    elsif ( !defined $self->annotatedFilePath ) {
+        $self->log( 'warn',
+            "if inputFileNames not provided, annotatedFilePath must be passed"
+        );
+        return (
+            "if inputFileNames not provided, annotatedFilePath must be passed",
+            undef
+        );
+    }
 }
 
 sub _errorWithCleanup {
-  my ($self, $msg) = @_;
+    my ( $self, $msg ) = @_;
 
-  # To send a message to clean up files.
-  # TODO: Need somethign better
-  #MCE->gather(undef, undef, $msg);
+    # To send a message to clean up files.
+    # TODO: Need somethign better
+    #MCE->gather(undef, undef, $msg);
 
-  $self->log('warn', $msg);
-  return $msg;
+    $self->log( 'warn', $msg );
+    return $msg;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/perl/lib/SeqElastic.pm
+++ b/perl/lib/SeqElastic.pm
@@ -12,6 +12,7 @@ use List::MoreUtils qw/first_index/;
 use Sys::CpuAffinity;
 use POSIX qw/ceil/;
 use DDP;
+use Scalar::Util qw/looks_like_number/;
 
 our $VERSION = '0.001';
 
@@ -259,16 +260,15 @@ sub go {
           $posIdx = 0;
           $overlapIdx = 0;
             POS_LOOP: for my $posValue ( split("\\$positionDelimiter", $field) ) {
-              if ($posValue eq $emptyFieldChar || $posValue eq "!") {
+              if ($posValue eq $emptyFieldChar) {
                 $out[$posIdx] = [[undef]];
 
                 $posIdx++;
                 next;
               }
 
-              # ES since > 5.2 deprecates lenient boolean
               for my $value ( split("\\$valueDelimiter", $posValue) ) {
-                if($value eq $emptyFieldChar || $value eq "!") {
+                if($value eq $emptyFieldChar) {
                   $out[$posIdx][$valueIdx]= [undef];
 
                   $valueIdx++;
@@ -276,14 +276,14 @@ sub go {
                 }
                 
                 for my $allele ( split("\\$overlapDelimiter", $value) ) {
-                  if($allele eq $emptyFieldChar || $allele eq "!") {
+                  if($allele eq $emptyFieldChar) {
                     $out[$posIdx][$valueIdx][$overlapIdx] = undef;
 
                     $overlapIdx++;
                     next;
                   }
 
-                  $out[$posIdx][$valueIdx][$overlapIdx] = $allele;
+                  $out[$posIdx][$valueIdx][$overlapIdx] = looks_like_number($allele) ? $allele + 0 : $allele;
                   $overlapIdx++;
                 }
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,13 +8,11 @@ opensearch-py[async]==2.3.2
 pandas==2.1.1
 pyarrow==14.0.1
 pystalk==0.7.0
-ray==2.7.1
+ray==2.8.0
 ruamel.yaml==0.17.31
 scikit-allel==1.3.6
 scikit-learn==1.2.2
 skops==0.7.post0
 tqdm==4.65.0
-cvxpy==1.2.1
-cloudpickle==2.0.*
-tensorflow==2.11.0
-torch==2.0.1
+cloudpickle==3.0.0
+torch==2.1.0

--- a/startup.yml
+++ b/startup.yml
@@ -9,10 +9,10 @@ apps:
     args:
       --conf_dir config --queue_conf config/beanstalk.yml --search_conf config/elastic-config2.yml
   - name: BystroIndexServer
-    script: bystro-index-worker
-    interpreter: 'python'
+    script: perl/bin/bystro-index-server.pl
+    interpreter: 'perl '
     args:
-      --conf_dir config --queue_conf config/beanstalk.yml --search_conf config/elastic-config2.yml
+      -q config/beanstalk.yml -c config/elastic-config2.yml
   - name: BystroAncestryServer
     script: python/python/bystro/ancestry/listener.py
     interpreter: 'python'


### PR DESCRIPTION
* Switches us back to a lightly modified version of the Perl indexer, which performs better than the Python version, and is more battle tested
* Fixes the hg19 index to work with the latest field definitions in the v6 database (all of the new gnomad, caddIndel, clinvervcf, dbSNP annotations introduced as part of issue #302)
* Also updates several python dependencies, and removes unused dependencies

Both bystro-index-server.pl and SeqElastic.pm can be lightly reviewed. 

These came from the b10 branch with only the modifications needed to 1) support the updated "addresses" field in beanstalk.yml (and the removal of the events field), and the storage of consistently 3D array values (whereas in b10 we would store 1D arrays where possible).

The movitation here: The new annotation outputs are so large that they seem to be causing memory pressure for Ray, which is really optimized for numpy arrays not raw strings. This seems to result in many copies and inefficiency

I have made a Go version of the codebase, and a Rust version, but we have enough on our plate to avoid introducing completely new codebases, and both libraries are severely limited by network performance anyhow. So instead, I figured out how to save some processing time (avoiding making the nested JSON, which Opensearch 2 supports, it will automatically convert field.child to field: {child: value}), and moved back to the stable codebase.

I will leave the python code for now, because we may return to it in 2024 (at least the handler.py may be reused). This may go away in the future.