### PR TITLE
Issue #392: Write conf to output dir

### DIFF
--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -353,9 +353,12 @@ sub annotateFile {
   # Sync to ensure all files written
   # This simply tries each close/sync/move operation in order
   # And returns an error early, or proceeds to next operation
+  my $configOutPath = $self->_workingDir->child( $self->outputFilesInfo->{config} );
+
   $err =
        $self->safeClose($outFh)
     || ( $statsFh && $self->safeClose($statsFh) )
+    || $self->safeSystem( "cp " . $self->config . " $configOutPath" )
     || $self->safeSystem('sync')
     || $self->_moveFilesToOutputDir();
 

--- a/perl/lib/Seq/Definition.pm
+++ b/perl/lib/Seq/Definition.pm
@@ -69,6 +69,9 @@ has maxThreads => (
 
 has outputJson => ( is => 'ro', isa => 'Bool', default => 0 );
 
+# The path to the annotation configuration file
+has config => ( is => 'ro', isa => 'Str', required => 1 );
+
 # has badSamplesField => (is => 'ro', default => 'badSamples', lazy => 1);
 
 ################ Public Exports ##################
@@ -122,6 +125,8 @@ has outputFilesInfo => (
       # which dominates the archive 99%, cannot be compressed at all
       $out{archived} = $self->makeTarballName( $outBaseName, !$self->compress );
     }
+
+    $out{config} = path( $self->config )->basename;
 
     return \%out;
   }

--- a/perl/t/definition.t
+++ b/perl/t/definition.t
@@ -8,6 +8,7 @@ my $test_db_dir = Path::Tiny->tempdir();
 my %baseArgs = (
   database_dir     => 't/tracks/gene/db/raw',
   input_file       => 'foo',
+  config           => 't/tracks/gene/db/raw/config.yaml',
   output_file_base => 'bar',
   tracks           => {
     tracks => [
@@ -16,7 +17,7 @@ my %baseArgs = (
         type        => 'reference',
         assembly    => 'hg19',
         chromosomes => ['chr1'],
-        files_dir   => 'fglla',
+        files_dir   => 'fglla'
       }
     ]
   },
@@ -34,24 +35,6 @@ sub test_dosageMatrixOut {
   );
   like( $outputFilesInfo->{dosageMatrixOutPath},
     qr/dosage\.feather$/, 'dosageMatrixOutPath should end with dosage.feather' );
-}
-
-# Mock a minimal configuration for testing
-sub mockConfig {
-  my ( $type, $args ) = shift;
-  return {
-    input_file     => "/path/to/input_file",
-    fileProcessors => {
-      $type => {
-        program  => "mockProgram",
-        args     => "--arg1 --arg2 \%output\%",
-        no_stdin => 0,                         # or 1, depending on the test case
-      }
-    },
-    outputFilesInfo => { output => "/path/to/output_file", },
-    _workingDir     => Path::Tiny->tempdir,
-    # Define other necessary attributes or methods here
-  };
 }
 
 sub test_preparePreprocessorProgram {

--- a/python/python/bystro/search/index/listener.py
+++ b/python/python/bystro/search/index/listener.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 import subprocess
+import shutil
 
 from ruamel.yaml import YAML
 
@@ -134,13 +135,13 @@ def main():
         queue_conf_deserialized = YAML(typ="safe").load(queue_config_file)
 
     def handler_fn(_: ProgressPublisher, beanstalkd_job_data: IndexJobData) -> list[str]:
-        inputs = beanstalkd_job_data.inputFileNames
+        inputs = beanstalkd_job_data.input_file_names
 
-        annotation_path = os.path.join(beanstalkd_job_data.inputDir, inputs.annotation)
+        annotation_path = os.path.join(beanstalkd_job_data.input_dir, inputs.annotation)
         m_path = get_config_file_path(conf_dir, beanstalkd_job_data.assembly, ".mapping.y*ml")
 
         header_fields = run_handler_with_config(
-            index_name=beanstalkd_job_data.indexName,
+            index_name=beanstalkd_job_data.index_name,
             submission_id=beanstalkd_job_data.submissionID,
             mapping_config=m_path,
             opensearch_config=search_conf,
@@ -153,14 +154,17 @@ def main():
     def submit_msg_fn(job_data: IndexJobData):
         return SubmittedJobMessage(job_data.submissionID)
 
-    def completed_msg_fn(job_data: IndexJobData, fieldNames: list[str]):
-        m_path = get_config_file_path(conf_dir, job_data.assembly, ".mapping.y*ml")
+    def completed_msg_fn(job_data: IndexJobData, field_names: list[str]):
+        mapping_config_path = get_config_file_path(conf_dir, job_data.assembly, ".mapping.y*ml")
 
-        with open(m_path, "r", encoding="utf-8") as f:
-            mapping_conf = YAML(typ="safe").load(f)
+        # Write mapping config path to the job data out_dir directory
+        map_config_basename = os.path.basename(mapping_config_path)
+        out_dir = job_data.out_dir
+        map_config_out_path = os.path.join(out_dir, map_config_basename)
+        shutil.copyfile(mapping_config_path, map_config_out_path)
 
         return IndexJobCompleteMessage(
-            submissionID=job_data.submissionID, results=IndexJobResults(mapping_conf, fieldNames)
+            submissionID=job_data.submissionID, results=IndexJobResults(map_config_basename, field_names)
         )  # noqa: E501
 
     listen(

--- a/python/python/bystro/search/save/handler.py
+++ b/python/python/bystro/search/save/handler.py
@@ -1,4 +1,5 @@
 """A module to handle the saving of search results into a new annotation"""
+
 # TODO 2023-05-08: Track number of skipped entries
 # TODO 2023-05-08: Write to Arrow IPC or Parquet, alongside tsv.
 # TODO 2023-05-08: Implement distributed pipeline/filters/transforms
@@ -10,6 +11,7 @@ import logging
 import math
 import os
 import pathlib
+import shutil
 import subprocess
 import traceback
 from typing import Any
@@ -110,9 +112,7 @@ def _make_output_string(rows: list, delims: DelimitersConfig):
                             inner_values.append(
                                 delims.overlap.join(
                                     map(
-                                        lambda x: str(x)
-                                        if x is not None
-                                        else empty_field_char,
+                                        lambda x: str(x) if x is not None else empty_field_char,
                                         sub,
                                     )
                                 )
@@ -172,9 +172,7 @@ def _process_query(
 
             row = np.empty(len(field_names), dtype=object)
             for y in range(len(field_names)):
-                row[y] = _populate_data(
-                    child_fields[y], doc["_source"].get(parent_fields[y])
-                )
+                row[y] = _populate_data(child_fields[y], doc["_source"].get(parent_fields[y]))
 
             if row[discordant_idx][0][0] is False:
                 row[discordant_idx][0][0] = 0
@@ -223,25 +221,26 @@ def go(  # pylint:disable=invalid-name
     keep_alive="1d",
 ) -> AnnotationOutputs:
     """Main function for running the query and writing the output"""
-    output_dir = os.path.dirname(job_data.outputBasePath)
-    basename = os.path.basename(job_data.outputBasePath)
+    output_dir = os.path.dirname(job_data.output_base_path)
+    basename = os.path.basename(job_data.output_base_path)
+
     pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
-    outputs, stats = AnnotationOutputs.from_path(output_dir, basename, compress=True)
+    outputs, stats = AnnotationOutputs.from_path(
+        output_dir, basename, job_data.input_file_names.config, compress=True
+    )
 
-    written_chunks = [os.path.join(output_dir, f"{job_data.indexName}_header")]
+    written_chunks = [os.path.join(output_dir, f"{job_data.index_name}_header")]
 
-    header = bytes("\t".join(job_data.fieldNames) + "\n", encoding="utf-8")
+    header = bytes("\t".join(job_data.field_names) + "\n", encoding="utf-8")
     with gzip.open(written_chunks[-1], "wb") as fw:
         fw.write(header)  # type: ignore
 
     search_client_args = gather_opensearch_args(search_conf)
     client = OpenSearch(**search_client_args)
 
-    query = _clean_query(job_data.queryBody)
-    num_slices = _get_num_slices(
-        client, job_data.indexName, max_query_size, max_slices, query
-    )
-    pit_id = client.create_point_in_time(index=job_data.indexName, params={"keep_alive": keep_alive})["pit_id"]  # type: ignore   # noqa: E501
+    query = _clean_query(job_data.query_body)
+    num_slices = _get_num_slices(client, job_data.index_name, max_query_size, max_slices, query)
+    pit_id = client.create_point_in_time(index=job_data.index_name, params={"keep_alive": keep_alive})["pit_id"]  # type: ignore   # noqa: E501
     try:
         reporter = get_progress_reporter(publisher)
         query["pit"] = {"id": pit_id}
@@ -249,9 +248,7 @@ def go(  # pylint:disable=invalid-name
 
         reqs = []
         for slice_id in range(num_slices):
-            written_chunks.append(
-                os.path.join(output_dir, f"{job_data.indexName}_{slice_id}")
-            )
+            written_chunks.append(os.path.join(output_dir, f"{job_data.index_name}_{slice_id}"))
             body = query.copy()
             if num_slices > 1:
                 # Slice queries require max > 1
@@ -259,7 +256,7 @@ def go(  # pylint:disable=invalid-name
             res = _process_query.remote(
                 {"body": body},
                 search_client_args,
-                job_data.fieldNames,
+                job_data.field_names,
                 job_data.pipeline,
                 written_chunks[-1],
                 reporter,
@@ -274,9 +271,7 @@ def go(  # pylint:disable=invalid-name
         all_chunks = " ".join(written_chunks)
 
         annotation_path = os.path.join(output_dir, outputs.annotation)
-        ret = subprocess.call(
-            f"cat {all_chunks} > {annotation_path}; rm {all_chunks}", shell=True
-        )
+        ret = subprocess.call(f"cat {all_chunks} > {annotation_path}; rm {all_chunks}", shell=True)
         if ret != 0:
             raise IOError(f"Failed to write {annotation_path}")
 
@@ -286,6 +281,10 @@ def go(  # pylint:disable=invalid-name
         )
         if ret != 0:
             raise IOError(f"Failed to write statistics for {annotation_path}")
+
+        # Copy the config file to the output directory
+        annotation_config_path = os.path.join(job_data.input_dir, job_data.input_file_names.config)
+        shutil.copy(annotation_config_path, os.path.join(output_dir, job_data.input_file_names.config))
     except Exception as err:
         client.delete_point_in_time(body={"pit_id": pit_id})  # type: ignore
         raise IOError(err) from err

--- a/python/python/bystro/search/save/listener.py
+++ b/python/python/bystro/search/save/listener.py
@@ -11,13 +11,13 @@ from bystro.beanstalkd.worker import (
     QueueConf,
     listen,
 )
+from bystro.beanstalkd.messages import SubmittedJobMessage
 from bystro.search.save.handler import go
-from bystro.search.utils.annotation import AnnotationOutputs, get_config_file_path
+from bystro.search.utils.annotation import AnnotationOutputs
 from bystro.search.utils.messages import (
     SaveJobCompleteMessage,
     SaveJobData,
-    SaveJobResults,
-    SaveJobSubmitMessage,
+    SaveJobResults
 )
 
 TUBE = "saveFromQuery"
@@ -46,7 +46,6 @@ def main():
     )
     args = parser.parse_args()
 
-    config_path_base_dir = args.conf_dir
     with open(args.queue_conf, "r", encoding="utf-8") as queue_config_file:
         queue_conf = YAML(typ="safe").load(queue_config_file)
 
@@ -57,12 +56,7 @@ def main():
         return go(job_data=job_data, search_conf=search_conf, publisher=publisher)
 
     def submit_msg_fn(job_data: SaveJobData):
-        config_path = get_config_file_path(config_path_base_dir, job_data.assembly)
-
-        with open(config_path, "r", encoding="utf-8") as file:
-            job_config = YAML(typ="safe").load(file)
-
-        return SaveJobSubmitMessage(submissionID=job_data.submissionID, jobConfig=job_config)
+        return SubmittedJobMessage(submissionID=job_data.submissionID)
 
     def completed_msg_fn(job_data: SaveJobData, results: AnnotationOutputs) -> SaveJobCompleteMessage:
         return SaveJobCompleteMessage(

--- a/python/python/bystro/search/utils/annotation.py
+++ b/python/python/bystro/search/utils/annotation.py
@@ -82,6 +82,8 @@ class AnnotationOutputs(Struct, frozen=True, forbid_unknown_fields=True):
             Basename of the sample list file, in the output directory
         log: str
             Basename of the log file, in the output directory
+        config: str
+            Basename of the config file, in the output directory
         statistics: StatisticsOutputs
             Basenames of the statistics files, in the output directory
         dosageMatrixOutPath: str
@@ -95,6 +97,7 @@ class AnnotationOutputs(Struct, frozen=True, forbid_unknown_fields=True):
     annotation: str
     sampleList: str
     log: str
+    config: str
     statistics: StatisticsOutputs
     dosageMatrixOutPath: str
     header: str | None = None
@@ -104,6 +107,7 @@ class AnnotationOutputs(Struct, frozen=True, forbid_unknown_fields=True):
     def from_path(
         output_dir: str,
         basename: str,
+        annotation_config_path: str,
         compress: bool,
         make_dir: bool = True,
         make_dir_mode: int = 511,
@@ -121,7 +125,7 @@ class AnnotationOutputs(Struct, frozen=True, forbid_unknown_fields=True):
         if compress:
             annotation += ".gz"
 
-        sampleList = f"{basename}.sample_list"
+        sample_list = f"{basename}.sample_list"
 
         stats = Statistics(output_base_path=os.path.join(output_dir, basename))
         statistics_output_members = StatisticsOutputs(
@@ -135,8 +139,9 @@ class AnnotationOutputs(Struct, frozen=True, forbid_unknown_fields=True):
         return (
             AnnotationOutputs(
                 annotation=annotation,
-                sampleList=sampleList,
+                sampleList=sample_list,
                 statistics=statistics_output_members,
+                config=annotation_config_path,
                 dosageMatrixOutPath=dosage,
                 log=log,
             ),

--- a/python/python/bystro/search/utils/messages.py
+++ b/python/python/bystro/search/utils/messages.py
@@ -1,6 +1,5 @@
 from bystro.beanstalkd.messages import (
     BaseMessage,
-    SubmittedJobMessage,
     CompletedJobMessage,
     Struct,
 )
@@ -9,20 +8,21 @@ from bystro.search.save.hwe import HWEFilter
 from bystro.search.save.binomial_maf import BinomialMafFilter
 
 
-class IndexJobData(BaseMessage, frozen=True):
+class IndexJobData(BaseMessage, frozen=True, forbid_unknown_fields=True):
     """Data for Indexing jobs received from beanstalkd"""
 
-    inputDir: str
-    inputFileNames: AnnotationOutputs
-    indexName: str
+    input_dir: str
+    out_dir: str
+    input_file_names: AnnotationOutputs
+    index_name: str
     assembly: str
-    fieldNames: list[str] | None = None
-    indexConfig: dict | None = None
+    index_config_path: str | None = None
+    field_names: list[str] | None = None
 
 
 class IndexJobResults(Struct, frozen=True):
-    indexConfig: dict
-    fieldNames: list
+    index_config_path: str
+    field_names: list
 
 
 class IndexJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True):
@@ -36,19 +36,17 @@ class SaveJobData(BaseMessage, frozen=True):
     """Data for SaveFromQuery jobs received from beanstalkd"""
 
     assembly: str
-    queryBody: dict
-    indexName: str
-    outputBasePath: str
-    fieldNames: list[str]
+    query_body: dict
+    input_dir: str
+    input_file_names: AnnotationOutputs
+    index_name: str
+    output_base_path: str
+    field_names: list[str]
     pipeline: PipelineType = None
 
 
-class SaveJobSubmitMessage(SubmittedJobMessage, frozen=True, kw_only=True):
-    jobConfig: dict
-
-
 class SaveJobResults(Struct, frozen=True):
-    outputFileNames: AnnotationOutputs
+    output_file_names: AnnotationOutputs
 
 
 class SaveJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True):


### PR DESCRIPTION
* Don't output configuration objects directly to beanstalkd. Instead, write the configuration files to the user's output directory for reproducibility
* Continue threading through snake_case in python. 

This matches a corresponding change in Bystro-web that dynamically loads configurations, rather than relies on the data being passed around on the mongo object.

In a future PR I will completely remove camelCase from Python.