### PR TITLE
Bump Ray to 2.9.2

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ opensearch-py[async]==2.3.2
 pandas==2.1.1
 pyarrow==14.0.1
 pystalk==0.7.0
-ray==2.8.0
+ray==2.9.2
 ruamel.yaml==0.17.31
 scikit-allel==1.3.6
 scikit-learn==1.2.2


### PR DESCRIPTION
* Increase Ray to 2.9.2. Includes a number of enhances and official support for PyArrow 14.0.1, which we depend on: https://github.com/ray-project/ray/releases