### PR TITLE
Issue #421: Improve OpenSearch relevance for HGVS queries

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -533,7 +533,6 @@ mappings:
           fields:
             exact:
               type: keyword
-              normalizer: lowercase_normalizer
         DBVARID:
           type: keyword
           normalizer: lowercase_normalizer


### PR DESCRIPTION
* Don't lowercase HGVS clinvarVCF.CLNHGVS, because no one lowercases HGVS