### PR TITLE
Issue #393: Consistent snake_case in python library

### DIFF
--- a/go/beanstalkd/beanstalkd.go
+++ b/go/beanstalkd/beanstalkd.go
@@ -18,7 +18,7 @@ type ProgressData struct {
 }
 
 type ProgressMessage struct {
-	SubmissionID string       `json:"submissionID"`
+	SubmissionID string       `json:"submissionId"`
 	Data         ProgressData `json:"data"`
 	Event        string       `json:"event"`
 }

--- a/perl/bin/bystro-server.pl
+++ b/perl/bin/bystro-server.pl
@@ -53,11 +53,11 @@ my $conf = LoadFile($queueConfigPath);
 
 # The properties that we accept from the worker caller
 my %requiredForAll = (
-  output_file_base => 'output_base_path',
+  output_file_base => 'outputBasePath',
   assembly         => 'assembly',
 );
 
-my $requiredForType = { input_file => 'input_file_path' };
+my $requiredForType = { input_file => 'inputFilePath' };
 
 say "Running Annotation queue server";
 
@@ -125,8 +125,8 @@ while ( my $job = $beanstalk->reserve ) {
         data     => encode_json(
           {
             event        => $STARTED,
-            submissionID => $jobDataHref->{submissionID},
-            queueID      => $job->id,
+            submissionId => $jobDataHref->{submissionId},
+            queueId      => $job->id,
           }
         )
       }
@@ -161,8 +161,8 @@ while ( my $job = $beanstalk->reserve ) {
     my $data = {
       event        => $FAILED,
       reason       => $err,
-      queueID      => $job->id,
-      submissionID => $jobDataHref->{submissionID},
+      queueId      => $job->id,
+      submissionId => $jobDataHref->{submissionId},
     };
 
     $beanstalkEvents->put( { priority => 0, data => encode_json($data) } );
@@ -179,9 +179,9 @@ while ( my $job = $beanstalk->reserve ) {
 
   my $data = {
     event        => $COMPLETED,
-    queueID      => $job->id,
-    submissionID => $jobDataHref->{submissionID},
-    results      => { output_file_names => $outputFileNamesHashRef, }
+    queueId      => $job->id,
+    submissionId => $jobDataHref->{submissionId},
+    results      => { outputFileNames => $outputFileNamesHashRef, }
   };
 
   if ( defined $debug ) {
@@ -213,7 +213,7 @@ sub coerceInputs {
   my %jobSpecificArgs;
   for my $key ( keys %requiredForAll ) {
     if ( !defined $jobDetailsHref->{ $requiredForAll{$key} } ) {
-      $err = "Missing required key: $key in job message";
+      $err = "Missing required key: $requiredForAll{$key} in job message";
       return ( $err, undef );
     }
 
@@ -243,8 +243,8 @@ sub coerceInputs {
       queue       => $queueConfig->{events},
       messageBase => {
         event        => $PROGRESS,
-        queueID      => $queueId,
-        submissionID => $jobDetailsHref->{submissionID},
+        queueId      => $queueId,
+        submissionId => $jobDetailsHref->{submissionId},
         data         => undef,
       }
     },

--- a/python/python/bystro/ancestry/ancestry_types.py
+++ b/python/python/bystro/ancestry/ancestry_types.py
@@ -4,7 +4,7 @@ from msgspec import Struct
 LOWER_UNIT_BOUND = 0.0
 UPPER_UNIT_BOUND = 1.0
 
-class ProbabilityInterval(Struct):
+class ProbabilityInterval(Struct, rename="camel"):
     """Represent an interval of probabilities."""
 
     lower_bound: float
@@ -105,7 +105,7 @@ class AncestryTopHit(Struct):
             raise TypeError(f"probability must be between {LOWER_UNIT_BOUND} and {UPPER_UNIT_BOUND}")
 
 
-class AncestryScoresOneSample(Struct, frozen=True):
+class AncestryScoresOneSample(Struct, frozen=True, rename="camel"):
     """An ancestry result for a sample.
 
     Represents ancestry model output for an individual study

--- a/python/python/bystro/ancestry/inference.py
+++ b/python/python/bystro/ancestry/inference.py
@@ -26,7 +26,7 @@ from bystro.utils.timer import Timer
 logger = logging.getLogger(__name__)
 
 
-class AncestryModel(Struct, frozen=True, forbid_unknown_fields=True):
+class AncestryModel(Struct, frozen=True, forbid_unknown_fields=True, rename="camel"):
     """Bundle together PCA and RFC models for bookkeeping purposes."""
 
     pca_loadings_df: pd.DataFrame

--- a/python/python/bystro/ancestry/listener.py
+++ b/python/python/bystro/ancestry/listener.py
@@ -45,13 +45,13 @@ def _get_model_from_s3() -> AncestryModel:
     return AncestryModel(pca_loadings_df, rfc)
 
 
-class AncestryJobData(BaseMessage, frozen=True):
+class AncestryJobData(BaseMessage, frozen=True, rename="camel"):
     """
     The expected JSON message for the Ancestry job.
 
     Parameters
     ----------
-    submissionID: str
+    submission_id: str
         The unique identifier for the job.
     dosage_matrix_path: str
         The path to the dosage matrix file.
@@ -63,7 +63,7 @@ class AncestryJobData(BaseMessage, frozen=True):
     out_dir: str
 
 
-class AncestryJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True):
+class AncestryJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True, rename="camel"):
     """The returned JSON message expected by the API server"""
 
     result_path: str
@@ -100,7 +100,7 @@ def handler_fn_factory(
 def submit_msg_fn(ancestry_job_data: AncestryJobData) -> SubmittedJobMessage:
     """Acknowledge receipt of AncestryJobData."""
     logger.debug("entering submit_msg_fn: %s", ancestry_job_data)
-    return SubmittedJobMessage(ancestry_job_data.submissionID)
+    return SubmittedJobMessage(ancestry_job_data.submission_id)
 
 
 def completed_msg_fn(
@@ -116,7 +116,9 @@ def completed_msg_fn(
     with open(out_path, "wb") as f:
         f.write(json_data)
 
-    return AncestryJobCompleteMessage(submissionID=ancestry_job_data.submissionID, result_path=out_path)
+    return AncestryJobCompleteMessage(
+        submission_id=ancestry_job_data.submission_id, result_path=out_path
+    )
 
 
 def main(ancestry_model: AncestryModel, queue_conf: QueueConf) -> None:

--- a/python/python/bystro/api/cli.py
+++ b/python/python/bystro/api/cli.py
@@ -20,7 +20,7 @@ JOB_TYPE_ROUTE_MAP = {
 }
 
 
-class SignupResponse(Struct):
+class SignupResponse(Struct, rename="camel"):
     """
     The response body for signing up for Bystro.
 
@@ -33,7 +33,7 @@ class SignupResponse(Struct):
     access_token: str
 
 
-class LoginResponse(Struct):
+class LoginResponse(Struct, rename="camel"):
     """
     The response body for logging in to Bystro.
 
@@ -46,7 +46,7 @@ class LoginResponse(Struct):
     access_token: str
 
 
-class CachedAuth(Struct):
+class CachedAuth(Struct, rename="camel"):
     """
     The authentication state.
 
@@ -65,7 +65,7 @@ class CachedAuth(Struct):
     url: str
 
 
-class JobBasicResponse(Struct):
+class JobBasicResponse(Struct, rename="camel"):
     """
     The basic job information, returned in job list commands
 
@@ -84,7 +84,7 @@ class JobBasicResponse(Struct):
     createdAt: datetime.datetime
 
 
-class UserProfile(Struct):
+class UserProfile(Struct, rename="camel"):
     """
     The response body for fetching the user profile.
 

--- a/python/python/bystro/api/tests/test_cli.py
+++ b/python/python/bystro/api/tests/test_cli.py
@@ -78,7 +78,7 @@ EXAMPLE_JOB = {
         "_id": "64db4e68fb86b79cbda4f387",
         "type": "annotation",
         "submittedDate": "2023-08-15T10:07:36.027Z",
-        "queueID": "1538",
+        "queueId": "1538",
         "startedDate": "2023-08-15T10:07:37.045Z",
     },
     "config": json.encode(

--- a/python/python/bystro/beanstalkd/messages.py
+++ b/python/python/bystro/beanstalkd/messages.py
@@ -6,6 +6,7 @@ from msgspec import Struct, field
 SubmissionID = str | int
 BeanstalkJobID = int
 
+
 class Event(str, Enum):
     """Beanstalkd Event"""
 
@@ -14,27 +15,32 @@ class Event(str, Enum):
     STARTED = "started"
     COMPLETED = "completed"
 
-class BaseMessage(Struct, frozen=True):
-    submissionID: SubmissionID
+
+class BaseMessage(Struct, frozen=True, rename="camel"):
+    submission_id: SubmissionID
 
     @classmethod
     def keys_with_types(cls) -> dict:
         return get_type_hints(cls)
 
+
 class SubmittedJobMessage(BaseMessage, frozen=True):
     event: Event = Event.STARTED
 
+
 class CompletedJobMessage(BaseMessage, frozen=True):
     event: Event = Event.COMPLETED
+
 
 class FailedJobMessage(BaseMessage, frozen=True):
     reason: str
     event: Event = Event.FAILED
 
-class InvalidJobMessage(Struct, frozen=True):
+
+class InvalidJobMessage(Struct, frozen=True, rename="camel"):
     # Invalid jobs that are invalid because the submission breaks serialization invariants
-    # will not have a submissionID as that ID is held in the serialized data
-    queueID: BeanstalkJobID
+    # will not have a submission_id as that ID is held in the serialized data
+    queue_id: BeanstalkJobID
     reason: str
     event: Event = Event.FAILED
 
@@ -42,9 +48,11 @@ class InvalidJobMessage(Struct, frozen=True):
     def keys_with_types(cls) -> dict:
         return get_type_hints(cls)
 
+
 class ProgressData(Struct):
     progress: int = 0
     skipped: int = 0
+
 
 class ProgressMessage(BaseMessage, frozen=True):
     """Beanstalkd Message"""

--- a/python/python/bystro/beanstalkd/tests/test_messages.py
+++ b/python/python/bystro/beanstalkd/tests/test_messages.py
@@ -1,7 +1,7 @@
 import unittest
 from enum import Enum
 
-from msgspec import Struct
+from msgspec import Struct, json
 from msgspec.inspect import type_info, Field, IntType, NODEFAULT
 
 from bystro.beanstalkd.messages import (
@@ -45,13 +45,13 @@ class ModuleTests(unittest.TestCase):
 
         t_immutable = ImmutableT(a=1, b="test")
         with self.assertRaisesRegex(AttributeError, "immutable type: 'ImmutableT'"):
-            t_immutable.a = 2 # type: ignore
+            t_immutable.a = 2  # type: ignore
 
         t_default = DefaultT(a=1)
         self.assertEqual(t_default.b, "test")
 
         with self.assertRaisesRegex(TypeError, "Missing required argument 'c'"):
-            InheritedT(a=5, b="test") # type: ignore
+            InheritedT(a=5, b="test")  # type: ignore
 
     def test_event_enum(self):
         self.assertTrue(issubclass(Event, Enum))
@@ -63,91 +63,91 @@ class ModuleTests(unittest.TestCase):
     def test_base_message(self):
         self.assertTrue(issubclass(BaseMessage, Struct))
 
-        t = BaseMessage(submissionID="test")
+        t = BaseMessage(submission_id="test")
         types = BaseMessage.keys_with_types()
 
-        self.assertEqual(t.submissionID, "test")
-        self.assertEqual(set(types.keys()), set({"submissionID"}))
-        self.assertEqual(types["submissionID"], SubmissionID)
+        self.assertEqual(t.submission_id, "test")
+        self.assertEqual(set(types.keys()), set({"submission_id"}))
+        self.assertEqual(types["submission_id"], SubmissionID)
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'BaseMessage'"):
-            t.submissionID = "test2" # type: ignore
+            t.submission_id = "test2"  # type: ignore
 
     def test_submitted_job_message(self):
         self.assertTrue(issubclass(SubmittedJobMessage, BaseMessage))
 
-        t = SubmittedJobMessage(submissionID="test")
+        t = SubmittedJobMessage(submission_id="test")
         types = SubmittedJobMessage.keys_with_types()
 
         self.assertEqual(t.event, Event.STARTED)
-        self.assertEqual(set(types.keys()), set({"submissionID", "event"}))
-        self.assertEqual(types["submissionID"], SubmissionID)
+        self.assertEqual(set(types.keys()), set({"submission_id", "event"}))
+        self.assertEqual(types["submission_id"], SubmissionID)
         self.assertEqual(types["event"], Event)
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'SubmittedJobMessage'"):
-            t.submissionID = "test2" # type: ignore
+            t.submission_id = "test2"  # type: ignore
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'SubmittedJobMessage'"):
-            t.event = Event.PROGRESS # type: ignore
+            t.event = Event.PROGRESS  # type: ignore
 
     def test_completed_job_message(self):
         self.assertTrue(issubclass(CompletedJobMessage, BaseMessage))
 
-        t = CompletedJobMessage(submissionID="test")
+        t = CompletedJobMessage(submission_id="test")
         types = CompletedJobMessage.keys_with_types()
 
         self.assertEqual(t.event, Event.COMPLETED)
-        self.assertEqual(set(types.keys()), set({"submissionID", "event"}))
-        self.assertEqual(types["submissionID"], SubmissionID)
+        self.assertEqual(set(types.keys()), set({"submission_id", "event"}))
+        self.assertEqual(types["submission_id"], SubmissionID)
         self.assertEqual(types["event"], Event)
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'CompletedJobMessage'"):
-            t.submissionID = "test2" # type: ignore
+            t.submission_id = "test2"  # type: ignore
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'CompletedJobMessage'"):
-            t.event = Event.PROGRESS # type: ignore
+            t.event = Event.PROGRESS  # type: ignore
 
     def test_failed_job_message(self):
         self.assertTrue(issubclass(FailedJobMessage, BaseMessage))
 
         with self.assertRaisesRegex(TypeError, "Missing required argument 'reason'"):
-            t = FailedJobMessage(submissionID="test") # type: ignore
+            t = FailedJobMessage(submission_id="test")  # type: ignore
 
-        t = FailedJobMessage(submissionID="test", reason="foo")
+        t = FailedJobMessage(submission_id="test", reason="foo")
         types = FailedJobMessage.keys_with_types()
 
         self.assertEqual(t.event, Event.FAILED)
-        self.assertEqual(set(types.keys()), set({"submissionID", "event", "reason"}))
-        self.assertEqual(types["submissionID"], SubmissionID)
+        self.assertEqual(set(types.keys()), set({"submission_id", "event", "reason"}))
+        self.assertEqual(types["submission_id"], SubmissionID)
         self.assertEqual(types["event"], Event)
         self.assertEqual(types["reason"], str)
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'FailedJobMessage'"):
-            t.event = "test2" # type: ignore
+            t.event = "test2"  # type: ignore
 
     def test_invalid_job_message(self):
         self.assertTrue(issubclass(InvalidJobMessage, Struct))
         self.assertTrue(not issubclass(InvalidJobMessage, BaseMessage))
 
         with self.assertRaisesRegex(TypeError, "Missing required argument 'reason'"):
-            t = InvalidJobMessage(queueID="test") # type: ignore
+            t = InvalidJobMessage(queue_id="test")  # type: ignore
 
-        t = InvalidJobMessage(queueID=1, reason="foo")
+        t = InvalidJobMessage(queue_id=1, reason="foo")
         types = InvalidJobMessage.keys_with_types()
 
         self.assertEqual(t.event, Event.FAILED)
-        self.assertEqual(set(types.keys()), set({"queueID", "event", "reason"}))
-        self.assertEqual(types["queueID"], BeanstalkJobID)
+        self.assertEqual(set(types.keys()), set({"queue_id", "event", "reason"}))
+        self.assertEqual(types["queue_id"], BeanstalkJobID)
         self.assertEqual(types["event"], Event)
         self.assertEqual(types["reason"], str)
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'InvalidJobMessage'"):
-            t.event = "test2" # type: ignore
+            t.event = "test2"  # type: ignore
 
     def test_progress_data(self):
         self.assertTrue(issubclass(ProgressData, Struct))
 
-        types = list(type_info(ProgressData).fields) # type: ignore
+        types = list(type_info(ProgressData).fields)  # type: ignore
 
         expected_types = [
             Field(
@@ -179,26 +179,110 @@ class ModuleTests(unittest.TestCase):
     def test_progress_message(self):
         self.assertTrue(issubclass(ProgressMessage, BaseMessage))
 
-        with self.assertRaisesRegex(TypeError, "Missing required argument 'submissionID'"):
-            t = ProgressMessage() # type: ignore
+        with self.assertRaisesRegex(TypeError, "Missing required argument 'submission_id'"):
+            t = ProgressMessage()  # type: ignore
 
-        t = ProgressMessage(submissionID="test")
+        t = ProgressMessage(submission_id="test")
         types = ProgressMessage.keys_with_types()
 
         self.assertEqual(t.event, Event.PROGRESS)
-        self.assertEqual(set(types.keys()), set({"submissionID", "event", "data"}))
-        self.assertEqual(types["submissionID"], SubmissionID)
+        self.assertEqual(set(types.keys()), set({"submission_id", "event", "data"}))
+        self.assertEqual(types["submission_id"], SubmissionID)
         self.assertEqual(types["event"], Event)
         self.assertEqual(types["data"], ProgressData)
 
         with self.assertRaisesRegex(AttributeError, "immutable type: 'ProgressMessage'"):
-            t.submissionID = "test2" # type: ignore
+            t.submission_id = "test2"  # type: ignore
 
         t.data.progress = 1
         t.data.skipped = 2
 
         self.assertEqual(t.data.progress, 1)
         self.assertEqual(t.data.skipped, 2)
+
+    def test_job_started_message_camel_decamel(self):
+        msg = SubmittedJobMessage(submission_id="my_submission_id2")
+
+        serialized_values = json.encode(msg)
+        expected_value = {"submissionId": "my_submission_id2", "event": "started"}
+        serialized_expected_value = json.encode(expected_value)
+
+        self.assertEqual(serialized_values, serialized_expected_value)
+
+        deserialized_values = json.decode(serialized_expected_value, type=SubmittedJobMessage)
+
+        self.assertEqual(deserialized_values, msg)
+
+    def test_job_completed_message_camel_decamel(self):
+        msg = CompletedJobMessage(submission_id="my_submission_id2")
+
+        serialized_values = json.encode(msg)
+        expected_value = {"submissionId": "my_submission_id2", "event": "completed"}
+        serialized_expected_value = json.encode(expected_value)
+
+        self.assertEqual(serialized_values, serialized_expected_value)
+
+        deserialized_values = json.decode(serialized_expected_value, type=CompletedJobMessage)
+
+        self.assertEqual(deserialized_values, msg)
+
+    def test_job_failed_message_camel_decamel(self):
+        msg = FailedJobMessage(submission_id="my_submission_id2", reason="foo")
+
+        serialized_values = json.encode(msg)
+        expected_value = {"submissionId": "my_submission_id2", "reason": "foo", "event": "failed"}
+        serialized_expected_value = json.encode(expected_value)
+
+        self.assertEqual(serialized_values, serialized_expected_value)
+
+        deserialized_values = json.decode(serialized_expected_value, type=FailedJobMessage)
+
+        self.assertEqual(deserialized_values, msg)
+
+    def test_invalid_job_message_camel_decamel(self):
+        msg = InvalidJobMessage(queue_id=1, reason="foo")
+
+        serialized_values = json.encode(msg)
+        expected_value = {"queueId": 1, "reason": "foo", "event": "failed"}
+        serialized_expected_value = json.encode(expected_value)
+
+        self.assertEqual(serialized_values, serialized_expected_value)
+
+        deserialized_values = json.decode(serialized_expected_value, type=InvalidJobMessage)
+
+        self.assertEqual(deserialized_values, msg)
+
+    def test_progress_message_camel_decamel(self):
+        msg = ProgressMessage(
+            submission_id="my_submission_id2", data=ProgressData(progress=1, skipped=2)
+        )
+
+        serialized_values = json.encode(msg)
+        expected_value = {
+            "submissionId": "my_submission_id2",
+            "event": "progress",
+            "data": {"progress": 1, "skipped": 2},
+        }
+        serialized_expected_value = json.encode(expected_value)
+
+        self.assertEqual(serialized_values, serialized_expected_value)
+
+        deserialized_values = json.decode(serialized_expected_value, type=ProgressMessage)
+
+        self.assertEqual(deserialized_values, msg)
+
+    def test_base_message_camel_decamel(self):
+        msg = BaseMessage(submission_id="my_submission_id2")
+
+        serialized_values = json.encode(msg)
+        expected_value = {"submissionId": "my_submission_id2"}
+        serialized_expected_value = json.encode(expected_value)
+
+        self.assertEqual(serialized_values, serialized_expected_value)
+
+        deserialized_values = json.decode(serialized_expected_value, type=BaseMessage)
+
+        self.assertEqual(deserialized_values, msg)
 
 
 if __name__ == "__main__":

--- a/python/python/bystro/beanstalkd/worker.py
+++ b/python/python/bystro/beanstalkd/worker.py
@@ -60,8 +60,8 @@ def default_failed_msg_fn(
 ) -> FailedJobMessage | InvalidJobMessage:  # noqa: E501
     """Default failed message function"""
     if job_data is None:
-        return InvalidJobMessage(queueID=job_id, reason=str(err))
-    return FailedJobMessage(submissionID=job_data.submissionID, reason=str(err))
+        return InvalidJobMessage(queue_id=job_id, reason=str(err))
+    return FailedJobMessage(submission_id=job_data.submission_id, reason=str(err))
 
 
 def listen(
@@ -145,7 +145,7 @@ def listen(
                     host=client.host,
                     port=client.port,
                     queue=tube_conf["events"],
-                    message=ProgressMessage(submissionID=job_data.submissionID),
+                    message=ProgressMessage(submission_id=job_data.submission_id),
                 )
 
                 client.put_job(json.encode(submit_msg_fn(job_data)))

--- a/python/python/bystro/proteomics/proteomics_listener.py
+++ b/python/python/bystro/proteomics/proteomics_listener.py
@@ -34,7 +34,7 @@ class ProteomicsJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=Tru
 def submit_msg_fn(proteomics_job_data: ProteomicsJobData) -> SubmittedJobMessage:
     """Acknowledge receipt of ProteomicsJobData."""
     logger.debug("entering submit_msg_fn: %s", proteomics_job_data)
-    return SubmittedJobMessage(proteomics_job_data.submissionID)
+    return SubmittedJobMessage(proteomics_job_data.submission_id)
 
 
 def handler_fn(
@@ -60,7 +60,7 @@ def completed_msg_fn(
         )
         raise ValueError(err_msg)
     return ProteomicsJobCompleteMessage(
-        submissionID=proteomics_job_data.submissionID, results=proteomics_response
+        submission_id=proteomics_job_data.submission_id, results=proteomics_response
     )
 
 

--- a/python/python/bystro/proteomics/tests/test_proteomics_listener.py
+++ b/python/python/bystro/proteomics/tests/test_proteomics_listener.py
@@ -27,20 +27,20 @@ LOAD_FRAGPIPE_DATASET_PATCH_TARGET = "bystro.proteomics.proteomics_listener.load
 def test_submit_msg_fn_happy_path():
     proteomics_submission = ProteomicsSubmission("foo.tsv")
     proteomics_job_data = ProteomicsJobData(
-        submissionID="my_submission_id", proteomics_submission=proteomics_submission
+        submission_id="my_submission_id", proteomics_submission=proteomics_submission
     )
     submitted_job_message = submit_msg_fn(proteomics_job_data)
-    assert proteomics_job_data.submissionID == submitted_job_message.submissionID
+    assert proteomics_job_data.submission_id == submitted_job_message.submission_id
 
 
 def test_handler_fn_happy_path():
-    progress_message = ProgressMessage(submissionID="my_submission_id")
+    progress_message = ProgressMessage(submission_id="my_submission_id")
     publisher = ProgressPublisher(
         host="127.0.0.1", port=1234, queue="my_queue", message=progress_message
     )
     proteomics_submission = ProteomicsSubmission("foo.tsv")
     proteomics_job_data = ProteomicsJobData(
-        submissionID="my_submission_id2", proteomics_submission=proteomics_submission
+        submission_id="my_submission_id2", proteomics_submission=proteomics_submission
     )
     with patch(LOAD_FRAGPIPE_DATASET_PATCH_TARGET, return_value=FAKE_FRAGPIPE_DF) as _mock:
         proteomics_response = handler_fn(publisher, proteomics_job_data)
@@ -48,37 +48,37 @@ def test_handler_fn_happy_path():
 
 
 def test_completed_msg_fn_happy_path():
-    progress_message = ProgressMessage(submissionID="my_submission_id")
+    progress_message = ProgressMessage(submission_id="my_submission_id")
     publisher = ProgressPublisher(
         host="127.0.0.1", port=1234, queue="my_queue", message=progress_message
     )
 
     proteomics_submission = ProteomicsSubmission("foo.tsv")
     proteomics_job_data = ProteomicsJobData(
-        submissionID="my_submission_id", proteomics_submission=proteomics_submission
+        submission_id="my_submission_id", proteomics_submission=proteomics_submission
     )
 
     with patch(LOAD_FRAGPIPE_DATASET_PATCH_TARGET, return_value=FAKE_FRAGPIPE_DF) as _mock:
         proteomics_response = handler_fn(publisher, proteomics_job_data)
     proteomics_job_complete_message = completed_msg_fn(proteomics_job_data, proteomics_response)
 
-    assert proteomics_job_complete_message.submissionID == proteomics_job_data.submissionID
+    assert proteomics_job_complete_message.submission_id == proteomics_job_data.submission_id
     assert proteomics_job_complete_message.results == proteomics_response
 
 
 def test_completed_msg_fn_filenames_dont_match():
-    progress_message = ProgressMessage(submissionID="my_submission_id")
+    progress_message = ProgressMessage(submission_id="my_submission_id")
     publisher = ProgressPublisher(
         host="127.0.0.1", port=1234, queue="my_queue", message=progress_message
     )
 
     proteomics_submission = ProteomicsSubmission("foo.tsv")
     proteomics_job_data = ProteomicsJobData(
-        submissionID="my_submission_id", proteomics_submission=proteomics_submission
+        submission_id="my_submission_id", proteomics_submission=proteomics_submission
     )
     wrong_proteomics_submission = ProteomicsSubmission("wrong_file.tsv")
     wrong_proteomics_job_data = ProteomicsJobData(
-        submissionID="wrong_submission_id", proteomics_submission=wrong_proteomics_submission
+        submission_id="wrong_submission_id", proteomics_submission=wrong_proteomics_submission
     )
 
     with patch(LOAD_FRAGPIPE_DATASET_PATCH_TARGET, return_value=FAKE_FRAGPIPE_DF) as _mock:

--- a/python/python/bystro/prs/listener.py
+++ b/python/python/bystro/prs/listener.py
@@ -16,11 +16,11 @@ TUBE = "PRS"
 
 
 def submit_msg_fn(job_data: PRSJobData):
-    return SubmittedJobMessage(submissionID=job_data.submissionID)
+    return SubmittedJobMessage(submission_id=job_data.submission_id)
 
 
 def completed_msg_fn(job_data: PRSJobData, results: PRSJobResult) -> PRSJobResultMessage:
-    return PRSJobResultMessage(submissionID=job_data.submissionID, results=results)
+    return PRSJobResultMessage(submission_id=job_data.submission_id, results=results)
 
 
 def main():

--- a/python/python/bystro/search/index/listener.py
+++ b/python/python/bystro/search/index/listener.py
@@ -2,6 +2,7 @@
     CLI tool to start search indexing server that listens to beanstalkd queue
     and indexes submitted data in Opensearch
 """
+
 import argparse
 import os
 import subprocess
@@ -142,7 +143,7 @@ def main():
 
         header_fields = run_handler_with_config(
             index_name=beanstalkd_job_data.index_name,
-            submission_id=beanstalkd_job_data.submissionID,
+            submission_id=beanstalkd_job_data.submission_id,
             mapping_config=m_path,
             opensearch_config=search_conf,
             queue_config=queue_conf,
@@ -152,7 +153,8 @@ def main():
         return header_fields
 
     def submit_msg_fn(job_data: IndexJobData):
-        return SubmittedJobMessage(job_data.submissionID)
+        print("jbo_data", job_data)
+        return SubmittedJobMessage(job_data.submission_id)
 
     def completed_msg_fn(job_data: IndexJobData, field_names: list[str]):
         mapping_config_path = get_config_file_path(conf_dir, job_data.assembly, ".mapping.y*ml")
@@ -164,7 +166,8 @@ def main():
         shutil.copyfile(mapping_config_path, map_config_out_path)
 
         return IndexJobCompleteMessage(
-            submissionID=job_data.submissionID, results=IndexJobResults(map_config_basename, field_names)
+            submission_id=job_data.submission_id,
+            results=IndexJobResults(map_config_basename, field_names),
         )  # noqa: E501
 
     listen(

--- a/python/python/bystro/search/save/listener.py
+++ b/python/python/bystro/search/save/listener.py
@@ -56,11 +56,11 @@ def main():
         return go(job_data=job_data, search_conf=search_conf, publisher=publisher)
 
     def submit_msg_fn(job_data: SaveJobData):
-        return SubmittedJobMessage(submissionID=job_data.submissionID)
+        return SubmittedJobMessage(submission_id=job_data.submission_id)
 
     def completed_msg_fn(job_data: SaveJobData, results: AnnotationOutputs) -> SaveJobCompleteMessage:
         return SaveJobCompleteMessage(
-            submissionID=job_data.submissionID, results=SaveJobResults(results)
+            submission_id=job_data.submission_id, results=SaveJobResults(results)
         )
 
     listen(

--- a/python/python/bystro/search/utils/messages.py
+++ b/python/python/bystro/search/utils/messages.py
@@ -8,7 +8,7 @@ from bystro.search.save.hwe import HWEFilter
 from bystro.search.save.binomial_maf import BinomialMafFilter
 
 
-class IndexJobData(BaseMessage, frozen=True, forbid_unknown_fields=True):
+class IndexJobData(BaseMessage, frozen=True, forbid_unknown_fields=True, kw_only=True, rename="camel"):
     """Data for Indexing jobs received from beanstalkd"""
 
     input_dir: str
@@ -20,9 +20,9 @@ class IndexJobData(BaseMessage, frozen=True, forbid_unknown_fields=True):
     field_names: list[str] | None = None
 
 
-class IndexJobResults(Struct, frozen=True):
+class IndexJobResults(Struct, frozen=True, forbid_unknown_fields=True, rename="camel"):
     index_config_path: str
-    field_names: list
+    field_names: list[str]
 
 
 class IndexJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True):
@@ -32,7 +32,7 @@ class IndexJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True):
 PipelineType = list[BinomialMafFilter | HWEFilter] | None
 
 
-class SaveJobData(BaseMessage, frozen=True):
+class SaveJobData(BaseMessage, frozen=True, forbid_unknown_fields=True, kw_only=True, rename="camel"):
     """Data for SaveFromQuery jobs received from beanstalkd"""
 
     assembly: str
@@ -45,9 +45,9 @@ class SaveJobData(BaseMessage, frozen=True):
     pipeline: PipelineType = None
 
 
-class SaveJobResults(Struct, frozen=True):
+class SaveJobResults(Struct, frozen=True, rename="camel"):
     output_file_names: AnnotationOutputs
 
 
-class SaveJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True):
+class SaveJobCompleteMessage(CompletedJobMessage, frozen=True, kw_only=True, rename="camel"):
     results: SaveJobResults

--- a/python/python/bystro/search/utils/tests/test_annotation.py
+++ b/python/python/bystro/search/utils/tests/test_annotation.py
@@ -1,3 +1,4 @@
+from msgspec import json
 import pytest
 
 from bystro.search.utils.annotation import (
@@ -23,11 +24,9 @@ def test_delimiters_default_values():
 
 
 def test_delimiters_from_dict_no_arg():
-    with pytest.raises(
-        TypeError, match=r"missing 1 required positional argument: 'annotation_config'"
-    ):
+    with pytest.raises(TypeError, match=r"missing 1 required positional argument: 'annotation_config'"):
         # Ignoring type checking because we're testing the error
-        DelimitersConfig.from_dict() # type: ignore
+        DelimitersConfig.from_dict()  # type: ignore
 
 
 def test_delimiters_from_dict_no_delimiters_key():
@@ -38,9 +37,7 @@ def test_delimiters_from_dict_no_delimiters_key():
 
 def test_delimiters_from_dict_unexpected_key():
     annotation_config = {"delimiters": {"random_delim_key": "random_value"}}
-    with pytest.raises(
-        TypeError, match=r"Unexpected keyword argument 'random_delim_key'"
-    ):
+    with pytest.raises(TypeError, match=r"Unexpected keyword argument 'random_delim_key'"):
         DelimitersConfig.from_dict(annotation_config)
 
 
@@ -73,11 +70,9 @@ def test_delimiters_from_dict_partial_delimiters_key():
 
 
 def test_delimiters_unexpected_key():
-    with pytest.raises(
-        TypeError, match=r"Unexpected keyword argument 'random_delim_key2'"
-    ):
-         # Ignoring type checking because we're testing the error
-        DelimitersConfig(random_delim_key2= "random_value") # type: ignore
+    with pytest.raises(TypeError, match=r"Unexpected keyword argument 'random_delim_key2'"):
+        # Ignoring type checking because we're testing the error
+        DelimitersConfig(random_delim_key2="random_value")  # type: ignore
 
 
 def test_get_config_file_path_no_path_found(mocker):
@@ -129,23 +124,21 @@ def test_statistics_output_extensions_defaults():
 
 def test_statistics_config_defaults():
     config = StatisticsConfig()
-    assert config.dbSNPnameField == "dbSNP.name"
-    assert config.siteTypeField == "refSeq.siteType"
-    assert config.exonicAlleleFunctionField == "refSeq.exonicAlleleFunction"
-    assert config.refField == "ref"
-    assert config.homozygotesField == "homozygotes"
-    assert config.heterozygotesField == "heterozygotes"
-    assert config.altField == "alt"
-    assert config.programPath == "bystro-stats"
-    assert isinstance(config.outputExtensions, StatisticsOutputExtensions)
+    assert config.dbsnp_name_field == "dbSNP.name"
+    assert config.site_type_field == "refSeq.siteType"
+    assert config.exonic_allele_function_field == "refSeq.exonicAlleleFunction"
+    assert config.ref_field == "ref"
+    assert config.homozygotes_field == "homozygotes"
+    assert config.heterozygotes_field == "heterozygotes"
+    assert config.alt_field == "alt"
+    assert config.program_path == "bystro-stats"
+    assert isinstance(config.output_extension, StatisticsOutputExtensions)
 
 
 def test_statistics_config_from_dict_none():
-    with pytest.raises(
-        TypeError, match=r"missing 1 required positional argument: 'annotation_config'"
-    ):
+    with pytest.raises(TypeError, match=r"missing 1 required positional argument: 'annotation_config'"):
         # Ignoring type checking because we're testing the error
-        StatisticsConfig.from_dict() # type: ignore
+        StatisticsConfig.from_dict()  # type: ignore
 
 
 def test_statistics_config_from_dict_no_statistics_key():
@@ -153,15 +146,13 @@ def test_statistics_config_from_dict_no_statistics_key():
     config = StatisticsConfig.from_dict(annotation_config)
 
     assert (
-        config.dbSNPnameField == "dbSNP.name"
+        config.dbsnp_name_field == "dbSNP.name"
     )  # Again, just checking one representative default value
 
 
 def test_statistics_config_no_statistics_key():
-    with pytest.raises(
-        TypeError, match=r"Unexpected keyword argument 'random_stats_key2'"
-    ):
-        StatisticsConfig(random_stats_key2="random_value") # type: ignore
+    with pytest.raises(TypeError, match=r"Unexpected keyword argument 'random_stats_key2'"):
+        StatisticsConfig(random_stats_key2="random_value")  # type: ignore
 
 
 def test_statistics_config_from_dict_unexpected_key():
@@ -173,9 +164,9 @@ def test_statistics_config_from_dict_unexpected_key():
 def test_statistics_config_from_dict_with_statistics_key():
     annotation_config = {
         "statistics": {
-            "dbSNPnameField": "new.dbSNP.name",
-            "siteTypeField": "new.refSeq.siteType",
-            "outputExtensions": {
+            "dbsnp_name_field": "new.dbSNP.name",
+            "site_type_field": "new.refSeq.siteType",
+            "output_extension": {
                 "json": ".new.json",
                 "tsv": ".new.tsv",
                 "qc": ".new.qc.tsv",
@@ -183,11 +174,11 @@ def test_statistics_config_from_dict_with_statistics_key():
         }
     }
     config = StatisticsConfig.from_dict(annotation_config)
-    assert config.dbSNPnameField == "new.dbSNP.name"
-    assert config.siteTypeField == "new.refSeq.siteType"
-    assert config.outputExtensions.json == ".new.json"
-    assert config.outputExtensions.tsv == ".new.tsv"
-    assert config.outputExtensions.qc == ".new.qc.tsv"
+    assert config.dbsnp_name_field == "new.dbSNP.name"
+    assert config.site_type_field == "new.refSeq.siteType"
+    assert config.output_extension.json == ".new.json"
+    assert config.output_extension.tsv == ".new.tsv"
+    assert config.output_extension.qc == ".new.qc.tsv"
 
 
 def test_statistics_init_program_not_found(mocker):
@@ -216,3 +207,37 @@ def test_statistics_get_stats_arguments(mocker):
     )
 
     assert statistics.stdin_cli_stats_command == expected_args
+
+
+def test_StatisticsConfig_camel_decamel():
+    annotation_config = {
+        "statistics": {
+            "dbsnp_name_field": "new.dbSNP.name",
+            "site_type_field": "new.refSeq.siteType",
+            "output_extension": {
+                "json": ".new.json",
+                "tsv": ".new.tsv",
+                "qc": ".new.qc.tsv",
+            },
+        }
+    }
+    config = StatisticsConfig.from_dict(annotation_config)
+    serialized_values = json.encode(config)
+    expected_value = {
+        "dbsnpNameField": "new.dbSNP.name",
+        "siteTypeField": "new.refSeq.siteType",
+        "exonicAlleleFunctionField": "refSeq.exonicAlleleFunction",
+        "refField": "ref",
+        "homozygotesField": "homozygotes",
+        "heterozygotesField": "heterozygotes",
+        "altField": "alt",
+        "programPath": "bystro-stats",
+        "outputExtension": {
+            "json": ".new.json", "tsv": ".new.tsv", "qc": ".new.qc.tsv"
+        }
+    }
+    serialized_expected_value = json.encode(expected_value)
+    assert serialized_values == serialized_expected_value
+
+    deserialized_values = json.decode(serialized_expected_value, type=StatisticsConfig)
+    assert deserialized_values == config

--- a/python/python/bystro/search/utils/tests/test_search_messages.py
+++ b/python/python/bystro/search/utils/tests/test_search_messages.py
@@ -1,0 +1,246 @@
+from msgspec import json
+
+from bystro.search.utils.annotation import AnnotationOutputs, StatisticsOutputs
+from bystro.search.utils.messages import (
+    IndexJobData,
+    IndexJobResults,
+    IndexJobCompleteMessage,
+    SaveJobData,
+    SaveJobResults,
+    SaveJobCompleteMessage,
+)
+
+
+def test_index_job_data_camel_decamel():
+    job_data = IndexJobData(
+        submission_id="foo",
+        input_dir="input_dir",
+        out_dir="out_dir",
+        input_file_names=AnnotationOutputs(
+            annotation="annotation",
+            sample_list="sample_list",
+            log="log",
+            config="config",
+            statistics=StatisticsOutputs(json="json", tab="tab", qc="qc"),
+            dosage_matrix_out_path="dosage_matrix_out_path",
+            header="header",
+            archived=None,
+        ),
+        index_name="index_name",
+        assembly="assembly",
+        index_config_path="index_config_path",
+        field_names=["field1", "field2"],
+    )
+
+    serialized_values = json.encode(job_data)
+    expected_value = {
+        "submissionId": "foo",
+        "inputDir": "input_dir",
+        "outDir": "out_dir",
+        "inputFileNames": {
+            "annotation": "annotation",
+            "sampleList": "sample_list",
+            "log": "log",
+            "config": "config",
+            "statistics": {
+                "json": "json",
+                "tab": "tab",
+                "qc": "qc",
+            },
+            "dosageMatrixOutPath": "dosage_matrix_out_path",
+            "header": "header",
+            "archived": None,
+        },
+        "indexName": "index_name",
+        "assembly": "assembly",
+        "indexConfigPath": "index_config_path",
+        "fieldNames": ["field1", "field2"],
+    }
+    serialized_expected_value = json.encode(expected_value)
+
+    assert serialized_values == serialized_expected_value
+
+    deserialized_values = json.decode(serialized_expected_value, type=IndexJobData)
+    assert deserialized_values == job_data
+
+def test_index_job_results_camel_decamel():
+    job_results = IndexJobResults(
+        index_config_path="index_config_path",
+        field_names=["field1", "field2"]
+    )
+
+    serialized_values = json.encode(job_results)
+    expected_value = {
+        "indexConfigPath": "index_config_path",
+        "fieldNames": ["field1", "field2"]
+    }
+    serialized_expected_value = json.encode(expected_value)
+
+    assert serialized_values == serialized_expected_value
+
+    deserialized_values = json.decode(serialized_expected_value, type=IndexJobResults)
+    assert deserialized_values == job_results
+
+def test_index_job_complete_message_camel_decamel():
+    job_results = IndexJobResults(
+        index_config_path="index_config_path",
+        field_names=["field1", "field2"]
+    )
+    completed_msg = IndexJobCompleteMessage(
+        submission_id="foo",
+        results=job_results
+    )
+
+    serialized_values = json.encode(completed_msg)
+    expected_value = {
+        "submissionId": "foo",
+        "event": "completed",
+        "results": {
+            "indexConfigPath": "index_config_path",
+            "fieldNames": ["field1", "field2"]
+        }
+    }
+    serialized_expected_value = json.encode(expected_value)
+
+    assert serialized_values == serialized_expected_value
+
+    deserialized_values = json.decode(serialized_expected_value, type=IndexJobCompleteMessage)
+    assert deserialized_values == completed_msg
+
+def test_save_job_data_camel_decamel():
+    job_data = SaveJobData(
+        submission_id="submit1",
+        assembly="assembly",
+        query_body={"query": "body"},
+        input_dir="input_dir",
+        input_file_names=AnnotationOutputs(
+            annotation="annotation",
+            sample_list="sample_list",
+            log="log",
+            config="config",
+            statistics=StatisticsOutputs(json="json", tab="tab", qc="qc"),
+            dosage_matrix_out_path="dosage_matrix_out_path",
+            header="header",
+            archived=None,
+        ),
+        index_name="index_name",
+        output_base_path="output_base_path",
+        field_names=["field1", "field2"],
+        pipeline=None,
+    )
+
+    serialized_values = json.encode(job_data)
+    expected_value = {
+        "submissionId": "submit1",
+        "assembly": "assembly",
+        "queryBody": {"query": "body"},
+        "inputDir": "input_dir",
+        "inputFileNames": {
+            "annotation": "annotation",
+            "sampleList": "sample_list",
+            "log": "log",
+            "config": "config",
+            "statistics": {
+                "json": "json",
+                "tab": "tab",
+                "qc": "qc",
+            },
+            "dosageMatrixOutPath": "dosage_matrix_out_path",
+            "header": "header",
+            "archived": None,
+        },
+        "indexName": "index_name",
+        "outputBasePath": "output_base_path",
+        "fieldNames": ["field1", "field2"],
+        "pipeline": None,
+    }
+    serialized_expected_value = json.encode(expected_value)
+
+    assert serialized_values == serialized_expected_value
+
+    deserialized_values = json.decode(serialized_expected_value, type=SaveJobData)
+    assert deserialized_values == job_data
+
+def test_save_job_results_camel_decamel():
+    job_results = SaveJobResults(
+        output_file_names=AnnotationOutputs(
+            annotation="annotation",
+            sample_list="sample_list",
+            log="log",
+            config="config",
+            statistics=StatisticsOutputs(json="json", tab="tab", qc="qc"),
+            dosage_matrix_out_path="dosage_matrix_out_path",
+            header="header",
+            archived=None,
+        )
+    )
+
+    serialized_values = json.encode(job_results)
+    expected_value = {
+        "outputFileNames": {
+            "annotation": "annotation",
+            "sampleList": "sample_list",
+            "log": "log",
+            "config": "config",
+            "statistics": {
+                "json": "json",
+                "tab": "tab",
+                "qc": "qc",
+            },
+            "dosageMatrixOutPath": "dosage_matrix_out_path",
+            "header": "header",
+            "archived": None,
+        }
+    }
+    serialized_expected_value = json.encode(expected_value)
+
+    assert serialized_values == serialized_expected_value
+
+    deserialized_values = json.decode(serialized_expected_value, type=SaveJobResults)
+    assert deserialized_values == job_results
+
+def test_save_job_complete_message_camel_decamel():
+    job_results = SaveJobResults(
+        output_file_names=AnnotationOutputs(
+            annotation="annotation",
+            sample_list="sample_list",
+            log="log",
+            config="config",
+            statistics=StatisticsOutputs(json="json", tab="tab", qc="qc"),
+            dosage_matrix_out_path="dosage_matrix_out_path",
+            header="header",
+            archived=None,
+        )
+    )
+    completed_msg = SaveJobCompleteMessage(
+        submission_id="submit1",
+        results=job_results
+    )
+
+    serialized_values = json.encode(completed_msg)
+    expected_value = {
+        "submissionId": "submit1",
+        "event": "completed",
+        "results": {
+            "outputFileNames": {
+                "annotation": "annotation",
+                "sampleList": "sample_list",
+                "log": "log",
+                "config": "config",
+                "statistics": {
+                    "json": "json",
+                    "tab": "tab",
+                    "qc": "qc",
+                },
+                "dosageMatrixOutPath": "dosage_matrix_out_path",
+                "header": "header",
+                "archived": None,
+            }
+        }
+    }
+    serialized_expected_value = json.encode(expected_value)
+
+    assert serialized_values == serialized_expected_value
+
+    deserialized_values = json.decode(serialized_expected_value, type=SaveJobCompleteMessage)
+    assert deserialized_values == completed_msg

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 Cython==3.0.4
 attrs==23.1.0
 boto3==1.28.9
-liftover==1.1.16
+git+https://github.com/bystrogenomics/liftover.git@v1.1.18
 maturin[zig]==1.3.2
 msgspec==0.18.6
 opensearch-py[async]==2.3.2


### PR DESCRIPTION
* Enforces snake_case in python. This auto-converts from camelcase, and will convert back to camelcase upon serialization. This way our JSON responses and inputs can follow JSON conventions , but also Python conventions.
* As part of this submissionID -> submissionId and queueID -> queueId, because this makes auto-camelization/un-camelization easier
* Fork liftover and fix liftover failure due to https://github.com/jeremymcrae/liftover/issues/19