### PR TITLE
Issue #421: Update opensearch gnomad mappings to match updates hg19 and hg38 data

### DIFF
--- a/config/hg19.clean.yml
+++ b/config/hg19.clean.yml
@@ -1,10 +1,34 @@
 ---
 assembly: hg19
 build_author: alexkotlar
-build_date: 2023-11-08T00:03:00
+build_date: 2024-03-07T13:01:00
 chromosomes:
   - chr1
-database_dir: "~"
+  - chr2
+  - chr3
+  - chr4
+  - chr5
+  - chr6
+  - chr7
+  - chr8
+  - chr9
+  - chr10
+  - chr11
+  - chr12
+  - chr13
+  - chr14
+  - chr15
+  - chr16
+  - chr17
+  - chr18
+  - chr19
+  - chr20
+  - chr21
+  - chr22
+  - chrM
+  - chrX
+  - chrY
+database_dir: /mnt/annotator/hg19_v8
 fileProcessors:
   snp:
     args: --emptyField NA --minGq .95
@@ -12,9 +36,9 @@ fileProcessors:
   vcf:
     args: --emptyField NA --sample %sampleList% --keepPos --keepId --dosageOutput %dosageMatrixOutPath%
     program: bystro-vcf
-files_dir: "~"
+files_dir: /mnt/files1/bystro_annotator/raw_files/hg19
 statistics:
-  dbSNPnameField: dbSNP.name
+  dbSNPnameField: dbSNP.id
   exonicAlleleFunctionField: refSeq.exonicAlleleFunction
   outputExtensions:
     json: .statistics.json
@@ -23,14 +47,22 @@ statistics:
   programPath: bystro-stats
   refTrackField: ref
   siteTypeField: refSeq.siteType
-temp_dir: "~"
+temp_dir: /mnt/annotator/tmp
 tracks:
   outputOrder:
     - ref
-    - clinvar2
+    - refSeq
+    - nearest.refSeq
+    - nearestTss.refSeq
+    - clinvarVcf
+    - gnomad.exomes
+    - gnomad.genomes
+    - dbSNP
+    - cadd
+    - caddIndel
   tracks:
     - build_author: alexkotlar
-      build_date: 2023-11-05T22:11:00
+      build_date: 2024-03-07T13:01:00
       local_files:
         - chr1.fa.gz
         - chr2.fa.gz
@@ -88,10 +120,322 @@ tracks:
               - chrM.fa.gz
               - chrX.fa.gz
               - chrY.fa.gz
+          completed: 2023-11-09T20:16:00
           name: fetch
-      version: 32
+      version: 35
     - build_author: alexkotlar
-      build_date: 2023-11-08T00:03:00
+      build_date: 2024-03-07T13:01:00
+      build_field_transformations:
+        description: split [;]
+        ensemblID: split [;]
+        kgID: split [;]
+        mRNA: split [;]
+        protAcc: split [;]
+        rfamAcc: split [;]
+        spDisplayID: split [;]
+        spID: split [;]
+        tRnaName: split [;]
+      features:
+        - name
+        - name2
+        - description
+        - kgID
+        - mRNA
+        - spID
+        - spDisplayID
+        - protAcc
+        - rfamAcc
+        - tRnaName
+        - ensemblID
+      join:
+        features:
+          - alleleID
+          - phenotypeList
+          - clinicalSignificance
+          - type
+          - origin
+          - numberSubmitters
+          - reviewStatus
+          - chromStart
+          - chromEnd
+        track: clinvar
+      local_files:
+        - hg19.kgXref.chr1.gz
+        - hg19.kgXref.chr2.gz
+        - hg19.kgXref.chr3.gz
+        - hg19.kgXref.chr4.gz
+        - hg19.kgXref.chr5.gz
+        - hg19.kgXref.chr6.gz
+        - hg19.kgXref.chr7.gz
+        - hg19.kgXref.chr8.gz
+        - hg19.kgXref.chr9.gz
+        - hg19.kgXref.chr10.gz
+        - hg19.kgXref.chr11.gz
+        - hg19.kgXref.chr12.gz
+        - hg19.kgXref.chr13.gz
+        - hg19.kgXref.chr14.gz
+        - hg19.kgXref.chr15.gz
+        - hg19.kgXref.chr16.gz
+        - hg19.kgXref.chr17.gz
+        - hg19.kgXref.chr18.gz
+        - hg19.kgXref.chr19.gz
+        - hg19.kgXref.chr20.gz
+        - hg19.kgXref.chr21.gz
+        - hg19.kgXref.chr22.gz
+        - hg19.kgXref.chrM.gz
+        - hg19.kgXref.chrX.gz
+        - hg19.kgXref.chrY.gz
+      name: refSeq
+      type: gene
+      utils:
+        - args:
+            connection:
+              database: hg19
+            sql:
+              SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
+              ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
+              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
+              e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
+              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
+              kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
+              GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
+              x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
+              GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
+              x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
+              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
+              refGene r WHERE chrom=%chromosomes%;
+          completed: 2023-11-09T20:18:00
+          name: fetch
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
+      build_row_filters:
+        AS_FilterStatus: == PASS
+      features:
+        - alt
+        - id
+        - AN: number
+        - AF: number
+        - AN_female: number
+        - AF_female: number
+        - non_cancer_AN: number
+        - non_cancer_AF: number
+        - non_neuro_AN: number
+        - non_neuro_AF: number
+        - non_topmed_AN: number
+        - non_topmed_AF: number
+        - controls_AN: number
+        - controls_AF: number
+        - AN_nfe_seu: number
+        - AF_nfe_seu: number
+        - AN_nfe_bgr: number
+        - AF_nfe_bgr: number
+        - AN_afr: number
+        - AF_afr: number
+        - AN_sas: number
+        - AF_sas: number
+        - AN_nfe_onf: number
+        - AF_nfe_onf: number
+        - AN_amr: number
+        - AF_amr: number
+        - AN_eas: number
+        - AF_eas: number
+        - AN_nfe_swe: number
+        - AF_nfe_swe: number
+        - AN_nfe_nwe: number
+        - AF_nfe_nwe: number
+        - AN_eas_jpn: number
+        - AF_eas_jpn: number
+        - AN_eas_kor: number
+        - AF_eas_kor: number
+      local_files:
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.1.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.2.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.3.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.4.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.5.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.6.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.7.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.8.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.9.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.10.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.11.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.12.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.13.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.14.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.15.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.16.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.17.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.18.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.19.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.20.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.21.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.22.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.X.vcf.bgz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/exomes/gnomad.exomes.r2.1.1.sites.Y.vcf.bgz
+      name: gnomad.exomes
+      type: vcf
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
+      local_files:
+        - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
+      name: cadd
+      sorted: 1
+      type: cadd
+      version: 6
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
+      dist: true
+      features:
+        - name2
+        - name
+      from: txStart
+      name: nearest.refSeq
+      ref: refSeq
+      to: txEnd
+      type: nearest
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
+      dist: true
+      features:
+        - name2
+        - name
+      from: txStart
+      name: nearestTss.refSeq
+      ref: refSeq
+      type: nearest
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
+      features:
+        - alt
+        - id
+        - AN: number
+        - AF: number
+        - AN_female: number
+        - AF_female: number
+        - non_neuro_AN: number
+        - non_neuro_AF: number
+        - non_topmed_AN: number
+        - non_topmed_AF: number
+        - controls_AN: number
+        - controls_AF: number
+        - AN_nfe_seu: number
+        - AF_nfe_seu: number
+        - AN_afr: number
+        - AF_afr: number
+        - AN_nfe_onf: number
+        - AF_nfe_onf: number
+        - AN_amr: number
+        - AF_amr: number
+        - AN_eas: number
+        - AF_eas: number
+        - AN_nfe_nwe: number
+        - AF_nfe_nwe: number
+        - AN_nfe_est: number
+        - AF_nfe_est: number
+        - AN_nfe: number
+        - AF_nfe: number
+        - AN_fin: number
+        - AF_fin: number
+        - AN_asj: number
+        - AF_asj: number
+        - AN_oth: number
+        - AF_oth: number
+      local_files:
+        - /mnt/files1/bystro_annotator/raw_files/hg19/gnomad2/vcf/genomes/gnomad.genomes.r2.1.1.sites.*.vcf.bgz
+      name: gnomad.genomes
+      type: vcf
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
+      features:
+        - id
+        - alt
+        - TOMMO: number
+        - ExAC: number
+        - GnomAD: number
+        - Korea1K: number
+        - GoNL: number
+        - KOREAN: number
+        - TWINSUK: number
+        - Vietnamese: number
+        - GENOME_DK: number
+        - GoESP: number
+        - GnomAD_exomes: number
+        - Siberian: number
+        - PRJEB37584: number
+        - SGDP_PRJ: number
+        - 1000Genomes: number
+        - dbGaP_PopFreq: number
+        - NorthernSweden: number
+        - HapMap: number
+        - TOPMED: number
+        - ALSPAC: number
+        - Qatari: number
+        - MGP: number
+      local_files:
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.1.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.2.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.3.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.4.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.5.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.6.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.7.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.8.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.9.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.10.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.11.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.12.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.13.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.14.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.15.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.16.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.17.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.18.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.19.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.20.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.21.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.22.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.X.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.Y.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.MT.vcf.gz
+      name: dbSNP
+      type: vcf
+      utils:
+        - completed: 2023-11-09T20:19:00
+          name: DbSnp2FormatInfo
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
       build_field_transformations:
         CLNDISDB: split [|]
         CLNDN: split [|]
@@ -116,8 +460,69 @@ tracks:
         - SSR
         - RS
       local_files:
-        - /mnt/files1/bystro_annotator/raw_files/hg19/clinvar/clinvar_20221001.vcf.gz
-      name: clinvar2
+        - clinvar.vcf.gz
+      name: clinvarVcf
       type: vcf
-      version: 5
-version: 16
+      utils:
+        - args:
+            remoteFiles:
+              - https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz
+          completed: 2024-03-07T12:50:00
+          name: fetch
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-07T13:01:00
+      features:
+        - alt
+        - PHRED: number
+      local_files:
+        - /mnt/files1/bystro_annotator/raw_files/hg19/caddIndel/Indels.vcf.gz
+      name: caddIndel
+      type: vcf
+      version: 4
+    - based: 1
+      build_field_transformations:
+        chrom: chr .
+        clinicalSignificance: split [;]
+        origin: split [;]
+        phenotypeList: split [;]
+        reviewStatus: split [;]
+        type: split [;]
+      build_row_filters:
+        Assembly: == GRCh37
+      features:
+        - alleleID: number
+        - phenotypeList
+        - clinicalSignificance
+        - type
+        - origin
+        - numberSubmitters: number
+        - reviewStatus
+        - referenceAllele
+        - alternateAllele
+      fieldMap:
+        "#AlleleID": alleleID
+        AlternateAllele: alternateAllele
+        Chromosome: chrom
+        ClinicalSignificance: clinicalSignificance
+        NumberSubmitters: numberSubmitters
+        Origin: origin
+        PhenotypeIDS: phenotypeIDs
+        PhenotypeList: phenotypeList
+        ReferenceAllele: referenceAllele
+        ReviewStatus: reviewStatus
+        Start: chromStart
+        Stop: chromEnd
+        Type: type
+      local_files:
+        - variant_summary.txt.gz
+      name: clinvar
+      no_build: true
+      type: sparse
+      utils:
+        - args:
+            remoteFiles:
+              - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
+          completed: 2024-03-07T12:51:00
+          name: fetch
+version: 4

--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -1,7 +1,5 @@
 sort:
   cadd: avg
-  dbSNP.alleleNs: avg
-  dbSNP.alleleFreqs: min
   refSeq.codonNumber: avg
   refSeq.codonPosition: avg
 post_index_settings:
@@ -594,8 +592,6 @@ mappings:
           type: half_float
         MGP:
           type: half_float
-        alleleFreqs:
-          type: half_float
     gnomad:
       properties:
         genomes:
@@ -610,599 +606,65 @@ mappings:
               type: integer
             AF:
               type: half_float
+            AN_female:
+              type: integer
+            AF_female:
+              type: half_float
+            non_neuro_AN:
+              type: integer
+            non_neuro_AF:
+              type: half_float
+            non_topmed_AN:
+              type: integer
+            non_topmed_AF:
+              type: half_float
+            controls_AN:
+              type: integer
+            controls_AF:
+              type: half_float
             AN_nfe_seu:
               type: integer
             AF_nfe_seu:
-              type: half_float
-            nhomalt_nfe_seu:
-              type: integer
-            controls_AN_afr_male:
-              type: integer
-            controls_AF_afr_male:
-              type: half_float
-            controls_nhomalt_afr_male:
-              type: half_float
-            non_topmed_AN_amr:
-              type: integer
-            non_topmed_AF_amr:
-              type: half_float
-            non_topmed_nhomalt_amr:
-              type: integer
-            AN_raw:
-              type: integer
-            AF_raw:
-              type: half_float
-            nhomalt_raw:
-              type: integer
-            AN_fin_female:
-              type: integer
-            AF_fin_female:
-              type: half_float
-            nhomalt_fin_female:
-              type: integer
-            non_neuro_AN_asj_female:
-              type: integer
-            non_neuro_AF_asj_female:
-              type: half_float
-            non_neuro_nhomalt_asj_female:
-              type: integer
-            non_neuro_AN_afr_male:
-              type: integer
-            non_neuro_AF_afr_male:
-              type: half_float
-            non_neuro_nhomalt_afr_male:
-              type: half_float
-            AN_afr_male:
-              type: integer
-            AF_afr_male:
-              type: half_float
-            nhomalt_afr_male:
               type: half_float
             AN_afr:
               type: integer
             AF_afr:
               type: half_float
-            nhomalt_afr:
-              type: half_float
-            non_neuro_AN_afr_female:
-              type: integer
-            non_neuro_AF_afr_female:
-              type: half_float
-            non_neuro_nhomalt_afr_female:
-              type: half_float
-            non_topmed_AN_amr_female:
-              type: integer
-            non_topmed_AF_amr_female:
-              type: half_float
-            non_topmed_nhomalt_amr_female:
-              type: integer
-            non_topmed_AN_oth_female:
-              type: integer
-            non_topmed_AF_oth_female:
-              type: half_float
-            non_topmed_nhomalt_oth_female:
-              type: integer
-            AN_eas_female:
-              type: integer
-            AF_eas_female:
-              type: half_float
-            nhomalt_eas_female:
-              type: integer
-            AN_afr_female:
-              type: integer
-            AF_afr_female:
-              type: half_float
-            nhomalt_afr_female:
-              type: half_float
-            non_neuro_AN_female:
-              type: integer
-            non_neuro_AF_female:
-              type: half_float
-            non_neuro_nhomalt_female:
-              type: integer
-            controls_AN_afr:
-              type: integer
-            controls_AF_afr:
-              type: half_float
-            controls_nhomalt_afr:
-              type: half_float
             AN_nfe_onf:
               type: integer
             AF_nfe_onf:
               type: half_float
-            nhomalt_nfe_onf:
-              type: integer
-            controls_AN_fin_male:
-              type: integer
-            controls_AF_fin_male:
-              type: half_float
-            controls_nhomalt_fin_male:
-              type: integer
-            non_neuro_AN_nfe_nwe:
-              type: integer
-            non_neuro_AF_nfe_nwe:
-              type: half_float
-            non_neuro_nhomalt_nfe_nwe:
-              type: integer
-            AN_fin_male:
-              type: integer
-            AF_fin_male:
-              type: half_float
-            nhomalt_fin_male:
-              type: integer
-            AN_nfe_female:
-              type: integer
-            AF_nfe_female:
-              type: half_float
-            nhomalt_nfe_female:
-              type: integer
             AN_amr:
               type: integer
             AF_amr:
               type: half_float
-            nhomalt_amr:
-              type: integer
-            non_topmed_AN_nfe_male:
-              type: integer
-            non_topmed_AF_nfe_male:
-              type: half_float
-            non_topmed_nhomalt_nfe_male:
-              type: integer
             AN_eas:
               type: integer
             AF_eas:
               type: half_float
-            nhomalt_eas:
-              type: integer
-            nhomalt:
-              type: integer
-            non_neuro_AN_nfe_female:
-              type: integer
-            non_neuro_AF_nfe_female:
-              type: half_float
-            non_neuro_nhomalt_nfe_female:
-              type: integer
-            non_neuro_AN_afr:
-              type: integer
-            non_neuro_AF_afr:
-              type: half_float
-            non_neuro_nhomalt_afr:
-              type: half_float
-            controls_AN_raw:
-              type: integer
-            controls_AF_raw:
-              type: half_float
-            controls_nhomalt_raw:
-              type: integer
-            controls_AN_male:
-              type: integer
-            controls_AF_male:
-              type: half_float
-            controls_nhomalt_male:
-              type: integer
-            non_topmed_AN_male:
-              type: integer
-            non_topmed_AF_male:
-              type: half_float
-            non_topmed_nhomalt_male:
-              type: integer
-            controls_AN_nfe_female:
-              type: integer
-            controls_AF_nfe_female:
-              type: half_float
-            controls_nhomalt_nfe_female:
-              type: integer
-            non_neuro_AN_amr:
-              type: integer
-            non_neuro_AF_amr:
-              type: half_float
-            non_neuro_nhomalt_amr:
-              type: integer
-            non_neuro_AN_eas_female:
-              type: integer
-            non_neuro_AF_eas_female:
-              type: half_float
-            non_neuro_nhomalt_eas_female:
-              type: integer
-            AN_asj_male:
-              type: integer
-            AF_asj_male:
-              type: half_float
-            nhomalt_asj_male:
-              type: integer
-            controls_AN_nfe_male:
-              type: integer
-            controls_AF_nfe_male:
-              type: half_float
-            controls_nhomalt_nfe_male:
-              type: integer
-            non_neuro_AN_fin:
-              type: integer
-            non_neuro_AF_fin:
-              type: half_float
-            non_neuro_nhomalt_fin:
-              type: integer
-            AN_oth_female:
-              type: integer
-            AF_oth_female:
-              type: half_float
-            nhomalt_oth_female:
-              type: integer
-            controls_AN_nfe:
-              type: integer
-            controls_AF_nfe:
-              type: half_float
-            controls_nhomalt_nfe:
-              type: integer
-            controls_AN_oth_female:
-              type: integer
-            controls_AF_oth_female:
-              type: half_float
-            controls_nhomalt_oth_female:
-              type: integer
-            controls_AN_asj:
-              type: integer
-            controls_AF_asj:
-              type: half_float
-            controls_nhomalt_asj:
-              type: integer
-            non_neuro_AN_amr_male:
-              type: integer
-            non_neuro_AF_amr_male:
-              type: half_float
-            non_neuro_nhomalt_amr_male:
-              type: integer
-            controls_AN_nfe_nwe:
-              type: integer
-            controls_AF_nfe_nwe:
-              type: half_float
-            controls_nhomalt_nfe_nwe:
-              type: integer
             AN_nfe_nwe:
               type: integer
             AF_nfe_nwe:
               type: half_float
-            nhomalt_nfe_nwe:
-              type: integer
-            controls_AN_nfe_seu:
-              type: integer
-            controls_AF_nfe_seu:
-              type: half_float
-            controls_nhomalt_nfe_seu:
-              type: integer
-            non_neuro_AN_amr_female:
-              type: integer
-            non_neuro_AF_amr_female:
-              type: half_float
-            non_neuro_nhomalt_amr_female:
-              type: integer
-            non_neuro_AN_nfe_onf:
-              type: integer
-            non_neuro_AF_nfe_onf:
-              type: half_float
-            non_neuro_nhomalt_nfe_onf:
-              type: integer
-            non_topmed_AN_eas_male:
-              type: integer
-            non_topmed_AF_eas_male:
-              type: half_float
-            non_topmed_nhomalt_eas_male:
-              type: integer
-            controls_AN_amr_female:
-              type: integer
-            controls_AF_amr_female:
-              type: half_float
-            controls_nhomalt_amr_female:
-              type: integer
-            non_neuro_AN_fin_male:
-              type: integer
-            non_neuro_AF_fin_male:
-              type: half_float
-            non_neuro_nhomalt_fin_male:
-              type: integer
-            AN_female:
-              type: integer
-            AF_female:
-              type: half_float
-            nhomalt_female:
-              type: integer
-            non_neuro_AN_oth_male:
-              type: integer
-            non_neuro_AF_oth_male:
-              type: half_float
-            non_neuro_nhomalt_oth_male:
-              type: integer
-            non_topmed_AN_nfe_est:
-              type: integer
-            non_topmed_AF_nfe_est:
-              type: half_float
-            non_topmed_nhomalt_nfe_est:
-              type: integer
-            non_topmed_AN_nfe_nwe:
-              type: integer
-            non_topmed_AF_nfe_nwe:
-              type: half_float
-            non_topmed_nhomalt_nfe_nwe:
-              type: integer
-            non_topmed_AN_amr_male:
-              type: integer
-            non_topmed_AF_amr_male:
-              type: half_float
-            non_topmed_nhomalt_amr_male:
-              type: integer
-            non_topmed_AN_nfe_onf:
-              type: integer
-            non_topmed_AF_nfe_onf:
-              type: half_float
-            non_topmed_nhomalt_nfe_onf:
-              type: integer
-            controls_AN_eas_male:
-              type: integer
-            controls_AF_eas_male:
-              type: half_float
-            controls_nhomalt_eas_male:
-              type: integer
-            controls_AN_oth_male:
-              type: integer
-            controls_AF_oth_male:
-              type: half_float
-            controls_nhomalt_oth_male:
-              type: integer
-            non_topmed_AN:
-              type: integer
-            non_topmed_AF:
-              type: half_float
-            non_topmed_nhomalt:
-              type: integer
-            controls_AN_fin:
-              type: integer
-            controls_AF_fin:
-              type: half_float
-            controls_nhomalt_fin:
-              type: integer
-            non_neuro_AN_nfe:
-              type: integer
-            non_neuro_AF_nfe:
-              type: half_float
-            non_neuro_nhomalt_nfe:
-              type: integer
-            non_neuro_AN_fin_female:
-              type: integer
-            non_neuro_AF_fin_female:
-              type: half_float
-            non_neuro_nhomalt_fin_female:
-              type: integer
-            non_topmed_AN_nfe_seu:
-              type: integer
-            non_topmed_AF_nfe_seu:
-              type: half_float
-            non_topmed_nhomalt_nfe_seu:
-              type: integer
-            controls_AN_eas_female:
-              type: integer
-            controls_AF_eas_female:
-              type: half_float
-            controls_nhomalt_eas_female:
-              type: integer
-            non_topmed_AN_asj:
-              type: integer
-            non_topmed_AF_asj:
-              type: half_float
-            non_topmed_nhomalt_asj:
-              type: integer
-            controls_AN_nfe_onf:
-              type: integer
-            controls_AF_nfe_onf:
-              type: half_float
-            controls_nhomalt_nfe_onf:
-              type: integer
-            non_neuro_AN:
-              type: integer
-            non_neuro_AF:
-              type: half_float
-            non_neuro_nhomalt:
-              type: integer
-            non_topmed_AN_nfe:
-              type: integer
-            non_topmed_AF_nfe:
-              type: half_float
-            non_topmed_nhomalt_nfe:
-              type: integer
-            non_topmed_AN_raw:
-              type: integer
-            non_topmed_AF_raw:
-              type: half_float
-            non_topmed_nhomalt_raw:
-              type: integer
-            non_neuro_AN_nfe_est:
-              type: integer
-            non_neuro_AF_nfe_est:
-              type: half_float
-            non_neuro_nhomalt_nfe_est:
-              type: integer
-            non_topmed_AN_oth_male:
-              type: integer
-            non_topmed_AF_oth_male:
-              type: half_float
-            non_topmed_nhomalt_oth_male:
-              type: integer
             AN_nfe_est:
               type: integer
             AF_nfe_est:
               type: half_float
-            nhomalt_nfe_est:
-              type: integer
-            non_topmed_AN_afr_male:
-              type: integer
-            non_topmed_AF_afr_male:
-              type: half_float
-            non_topmed_nhomalt_afr_male:
-              type: half_float
-            AN_eas_male:
-              type: integer
-            AF_eas_male:
-              type: half_float
-            nhomalt_eas_male:
-              type: integer
-            controls_AN_eas:
-              type: integer
-            controls_AF_eas:
-              type: half_float
-            controls_nhomalt_eas:
-              type: integer
-            non_neuro_AN_eas_male:
-              type: integer
-            non_neuro_AF_eas_male:
-              type: half_float
-            non_neuro_nhomalt_eas_male:
-              type: integer
-            non_neuro_AN_asj_male:
-              type: integer
-            non_neuro_AF_asj_male:
-              type: half_float
-            non_neuro_nhomalt_asj_male:
-              type: integer
-            controls_AN_oth:
-              type: integer
-            controls_AF_oth:
-              type: half_float
-            controls_nhomalt_oth:
-              type: integer
             AN_nfe:
               type: integer
             AF_nfe:
               type: half_float
-            nhomalt_nfe:
-              type: integer
-            non_topmed_AN_female:
-              type: integer
-            non_topmed_AF_female:
-              type: half_float
-            non_topmed_nhomalt_female:
-              type: integer
-            non_neuro_AN_asj:
-              type: integer
-            non_neuro_AF_asj:
-              type: half_float
-            non_neuro_nhomalt_asj:
-              type: integer
-            non_topmed_AN_eas_female:
-              type: integer
-            non_topmed_AF_eas_female:
-              type: half_float
-            non_topmed_nhomalt_eas_female:
-              type: integer
-            non_neuro_AN_raw:
-              type: integer
-            non_neuro_AF_raw:
-              type: half_float
-            non_neuro_nhomalt_raw:
-              type: integer
-            non_topmed_AN_eas:
-              type: integer
-            non_topmed_AF_eas:
-              type: half_float
-            non_topmed_nhomalt_eas:
-              type: integer
-            non_topmed_AN_fin_male:
-              type: integer
-            non_topmed_AF_fin_male:
-              type: half_float
-            non_topmed_nhomalt_fin_male:
-              type: integer
             AN_fin:
               type: integer
             AF_fin:
               type: half_float
-            nhomalt_fin:
-              type: integer
-            AN_nfe_male:
-              type: integer
-            AF_nfe_male:
-              type: half_float
-            nhomalt_nfe_male:
-              type: integer
-            controls_AN_amr_male:
-              type: integer
-            controls_AF_amr_male:
-              type: half_float
-            controls_nhomalt_amr_male:
-              type: integer
-            controls_AN_afr_female:
-              type: integer
-            controls_AF_afr_female:
-              type: half_float
-            controls_nhomalt_afr_female:
-              type: half_float
-            controls_AN_amr:
-              type: integer
-            controls_AF_amr:
-              type: half_float
-            controls_nhomalt_amr:
-              type: integer
-            AN_asj_female:
-              type: integer
-            AF_asj_female:
-              type: half_float
-            nhomalt_asj_female:
-              type: integer
-            non_neuro_AN_eas:
-              type: integer
-            non_neuro_AF_eas:
-              type: half_float
-            non_neuro_nhomalt_eas:
-              type: integer
-            non_neuro_AN_male:
-              type: integer
-            non_neuro_AF_male:
-              type: half_float
-            non_neuro_nhomalt_male:
-              type: integer
             AN_asj:
               type: integer
             AF_asj:
               type: half_float
-            nhomalt_asj:
-              type: integer
-            controls_AN_nfe_est:
-              type: integer
-            controls_AF_nfe_est:
-              type: half_float
-            controls_nhomalt_nfe_est:
-              type: integer
-            non_topmed_AN_asj_female:
-              type: integer
-            non_topmed_AF_asj_female:
-              type: half_float
-            non_topmed_nhomalt_asj_female:
-              type: integer
-            non_topmed_AN_oth:
-              type: integer
-            non_topmed_AF_oth:
-              type: half_float
-            non_topmed_nhomalt_oth:
-              type: integer
-            non_topmed_AN_fin_female:
-              type: integer
-            non_topmed_AF_fin_female:
-              type: half_float
-            non_topmed_nhomalt_fin_female:
-              type: integer
             AN_oth:
               type: integer
             AF_oth:
-              type: half_float
-            nhomalt_oth:
-              type: integer
-            non_neuro_AN_nfe_male:
-              type: integer
-            non_neuro_AF_nfe_male:
-              type: half_float
-            non_neuro_nhomalt_nfe_male:
-              type: integer
-            controls_AN_female:
-              type: integer
-            controls_AF_female:
               type: half_float
         exomes:
           properties:
@@ -1216,593 +678,63 @@ mappings:
               type: integer
             AF:
               type: half_float
+            AN_female:
+              type: integer
+            AF_female:
+              type: half_float
+            non_cancer_AN:
+              type: integer
+            non_cancer_AF:
+              type: half_float
+            non_neuro_AN:
+              type: integer
+            non_neuro_AF:
+              type: half_float
+            non_topmed_AN:
+              type: integer
+            non_topmed_AF:
+              type: half_float
             AN_nfe_seu:
               type: integer
             AF_nfe_seu:
               type: half_float
-            nhomalt_nfe_seu:
-              type: integer
-            controls_AN_afr_male:
-              type: integer
-            controls_AF_afr_male:
-              type: half_float
-            controls_nhomalt_afr_male:
-              type: half_float
-            non_neuro_AN_eas_kor:
-              type: integer
-            non_neuro_AF_eas_kor:
-              type: half_float
-            non_neuro_nhomalt_eas_kor:
-              type: integer
-            non_topmed_AN_amr:
-              type: integer
-            non_topmed_AF_amr:
-              type: half_float
-            non_topmed_nhomalt_amr:
-              type: integer
-            non_cancer_AN_asj_female:
-              type: integer
-            non_cancer_AF_asj_female:
-              type: integer
-            non_cancer_nhomalt_asj_female:
-              type: integer
-            AN_raw:
-              type: integer
-            AF_raw:
-              type: half_float
-            nhomalt_raw:
-              type: integer
-            AN_fin_female:
-              type: integer
-            AF_fin_female:
-              type: half_float
-            nhomalt_fin_female:
-              type: integer
-            non_cancer_AN_oth_female:
-              type: integer
-            non_cancer_AF_oth_female:
-              type: integer
-            non_cancer_nhomalt_oth_female:
-              type: integer
             AN_nfe_bgr:
               type: integer
             AF_nfe_bgr:
-              type: half_float
-            nhomalt_nfe_bgr:
-              type: integer
-            non_neuro_AN_asj_female:
-              type: integer
-            non_neuro_AF_asj_female:
-              type: half_float
-            non_neuro_nhomalt_asj_female:
-              type: integer
-            AN_sas_male:
-              type: integer
-            AF_sas_male:
-              type: half_float
-            nhomalt_sas_male:
-              type: integer
-            non_neuro_AN_afr_male:
-              type: integer
-            non_neuro_AF_afr_male:
-              type: half_float
-            non_neuro_nhomalt_afr_male:
-              type: half_float
-            AN_afr_male:
-              type: integer
-            AF_afr_male:
-              type: half_float
-            nhomalt_afr_male:
               type: half_float
             AN_afr:
               type: integer
             AF_afr:
               type: half_float
-            nhomalt_afr:
-              type: half_float
-            controls_AN_nfe_swe:
-              type: integer
-            controls_AF_nfe_swe:
-              type: half_float
-            controls_nhomalt_nfe_swe:
-              type: integer
-            non_neuro_AN_afr_female:
-              type: integer
-            non_neuro_AF_afr_female:
-              type: half_float
-            non_neuro_nhomalt_afr_female:
-              type: half_float
-            non_topmed_AN_amr_female:
-              type: integer
-            non_topmed_AF_amr_female:
-              type: half_float
-            non_topmed_nhomalt_amr_female:
-              type: integer
-            non_cancer_AN_female:
-              type: integer
-            non_cancer_AF_female:
-              type: integer
-            non_cancer_nhomalt_female:
-              type: integer
-            non_cancer_AN_nfe_onf:
-              type: integer
-            non_cancer_AF_nfe_onf:
-              type: integer
-            non_cancer_nhomalt_nfe_onf:
-              type: integer
-            non_cancer_AN_male:
-              type: integer
-            non_cancer_AF_male:
-              type: integer
-            non_cancer_nhomalt_male:
-              type: integer
-            non_topmed_AN_oth_female:
-              type: integer
-            non_topmed_AF_oth_female:
-              type: half_float
-            non_topmed_nhomalt_oth_female:
-              type: integer
-            AN_eas_female:
-              type: integer
-            AF_eas_female:
-              type: half_float
-            nhomalt_eas_female:
-              type: integer
-            non_cancer_AN_sas_female:
-              type: integer
-            non_cancer_AF_sas_female:
-              type: integer
-            non_cancer_nhomalt_sas_female:
-              type: integer
-            AN_afr_female:
-              type: integer
-            AF_afr_female:
-              type: half_float
-            nhomalt_afr_female:
-              type: half_float
             AN_sas:
               type: integer
             AF_sas:
               type: half_float
-            nhomalt_sas:
-              type: integer
-            non_neuro_AN_female:
-              type: integer
-            non_neuro_AF_female:
-              type: half_float
-            non_neuro_nhomalt_female:
-              type: integer
-            controls_AN_afr:
-              type: integer
-            controls_AF_afr:
-              type: half_float
-            controls_nhomalt_afr:
-              type: half_float
-            non_neuro_AN_eas_jpn:
-              type: integer
-            non_neuro_AF_eas_jpn:
-              type: half_float
-            non_neuro_nhomalt_eas_jpn:
-              type: integer
             AN_nfe_onf:
               type: integer
             AF_nfe_onf:
               type: half_float
-            nhomalt_nfe_onf:
-              type: integer
-            non_cancer_AN_amr_male:
-              type: integer
-            non_cancer_AF_amr_male:
-              type: integer
-            non_cancer_nhomalt_amr_male:
-              type: integer
-            controls_AN_fin_male:
-              type: integer
-            controls_AF_fin_male:
-              type: half_float
-            controls_nhomalt_fin_male:
-              type: integer
-            non_neuro_AN_nfe_nwe:
-              type: integer
-            non_neuro_AF_nfe_nwe:
-              type: half_float
-            non_neuro_nhomalt_nfe_nwe:
-              type: integer
-            AN_fin_male:
-              type: integer
-            AF_fin_male:
-              type: half_float
-            nhomalt_fin_male:
-              type: integer
-            AN_nfe_female:
-              type: integer
-            AF_nfe_female:
-              type: half_float
-            nhomalt_nfe_female:
-              type: integer
             AN_amr:
               type: integer
             AF_amr:
               type: half_float
-            nhomalt_amr:
-              type: integer
-            non_topmed_AN_nfe_male:
-              type: integer
-            non_topmed_AF_nfe_male:
-              type: half_float
-            non_topmed_nhomalt_nfe_male:
-              type: integer
-            non_neuro_AN_sas:
-              type: integer
-            non_neuro_AF_sas:
-              type: half_float
-            non_neuro_nhomalt_sas:
-              type: integer
-            non_cancer_AN_fin_male:
-              type: integer
-            non_cancer_AF_fin_male:
-              type: integer
-            non_cancer_nhomalt_fin_male:
-              type: integer
-            non_cancer_AN_nfe_seu:
-              type: integer
-            non_cancer_AF_nfe_seu:
-              type: integer
-            non_cancer_nhomalt_nfe_seu:
-              type: integer
             AN_eas:
               type: integer
             AF_eas:
               type: half_float
-            nhomalt_eas:
-              type: integer
-            nhomalt:
-              type: integer
-            non_neuro_AN_nfe_female:
-              type: integer
-            non_neuro_AF_nfe_female:
-              type: half_float
-            non_neuro_nhomalt_nfe_female:
-              type: integer
-            non_neuro_AN_afr:
-              type: integer
-            non_neuro_AF_afr:
-              type: half_float
-            non_neuro_nhomalt_afr:
-              type: half_float
-            controls_AN_raw:
-              type: integer
-            controls_AF_raw:
-              type: half_float
-            controls_nhomalt_raw:
-              type: integer
-            non_cancer_AN_eas:
-              type: integer
-            non_cancer_AF_eas:
-              type: integer
-            non_cancer_nhomalt_eas:
-              type: integer
-            non_cancer_AN_amr_female:
-              type: integer
-            non_cancer_AF_amr_female:
-              type: integer
-            non_cancer_nhomalt_amr_female:
-              type: integer
-            non_neuro_AN_nfe_swe:
-              type: integer
-            non_neuro_AF_nfe_swe:
-              type: half_float
-            non_neuro_nhomalt_nfe_swe:
-              type: integer
-            controls_AN_male:
-              type: integer
-            controls_AF_male:
-              type: half_float
-            controls_nhomalt_male:
-              type: integer
-            non_topmed_AN_male:
-              type: integer
-            non_topmed_AF_male:
-              type: half_float
-            non_topmed_nhomalt_male:
-              type: integer
-            controls_AN_eas_jpn:
-              type: integer
-            controls_AF_eas_jpn:
-              type: half_float
-            controls_nhomalt_eas_jpn:
-              type: integer
-            controls_AN_nfe_female:
-              type: integer
-            controls_AF_nfe_female:
-              type: half_float
-            controls_nhomalt_nfe_female:
-              type: integer
-            non_neuro_AN_amr:
-              type: integer
-            non_neuro_AF_amr:
-              type: half_float
-            non_neuro_nhomalt_amr:
-              type: integer
-            non_neuro_AN_eas_female:
-              type: integer
-            non_neuro_AF_eas_female:
-              type: half_float
-            non_neuro_nhomalt_eas_female:
-              type: integer
-            AN_asj_male:
-              type: integer
-            AF_asj_male:
-              type: half_float
-            nhomalt_asj_male:
-              type: integer
-            controls_AN_nfe_male:
-              type: integer
-            controls_AF_nfe_male:
-              type: half_float
-            controls_nhomalt_nfe_male:
-              type: integer
-            non_neuro_AN_fin:
-              type: integer
-            non_neuro_AF_fin:
-              type: half_float
-            non_neuro_nhomalt_fin:
-              type: integer
-            non_topmed_AN_sas:
-              type: integer
-            non_topmed_AF_sas:
-              type: half_float
-            non_topmed_nhomalt_sas:
-              type: integer
-            non_cancer_AN_nfe_female:
-              type: integer
-            non_cancer_AF_nfe_female:
-              type: integer
-            non_cancer_nhomalt_nfe_female:
-              type: integer
-            AN_oth_female:
-              type: integer
-            AF_oth_female:
-              type: half_float
-            nhomalt_oth_female:
-              type: integer
-            non_cancer_AN_asj:
-              type: integer
-            non_cancer_AF_asj:
-              type: integer
-            non_cancer_nhomalt_asj:
-              type: integer
             AN_nfe_swe:
               type: integer
             AF_nfe_swe:
               type: half_float
-            nhomalt_nfe_swe:
-              type: integer
-            controls_AN_nfe:
-              type: integer
-            controls_AF_nfe:
-              type: half_float
-            controls_nhomalt_nfe:
-              type: integer
-            controls_AN_oth_female:
-              type: integer
-            controls_AF_oth_female:
-              type: half_float
-            controls_nhomalt_oth_female:
-              type: integer
-            controls_AN_asj:
-              type: integer
-            controls_AF_asj:
-              type: half_float
-            controls_nhomalt_asj:
-              type: integer
-            non_neuro_AN_amr_male:
-              type: integer
-            non_neuro_AF_amr_male:
-              type: half_float
-            non_neuro_nhomalt_amr_male:
-              type: integer
-            controls_AN_nfe_nwe:
-              type: integer
-            controls_AF_nfe_nwe:
-              type: half_float
-            controls_nhomalt_nfe_nwe:
-              type: integer
             AN_nfe_nwe:
               type: integer
             AF_nfe_nwe:
               type: half_float
-            nhomalt_nfe_nwe:
-              type: integer
-            controls_AN_nfe_seu:
-              type: integer
-            controls_AF_nfe_seu:
-              type: half_float
-            controls_nhomalt_nfe_seu:
-              type: integer
-            controls_AN_sas_female:
-              type: integer
-            controls_AF_sas_female:
-              type: half_float
-            controls_nhomalt_sas_female:
-              type: integer
-            non_neuro_AN_amr_female:
-              type: integer
-            non_neuro_AF_amr_female:
-              type: half_float
-            non_neuro_nhomalt_amr_female:
-              type: integer
-            non_cancer_AN_eas_jpn:
-              type: integer
-            non_cancer_AF_eas_jpn:
-              type: integer
-            non_cancer_nhomalt_eas_jpn:
-              type: integer
-            non_neuro_AN_nfe_onf:
-              type: integer
-            non_neuro_AF_nfe_onf:
-              type: half_float
-            non_neuro_nhomalt_nfe_onf:
-              type: integer
-            non_topmed_AN_eas_male:
-              type: integer
-            non_topmed_AF_eas_male:
-              type: half_float
-            non_topmed_nhomalt_eas_male:
-              type: integer
             AN_eas_jpn:
               type: integer
             AF_eas_jpn:
               type: half_float
-            nhomalt_eas_jpn:
-              type: integer
-            non_cancer_AN_afr_male:
-              type: integer
-            non_cancer_AF_afr_male:
-              type: integer
-            non_cancer_nhomalt_afr_male:
-              type: integer
-            non_cancer_AN_afr:
-              type: integer
-            non_cancer_AF_afr:
-              type: integer
-            non_cancer_nhomalt_afr:
-              type: integer
-            controls_AN_amr_female:
-              type: integer
-            controls_AF_amr_female:
-              type: half_float
-            controls_nhomalt_amr_female:
-              type: integer
-            non_neuro_AN_fin_male:
-              type: integer
-            non_neuro_AF_fin_male:
-              type: half_float
-            non_neuro_nhomalt_fin_male:
-              type: integer
-            AN_female:
-              type: integer
-            AF_female:
-              type: half_float
-            nhomalt_female:
-              type: integer
-            non_neuro_AN_nfe_bgr:
-              type: integer
-            non_neuro_AF_nfe_bgr:
-              type: half_float
-            non_neuro_nhomalt_nfe_bgr:
-              type: integer
-            non_neuro_AN_oth_male:
-              type: integer
-            non_neuro_AF_oth_male:
-              type: half_float
-            non_neuro_nhomalt_oth_male:
-              type: integer
-            non_topmed_AN_nfe_est:
-              type: integer
-            non_topmed_AF_nfe_est:
-              type: half_float
-            non_topmed_nhomalt_nfe_est:
-              type: integer
-            non_topmed_AN_nfe_nwe:
-              type: integer
-            non_topmed_AF_nfe_nwe:
-              type: half_float
-            non_topmed_nhomalt_nfe_nwe:
-              type: integer
-            non_topmed_AN_amr_male:
-              type: integer
-            non_topmed_AF_amr_male:
-              type: half_float
-            non_topmed_nhomalt_amr_male:
-              type: integer
-            non_cancer_AN_amr:
-              type: integer
-            non_cancer_AF_amr:
-              type: integer
-            non_cancer_nhomalt_amr:
-              type: integer
-            non_topmed_AN_nfe_swe:
-              type: integer
-            non_topmed_AF_nfe_swe:
-              type: half_float
-            non_topmed_nhomalt_nfe_swe:
-              type: integer
-            non_topmed_AN_nfe_onf:
-              type: integer
-            non_topmed_AF_nfe_onf:
-              type: half_float
-            non_topmed_nhomalt_nfe_onf:
-              type: integer
-            controls_AN_eas_kor:
-              type: integer
-            controls_AF_eas_kor:
-              type: half_float
-            controls_nhomalt_eas_kor:
-              type: integer
-            non_topmed_AN_eas_oea:
-              type: integer
-            non_topmed_AF_eas_oea:
-              type: half_float
-            non_topmed_nhomalt_eas_oea:
-              type: integer
-            controls_AN_eas_male:
-              type: integer
-            controls_AF_eas_male:
-              type: half_float
-            controls_nhomalt_eas_male:
-              type: integer
-            controls_AN_oth_male:
-              type: integer
-            controls_AF_oth_male:
-              type: half_float
-            controls_nhomalt_oth_male:
-              type: integer
-            non_topmed_AN:
-              type: integer
-            non_topmed_AF:
-              type: half_float
-            non_topmed_nhomalt:
-              type: integer
-            controls_AN_fin:
-              type: integer
-            controls_AF_fin:
-              type: half_float
-            controls_nhomalt_fin:
-              type: integer
             AN_eas_kor:
               type: integer
             AF_eas_kor:
               type: half_float
-            nhomalt_eas_kor:
-              type: integer
-            non_neuro_AN_nfe:
-              type: integer
-            non_neuro_AF_nfe:
-              type: half_float
-            non_neuro_nhomalt_nfe:
-              type: integer
-            non_neuro_AN_fin_female:
-              type: integer
-            non_neuro_AF_fin_female:
-              type: half_float
-            non_neuro_nhomalt_fin_female:
-              type: integer
-            non_cancer_AN_nfe_male:
-              type: integer
-            non_cancer_AF_nfe_male:
-              type: integer
-            non_cancer_nhomalt_nfe_male:
-              type: integer
-            controls_AN_eas_oea:
-              type: integer
-            controls_AF_eas_oea:
-              type: half_float
-            controls_nhomalt_eas_oea:
-              type: integer
-            non_topmed_AN_nfe_seu:
-              type: integer
-            non_topmed_AF_nfe_seu:
-              type: half_float
-            non_topmed_nhomalt_nfe_seu:
-              type: integer

--- a/config/hg38.clean.yml
+++ b/config/hg38.clean.yml
@@ -1,7 +1,7 @@
 ---
 assembly: hg38
-build_author: ec2-user
-build_date: 2018-09-08T12:25:00
+build_author: alexkotlar
+build_date: 2024-03-11T12:24:00
 chromosomes:
   - chr1
   - chr2
@@ -28,7 +28,7 @@ chromosomes:
   - chrM
   - chrX
   - chrY
-database_dir: "~"
+database_dir: /mnt/annotator/hg38_v4
 fileProcessors:
   snp:
     args: --emptyField NA --minGq .95
@@ -36,7 +36,7 @@ fileProcessors:
   vcf:
     args: --emptyField NA --sample %sampleList% --keepPos --keepId --dosageOutput %dosageMatrixOutPath%
     program: bystro-vcf
-files_dir: "~"
+files_dir: /mnt/files1/bystro_annotator/raw_files/hg38
 statistics:
   dbSNPnameField: dbSNP.name
   exonicAlleleFunctionField: refSeq.exonicAlleleFunction
@@ -47,28 +47,48 @@ statistics:
   programPath: bystro-stats
   refTrackField: ref
   siteTypeField: refSeq.siteType
-temp_dir: "~"
+temp_dir: /mnt/annotator/tmp
 tracks:
   outputOrder:
     - ref
     - refSeq
-    - refSeq.gene
     - nearest.refSeq
     - nearestTss.refSeq
-    - phastCons
-    - phyloP
-    - cadd
-    - gnomad.genomes
     - gnomad.exomes
+    - gnomad.genomes
     - dbSNP
-    - clinvar
-    - cosmic.coding
-    - cosmic.nonCoding
+    - cadd
+    - caddIndel
+    - clinvarVcf
   tracks:
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
       local_files:
-        - chr*.fa.gz
+        - chr1.fa.gz
+        - chr2.fa.gz
+        - chr3.fa.gz
+        - chr4.fa.gz
+        - chr5.fa.gz
+        - chr6.fa.gz
+        - chr7.fa.gz
+        - chr8.fa.gz
+        - chr9.fa.gz
+        - chr10.fa.gz
+        - chr11.fa.gz
+        - chr12.fa.gz
+        - chr13.fa.gz
+        - chr14.fa.gz
+        - chr15.fa.gz
+        - chr16.fa.gz
+        - chr17.fa.gz
+        - chr18.fa.gz
+        - chr19.fa.gz
+        - chr20.fa.gz
+        - chr21.fa.gz
+        - chr22.fa.gz
+        - chrX.fa.gz
+        - chrY.fa.gz
+        - chrM.fa.gz
       name: ref
       type: reference
       utils:
@@ -97,154 +117,14 @@ tracks:
               - chr20.fa.gz
               - chr21.fa.gz
               - chr22.fa.gz
-              - chrM.fa.gz
               - chrX.fa.gz
               - chrY.fa.gz
-          completed: 2017-11-24T02:27:00
+              - chrM.fa.gz
+          completed: 2024-03-11T12:19:00
           name: fetch
-      version: 28
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      dist: true
-      features:
-        - name
-        - name2
-      from: txStart
-      local_files:
-        - hg38.kgXref.chr*.with_dbnsfp.gz
-      name: nearest.refSeq
-      to: txEnd
-      type: nearest
-      version: 2
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      dist: true
-      features:
-        - name
-        - name2
-      from: txStart
-      local_files:
-        - hg38.kgXref.chr*.with_dbnsfp.gz
-      name: nearestTss.refSeq
-      type: nearest
-      version: 19
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      local_files:
-        - chr*.phastCons100way.wigFix.gz
-      name: phastCons
-      type: score
-      utils:
-        - args:
-            remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/phastCons100way/hg38.100way.phastCons/
-            remoteFiles:
-              - chr1.phastCons100way.wigFix.gz
-              - chr2.phastCons100way.wigFix.gz
-              - chr3.phastCons100way.wigFix.gz
-              - chr4.phastCons100way.wigFix.gz
-              - chr5.phastCons100way.wigFix.gz
-              - chr6.phastCons100way.wigFix.gz
-              - chr7.phastCons100way.wigFix.gz
-              - chr8.phastCons100way.wigFix.gz
-              - chr9.phastCons100way.wigFix.gz
-              - chr10.phastCons100way.wigFix.gz
-              - chr11.phastCons100way.wigFix.gz
-              - chr12.phastCons100way.wigFix.gz
-              - chr13.phastCons100way.wigFix.gz
-              - chr14.phastCons100way.wigFix.gz
-              - chr15.phastCons100way.wigFix.gz
-              - chr16.phastCons100way.wigFix.gz
-              - chr17.phastCons100way.wigFix.gz
-              - chr18.phastCons100way.wigFix.gz
-              - chr19.phastCons100way.wigFix.gz
-              - chr20.phastCons100way.wigFix.gz
-              - chr21.phastCons100way.wigFix.gz
-              - chr22.phastCons100way.wigFix.gz
-              - chrX.phastCons100way.wigFix.gz
-              - chrY.phastCons100way.wigFix.gz
-              - chrM.phastCons100way.wigFix.gz
-          completed: 2017-11-23T21:05:00
-          name: fetch
-      version: 20
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      local_files:
-        - chr*.phyloP100way.wigFix.gz
-      name: phyloP
-      type: score
-      utils:
-        - args:
-            remoteDir: http://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP100way/hg38.100way.phyloP100way/
-            remoteFiles:
-              - chr1.phyloP100way.wigFix.gz
-              - chr2.phyloP100way.wigFix.gz
-              - chr3.phyloP100way.wigFix.gz
-              - chr4.phyloP100way.wigFix.gz
-              - chr5.phyloP100way.wigFix.gz
-              - chr6.phyloP100way.wigFix.gz
-              - chr7.phyloP100way.wigFix.gz
-              - chr8.phyloP100way.wigFix.gz
-              - chr9.phyloP100way.wigFix.gz
-              - chr10.phyloP100way.wigFix.gz
-              - chr11.phyloP100way.wigFix.gz
-              - chr12.phyloP100way.wigFix.gz
-              - chr13.phyloP100way.wigFix.gz
-              - chr14.phyloP100way.wigFix.gz
-              - chr15.phyloP100way.wigFix.gz
-              - chr16.phyloP100way.wigFix.gz
-              - chr17.phyloP100way.wigFix.gz
-              - chr18.phyloP100way.wigFix.gz
-              - chr19.phyloP100way.wigFix.gz
-              - chr20.phyloP100way.wigFix.gz
-              - chr21.phyloP100way.wigFix.gz
-              - chr22.phyloP100way.wigFix.gz
-              - chrX.phyloP100way.wigFix.gz
-              - chrY.phyloP100way.wigFix.gz
-              - chrM.phyloP100way.wigFix.gz
-          completed: 2017-11-23T21:10:00
-          name: fetch
-      version: 19
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      local_files:
-        - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
-        - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
-      name: cadd
-      sorted: 1
-      type: cadd
-      utils:
-        - args:
-            remoteFiles:
-              - http://krishna.gs.washington.edu/download/CADD/v1.4/GRCh38/whole_genome_SNVs.tsv.gz
-          completed: 2018-09-06T03:52:00
-          name: fetch
-        - completed: 2018-09-06T05:39:00
-          name: SortCadd
-      version: 19
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
+      version: 34
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
       build_field_transformations:
         description: split [;]
         ensemblID: split [;]
@@ -280,31 +160,31 @@ tracks:
           - chromEnd
         track: clinvar
       local_files:
-        - hg38.kgXref.chr8.with_dbnsfp.gz
-        - hg38.kgXref.chr4.with_dbnsfp.gz
-        - hg38.kgXref.chr3.with_dbnsfp.gz
-        - hg38.kgXref.chr1.with_dbnsfp.gz
-        - hg38.kgXref.chr6.with_dbnsfp.gz
-        - hg38.kgXref.chr2.with_dbnsfp.gz
-        - hg38.kgXref.chr5.with_dbnsfp.gz
-        - hg38.kgXref.chr7.with_dbnsfp.gz
-        - hg38.kgXref.chr10.with_dbnsfp.gz
-        - hg38.kgXref.chr9.with_dbnsfp.gz
-        - hg38.kgXref.chr16.with_dbnsfp.gz
-        - hg38.kgXref.chr11.with_dbnsfp.gz
-        - hg38.kgXref.chr12.with_dbnsfp.gz
-        - hg38.kgXref.chr14.with_dbnsfp.gz
-        - hg38.kgXref.chr15.with_dbnsfp.gz
-        - hg38.kgXref.chr13.with_dbnsfp.gz
-        - hg38.kgXref.chr18.with_dbnsfp.gz
-        - hg38.kgXref.chrY.with_dbnsfp.gz
-        - hg38.kgXref.chrM.with_dbnsfp.gz
-        - hg38.kgXref.chr17.with_dbnsfp.gz
-        - hg38.kgXref.chr22.with_dbnsfp.gz
-        - hg38.kgXref.chr21.with_dbnsfp.gz
-        - hg38.kgXref.chrX.with_dbnsfp.gz
-        - hg38.kgXref.chr19.with_dbnsfp.gz
-        - hg38.kgXref.chr20.with_dbnsfp.gz
+        - hg38.kgXref.chr1.gz
+        - hg38.kgXref.chr2.gz
+        - hg38.kgXref.chr3.gz
+        - hg38.kgXref.chr4.gz
+        - hg38.kgXref.chr5.gz
+        - hg38.kgXref.chr6.gz
+        - hg38.kgXref.chr7.gz
+        - hg38.kgXref.chr8.gz
+        - hg38.kgXref.chr9.gz
+        - hg38.kgXref.chr10.gz
+        - hg38.kgXref.chr11.gz
+        - hg38.kgXref.chr12.gz
+        - hg38.kgXref.chr13.gz
+        - hg38.kgXref.chr14.gz
+        - hg38.kgXref.chr15.gz
+        - hg38.kgXref.chr16.gz
+        - hg38.kgXref.chr17.gz
+        - hg38.kgXref.chr18.gz
+        - hg38.kgXref.chr19.gz
+        - hg38.kgXref.chr20.gz
+        - hg38.kgXref.chr21.gz
+        - hg38.kgXref.chr22.gz
+        - hg38.kgXref.chrM.gz
+        - hg38.kgXref.chrX.gz
+        - hg38.kgXref.chrY.gz
       name: refSeq
       type: gene
       utils:
@@ -327,243 +207,129 @@ tracks:
               x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
               '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
               refGene r WHERE chrom=%chromosomes%;
-          completed: 2018-09-07T14:04:00
+          completed: 2024-03-10T18:58:00
           name: fetch
-        - args:
-            geneFile: /mnt/bystro-files/dbnsfp//dbNSFP3.5_gene.complete
-          completed: 2018-09-07T14:05:00
-          name: refGeneXdbnsfp
-      version: 28
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      build_field_transformations:
-        pmid: split [;]
-        uniprot.func: split [;]
-      dist: false
-      features:
-        - name2
-        - pLi: number
-        - pRec: number
-        - pNull: number
-        - lofTool: number
-        - lofFdr: number
-        - pHi: number
-        - nonTCGA.pRec: number
-        - nonTCGA.pNull: number
-        - nonTCGA.pLi: number
-        - nonPsych.pRec: number
-        - nonPsych.pNull: number
-        - nonPsych.pLi: number
-        - gdi: number
-        - cnv.score: number
-        - cnv.flag
-        - pmid: number
-        - rvis: number
-      fieldMap:
-        dbnsfp.Disease_description: uniprot.disease
-        dbnsfp.ExAC_cnv.score: cnv.score
-        dbnsfp.ExAC_cnv_flag: cnv.flag
-        dbnsfp.ExAC_nonTCGA_pLI: nonTCGA.pLi
-        dbnsfp.ExAC_nonTCGA_pNull: nonTCGA.pNull
-        dbnsfp.ExAC_nonTCGA_pRec: nonTCGA.pRec
-        dbnsfp.ExAC_nonpsych_pLI: nonPsych.pLi
-        dbnsfp.ExAC_nonpsych_pNull: nonPsych.pNull
-        dbnsfp.ExAC_nonpsych_pRec: nonPsych.pRec
-        dbnsfp.ExAC_pLI: pLi
-        dbnsfp.ExAC_pNull: pNull
-        dbnsfp.ExAC_pRec: pRec
-        dbnsfp.Expression(GNF/Atlas): expression.gnfAtlas
-        dbnsfp.Expression(egenetics): expression.egenetics
-        dbnsfp.Function_description: function
-        dbnsfp.GDI-Phred: gdi
-        dbnsfp.GO_biological_process: go.biologicalProcess
-        dbnsfp.GO_cellular_component: go.cellularComponent
-        dbnsfp.GO_molecular_function: go.molecularFunction
-        dbnsfp.Known_rec_info: knownRecInfo
-        dbnsfp.LoF-FDR_ExAC: lofFdr
-        dbnsfp.LoFtool_score: lofTool
-        dbnsfp.P(HI): pHi
-        dbnsfp.P(rec): pRec
-        dbnsfp.RVIS_percentile_ExAC: rvis
-        dbnsfp.Tissue_specificity(Uniprot): uniprot.tissue
-        dbnsfp.Trait_association(GWAS): trait_association
-        dbnsfp.pubmedID: pmid
-      from: txStart
-      local_files:
-        - hg38.kgXref.chr*.with_dbnsfp.gz
-      name: refSeq.gene
-      storeNearest: false
-      to: txEnd
-      type: nearest
-      version: 24
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
-      build_field_transformations:
-        alleleFreqs: split [,]
-        alleleNs: split [,]
-        alleles: split [,]
-        func: split [,]
-        observed: split [\/]
-      features:
-        - name
-        - strand
-        - observed
-        - class
-        - func
-        - alleles
-        - alleleNs: number
-        - alleleFreqs: number
-      local_files:
-        - hg38.snp150.chr1.gz
-        - hg38.snp150.chr2.gz
-        - hg38.snp150.chr3.gz
-        - hg38.snp150.chr4.gz
-        - hg38.snp150.chr5.gz
-        - hg38.snp150.chr6.gz
-        - hg38.snp150.chr7.gz
-        - hg38.snp150.chr8.gz
-        - hg38.snp150.chr9.gz
-        - hg38.snp150.chr10.gz
-        - hg38.snp150.chr11.gz
-        - hg38.snp150.chr12.gz
-        - hg38.snp150.chr13.gz
-        - hg38.snp150.chr14.gz
-        - hg38.snp150.chr15.gz
-        - hg38.snp150.chr16.gz
-        - hg38.snp150.chr17.gz
-        - hg38.snp150.chr18.gz
-        - hg38.snp150.chr19.gz
-        - hg38.snp150.chr20.gz
-        - hg38.snp150.chr21.gz
-        - hg38.snp150.chr22.gz
-        - hg38.snp150.chrM.gz
-        - hg38.snp150.chrX.gz
-        - hg38.snp150.chrY.gz
-      name: dbSNP
-      type: sparse
-      utils:
-        - args:
-            sql: SELECT * FROM hg38.snp150 WHERE chrom = %chromosomes%
-          completed: 2018-09-07T14:06:00
-          name: fetch
-      version: 28
-    - build_author: ec2-user
-      build_date: 2018-09-08T12:25:00
-      build_row_filters:
-        AS_FilterStatus: == PASS
+      version: 34
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
       features:
         - alt
         - id
-        - af: number
-        - an: number
-        - an_afr: number
-        - an_amr: number
-        - an_asj: number
-        - an_eas: number
-        - an_fin: number
-        - an_nfe: number
-        - an_oth: number
-        - an_sas: number
-        - an_male: number
-        - an_female: number
-        - af_afr: number
-        - af_amr: number
-        - af_asj: number
-        - af_eas: number
-        - af_fin: number
-        - af_nfe: number
-        - af_oth: number
-        - af_sas: number
-        - af_male: number
-        - af_female: number
-      fieldMap:
-        AF: af
-        AF_AFR: af_afr
-        AF_AMR: af_amr
-        AF_ASJ: af_asj
-        AF_EAS: af_eas
-        AF_FIN: af_fin
-        AF_Female: af_female
-        AF_Male: af_male
-        AF_NFE: af_nfe
-        AF_OTH: af_oth
-        AF_SAS: af_sas
-        AN: an
-        AN_AFR: an_afr
-        AN_AMR: an_amr
-        AN_ASJ: an_asj
-        AN_EAS: an_eas
-        AN_FIN: an_fin
-        AN_Female: an_female
-        AN_Male: an_male
-        AN_NFE: an_nfe
-        AN_OTH: an_oth
-        AN_SAS: an_sas
+        - spliceai_ds_max: number
+        - pangolin_largest_ds: number
+        - phylop: number
+        - sift_max: number
+        - polyphen_max: number
+        - AN: number
+        - AF: number
+        - AF_XX: number
+        - AN_XX: number
+        - AF_XY: number
+        - AN_XY: number
+        - AF_afr: number
+        - AN_afr: number
+        - AF_amr: number
+        - AN_amr: number
+        - AF_asj: number
+        - AN_asj: number
+        - AF_eas: number
+        - AN_eas: number
+        - AF_fin: number
+        - AN_fin: number
+        - AF_mid: number
+        - AN_mid: number
+        - AF_nfe: number
+        - AN_nfe: number
+        - AF_non_ukb: number
+        - AN_non_ukb: number
+        - AF_non_ukb_afr: number
+        - AN_non_ukb_afr: number
+        - AF_non_ukb_amr: number
+        - AN_non_ukb_amr: number
+        - AF_non_ukb_asj: number
+        - AN_non_ukb_asj: number
+        - AF_non_ukb_eas: number
+        - AN_non_ukb_eas: number
+        - AF_non_ukb_fin: number
+        - AN_non_ukb_fin: number
+        - AF_non_ukb_mid: number
+        - AN_non_ukb_mid: number
+        - AF_non_ukb_nfe: number
+        - AN_non_ukb_nfe: number
+        - AF_non_ukb_remaining: number
+        - AN_non_ukb_remaining: number
+        - AF_non_ukb_sas: number
+        - AN_non_ukb_sas: number
+        - AF_remaining: number
+        - AN_remaining: number
+        - AF_sas: number
+        - AN_sas: number
+        - AF_grpmax: number
+        - AN_grpmax: number
+        - AF_grpmax_non_ukb: number
+        - AN_grpmax_non_ukb: number
+        - AF_grpmax_joint: number
+        - AN_grpmax_joint: number
       local_files:
-        - gnomad.genomes.r2.0.2.sites.chr*.liftedOver.hg38.vcf.liftedOver.gz
-      name: gnomad.genomes
-      type: vcf
-      version: 24
-    - build_author: ec2-user
-      build_date: 2018-09-08T12:25:00
-      build_row_filters:
-        AS_FilterStatus: == PASS
-      features:
-        - alt
-        - id
-        - af: number
-        - an: number
-        - an_afr: number
-        - an_amr: number
-        - an_asj: number
-        - an_eas: number
-        - an_fin: number
-        - an_nfe: number
-        - an_oth: number
-        - an_sas: number
-        - an_male: number
-        - an_female: number
-        - af_afr: number
-        - af_amr: number
-        - af_asj: number
-        - af_eas: number
-        - af_fin: number
-        - af_nfe: number
-        - af_oth: number
-        - af_sas: number
-        - af_male: number
-        - af_female: number
-      fieldMap:
-        AF: af
-        AF_AFR: af_afr
-        AF_AMR: af_amr
-        AF_ASJ: af_asj
-        AF_EAS: af_eas
-        AF_FIN: af_fin
-        AF_Female: af_female
-        AF_Male: af_male
-        AF_NFE: af_nfe
-        AF_OTH: af_oth
-        AF_SAS: af_sas
-        AN: an
-        AN_AFR: an_afr
-        AN_AMR: an_amr
-        AN_ASJ: an_asj
-        AN_EAS: an_eas
-        AN_FIN: an_fin
-        AN_Female: an_female
-        AN_Male: an_male
-        AN_NFE: an_nfe
-        AN_OTH: an_oth
-        AN_SAS: an_sas
-      local_files:
-        - gnomad.exomes.r2.0.2.sites.liftedOver.hg38.vcf.liftedOver.gz
+        - gnomad.exomes.v4.0.sites.chr1.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr2.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr3.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr4.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr5.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr6.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr7.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr8.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr9.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr10.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr11.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr12.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr13.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr14.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr15.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr16.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr17.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr18.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr19.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr20.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr21.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chr22.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chrX.vcf.bgz
+        - gnomad.exomes.v4.0.sites.chrY.vcf.bgz
       name: gnomad.exomes
       type: vcf
-      version: 24
+      utils:
+        - args:
+            remoteFiles:
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr1.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr2.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr3.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr4.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr5.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr6.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr7.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr8.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr9.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr10.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr11.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr12.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr13.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr14.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr15.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr16.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr17.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr18.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr19.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr20.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr21.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chr22.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrX.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz
+          completed: 2024-03-07T14:23:00
+          name: fetch
+      version: 29
     - based: 1
-      build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
+      build_author: alexkotlar
+      build_date: 2023-09-20T00:17:00
       build_field_transformations:
         chrom: chr .
         clinicalSignificance: split [;]
@@ -600,66 +366,298 @@ tracks:
       local_files:
         - variant_summary.txt.gz
       name: clinvar
+      no_build: true
       type: sparse
       utils:
         - args:
             remoteFiles:
               - ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/variant_summary.txt.gz
-          completed: 2018-09-07T17:31:00
+          completed: 2024-03-07T22:09:00
           name: fetch
-      version: 20
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
+      version: 24
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
+      local_files:
+        - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr11.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr12.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr13.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr14.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr15.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr16.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr17.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr18.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr19.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr2.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr20.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr21.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr22.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr3.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr4.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr5.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr6.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr7.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr8.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chr9.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrX.organized-by-chr.txt.sorted.txt.gz
+        - whole_genome_SNVs.tsv.chrY.organized-by-chr.txt.sorted.txt.gz
+      name: cadd
+      sorted: 1
+      type: cadd
+      utils:
+        - completed: 2023-09-09T11:18:00
+          name: SortCadd
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
+      features:
+        - alt
+        - PHRED: number
+      local_files:
+        - /mnt/files1/bystro_annotator/raw_files/hg38/caddIndel/gnomad.genomes.r4.0.indel.vcf.gz
+      name: caddIndel
+      type: vcf
+      version: 6
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
+      dist: true
+      features:
+        - name2
+        - name
+      from: txStart
+      name: nearest.refSeq
+      ref: refSeq
+      to: txEnd
+      type: nearest
+      version: 9
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
+      dist: true
+      features:
+        - name2
+        - name
+      from: txStart
+      name: nearestTss.refSeq
+      ref: refSeq
+      type: nearest
+      version: 4
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
       features:
         - alt
         - id
-        - cnt: number
-        - aa
-        - cds
-        - gene
-        - strand
-      fieldMap:
-        AA: aa
-        CDS: cds
-        CNT: cnt
-        GENE: gene
-        STRAND: strand
+        - spliceai_ds_max: number
+        - pangolin_largest_ds: number
+        - phylop: number
+        - sift_max: number
+        - polyphen_max: number
+        - AN: number
+        - AF: number
+        - AF_XX: number
+        - AN_XX: number
+        - AF_XY: number
+        - AN_XY: number
+        - AF_afr: number
+        - AN_afr: number
+        - AF_ami: number
+        - AN_ami: number
+        - AF_amr: number
+        - AN_amr: number
+        - AF_asj: number
+        - AN_asj: number
+        - AF_eas: number
+        - AN_eas: number
+        - AF_fin: number
+        - AN_fin: number
+        - AF_mid: number
+        - AN_mid: number
+        - AF_nfe: number
+        - AN_nfe: number
+        - AF_remaining: number
+        - AN_remaining: number
+        - AF_sas: number
+        - AN_sas: number
+        - AF_joint_XX: number
+        - AN_joint_XX: number
+        - AF_joint_XY: number
+        - AN_joint_XY: number
+        - AF_joint: number
+        - AN_joint: number
+        - AF_joint_afr: number
+        - AN_joint_afr: number
+        - AF_joint_ami: number
+        - AN_joint_ami: number
+        - AF_joint_amr: number
+        - AN_joint_amr: number
+        - AF_joint_asj: number
+        - AN_joint_asj: number
+        - AF_joint_eas: number
+        - AN_joint_eas: number
+        - AF_joint_fin: number
+        - AN_joint_fin: number
+        - AF_joint_mid: number
+        - AN_joint_mid: number
+        - AF_joint_nfe: number
+        - AN_joint_nfe: number
+        - AF_joint_remaining: number
+        - AN_joint_remaining: number
+        - AF_joint_sas: number
+        - AN_joint_sas: number
+        - AF_grpmax: number
+        - AN_grpmax: number
+        - AF_grpmax_joint: number
+        - AN_grpmax_joint: number
       local_files:
-        - CosmicCodingMuts.vcf.gz
-      name: cosmic.coding
+        - gnomad.genomes.v4.0.sites.chr1.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr2.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr3.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr4.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr5.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr6.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr7.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr8.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr9.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr10.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr11.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr12.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr13.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr14.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr15.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr16.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr17.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr18.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr19.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr20.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr21.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chr22.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chrX.vcf.bgz
+        - gnomad.genomes.v4.0.sites.chrY.vcf.bgz
+      name: gnomad.genomes
       type: vcf
       utils:
         - args:
             remoteFiles:
-              - https://s3.amazonaws.com/bystro-db/src/CosmicCodingMuts.vcf.gz
-          completed: 2018-09-07T17:31:00
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr1.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr2.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr3.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr4.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr5.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr6.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr7.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr8.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr9.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr10.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr11.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr12.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr13.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr14.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr15.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr16.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr17.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr18.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr19.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr20.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr21.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chr22.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrX.vcf.bgz
+              - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz
+          completed: 2024-03-07T15:59:00
           name: fetch
-      version: 2
-    - build_author: ec2-user
-      build_date: 2018-09-07T19:32:00
+      version: 27
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
       features:
-        - alt
         - id
-        - cnt: number
-        - aa
-        - cds
-        - gene
-        - strand
-      fieldMap:
-        AA: aa
-        CDS: cds
-        CNT: cnt
-        GENE: gene
-        STRAND: strand
+        - alt
+        - TOMMO: number
+        - ExAC: number
+        - GnomAD: number
+        - Korea1K: number
+        - GoNL: number
+        - KOREAN: number
+        - TWINSUK: number
+        - Vietnamese: number
+        - GENOME_DK: number
+        - GoESP: number
+        - GnomAD_exomes: number
+        - Siberian: number
+        - PRJEB37584: number
+        - SGDP_PRJ: number
+        - 1000Genomes: number
+        - dbGaP_PopFreq: number
+        - NorthernSweden: number
+        - HapMap: number
+        - TOPMED: number
+        - ALSPAC: number
+        - Qatari: number
+        - MGP: number
       local_files:
-        - CosmicNonCodingVariants.vcf.gz
-      name: cosmic.nonCoding
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.1_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.2_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.3_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.4_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.5_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.6_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.7_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.8_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.9_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.10_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.11_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.12_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.13_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.14_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.15_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.16_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.17_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.18_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.19_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.20_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.21_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.22_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.X_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.Y_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg38/dbSNP/GRCh38.dbSNP155.vcf.MT_processed.vcf.gz
+      name: dbSNP
+      type: vcf
+      utils:
+        - completed: 2024-03-10T16:30:00
+          name: DbSnp2FormatInfo
+      version: 6
+    - build_author: alexkotlar
+      build_date: 2024-03-11T12:24:00
+      build_field_transformations:
+        CLNDISDB: split [|]
+        CLNDN: split [|]
+        CLNSIGCONF: split [|]
+        CLNSIGINC: split [|]
+      features:
+        - id
+        - alt
+        - AF_ESP: number
+        - AF_EXAC: number
+        - AF_TGP: number
+        - ALLELEID: number
+        - CLNDN
+        - CLNDNINCL
+        - CLNHGVS
+        - CLNREVSTAT
+        - CLNSIG
+        - CLNSIGCONF
+        - CLNVCSO
+        - DBVARID
+        - ORIGIN
+        - SSR
+        - RS
+      local_files:
+        - clinvar.vcf.gz
+      name: clinvarVcf
       type: vcf
       utils:
         - args:
             remoteFiles:
-              - https://s3.amazonaws.com/bystro-db/src/CosmicNonCodingVariants.vcf.gz
-          completed: 2018-09-07T17:31:00
+              - https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz
+          completed: 2024-03-07T22:09:00
           name: fetch
       version: 2
-version: 216
+version: 229

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -1,1 +1,844 @@
-./hg19.mapping.yml
+sort:
+  cadd: avg
+  refSeq.codonNumber: avg
+  refSeq.codonPosition: avg
+post_index_settings:
+  index:
+    refresh_interval: 15s
+    number_of_replicas: 1
+index_settings:
+  index:
+    refresh_interval: -1
+    number_of_replicas: 0
+    codec: best_compression
+    mapping:
+      total_fields:
+        limit: 5000
+  analysis:
+    normalizer:
+      lowercase_normalizer:
+        type: custom
+        filter:
+          - lowercase
+          - asciifolding
+      uppercase_normalizer:
+        type: custom
+        filter:
+          - uppercase
+          - asciifolding
+    filter:
+      exclude_pathogenic:
+        type: pattern_capture
+        patterns: ["conflicting_interpretations_of_pathogenicity"]
+      catenate_filter:
+        type: word_delimiter
+        catenate_words: true
+        catenate_numbers: true
+        catenate_all: true
+        preserve_original: false
+        generate_word_parts: false
+        stem_english_possessive: true
+        generate_number_parts: false
+        split_on_numerics: false
+        split_on_case_change: false
+      catenate_filter_split:
+        type: word_delimiter
+        catenate_words: true
+        catenate_numbers: true
+        catenate_all: true
+        preserve_original: false
+        generate_word_parts: true
+        stem_english_possessive: true
+        generate_number_parts: false
+        split_on_numerics: false
+        split_on_case_change: true
+      english_stemmer:
+        type: stemmer
+        language: light_english
+      search_synonym_filter:
+        type: synonym
+        synonyms_path: "analysis/search-synonyms.txt"
+      amino_synonym_filter:
+        type: synonym
+        synonyms_path: "analysis/amino-synonyms.txt"
+      type_synonym_filter:
+        type: synonym
+        synonyms_path: "analysis/type-synonyms.txt"
+      dbSNP_func_synonyms:
+        type: synonym
+        synonyms_path: "analysis/dbsnp-func-synonyms.txt"
+      dbSNP_class_synonyms:
+        type: synonym
+        synonyms_path: "analysis/dbsnp-class-synonyms.txt"
+      exonic_allele_function_search_synonyms:
+        type: synonym
+        synonyms_path: "analysis/exonic-allele-function-search-synonyms.txt"
+      site_type_synonym_filter:
+        type: synonym
+        synonyms_path: "analysis/site-type-synonyms.txt"
+      codon_map_synonym_filter:
+        type: synonym
+        synonyms_path: "analysis/codon-map-synonyms.txt"
+      description_synonyms:
+        type: synonym
+        synonyms_path: "analysis/refseq-description-synonyms.txt"
+      disease_synonyms:
+        type: synonym
+        synonyms_path: "analysis/disease-synonyms.txt"
+      autocomplete_filter:
+        type: edge_ngram
+        min_gram: 1
+        max_gram: 30
+        token_chars:
+          - letter
+          - digit
+          - punctuation
+    tokenizer:
+      hgvs_tokenizer:
+        type: pattern
+      edge_ngram_tokenizer:
+        type: edge_ngram
+        min_gram: 1
+        max_gram: 30
+        token_chars:
+          - letter
+          - digit
+          - punctuation
+    analyzer:
+      hgvs_analyzer:
+        type: custom
+        tokenizer: hgvs_tokenizer
+        filter:
+          - lowercase
+      autocomplete_english:
+        type: custom
+        tokenizer: whitespace
+        filter:
+          - lowercase
+          - asciifolding
+          - catenate_filter
+          - english_stemmer
+          - autocomplete_filter
+      autocomplete_english_split:
+        type: custom
+        tokenizer: whitespace
+        filter:
+          - lowercase
+          - asciifolding
+          - catenate_filter_split
+          - english_stemmer
+          - autocomplete_filter
+      autocomplete_english_split_clinsig:
+        type: custom
+        tokenizer: whitespace
+        filter:
+          - lowercase
+          - exclude_pathogenic
+          - asciifolding
+          - catenate_filter_split
+      autocomplete_english_graph:
+        type: custom
+        tokenizer: keyword
+        filter:
+          - word_delimiter_graph
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - autocomplete_filter
+      english_graph:
+        type: custom
+        tokenizer: keyword
+        filter:
+          - word_delimiter_graph
+          - lowercase
+          - asciifolding
+          - english_stemmer
+      autocomplete_english_letter:
+        type: custom
+        tokenizer: letter
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - autocomplete_filter
+      search_english:
+        type: custom
+        tokenizer: classic
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - search_synonym_filter
+      search_english_split:
+        type: custom
+        tokenizer: standard
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - search_synonym_filter
+      search_english_split_letter:
+        type: custom
+        tokenizer: letter
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - search_synonym_filter
+      search_english_type:
+        type: custom
+        tokenizer: standard
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - type_synonym_filter
+          - dbSNP_class_synonyms
+      search_english_description_synonyms:
+        type: custom
+        tokenizer: standard
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - description_synonyms
+          - disease_synonyms
+      search_english_class:
+        type: custom
+        tokenizer: standard
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - dbSNP_class_synonyms
+      search_english_func:
+        type: custom
+        tokenizer: standard
+        filter:
+          - lowercase
+          - asciifolding
+          - english_stemmer
+          - dbSNP_func_synonyms
+      uppercase_keyword_text:
+        type: custom
+        tokenizer: keyword
+        filter:
+          - uppercase
+          - asciifolding
+      uppercase_keyword_text_codon:
+        type: custom
+        tokenizer: keyword
+        filter:
+          - uppercase
+          - asciifolding
+          - codon_map_synonym_filter
+          - amino_synonym_filter
+      uppercase_keyword_text_amino:
+        type: custom
+        tokenizer: keyword
+        filter:
+          - uppercase
+          - asciifolding
+          - amino_synonym_filter
+mappings:
+  properties:
+    chrom:
+      type: keyword
+      normalizer: lowercase_normalizer
+    pos:
+      type: integer
+    trTv:
+      type: byte
+    type:
+      type: text
+      analyzer: autocomplete_english
+      search_analyzer: search_english_type
+      fields:
+        exact:
+          type: keyword
+          normalizer: lowercase_normalizer
+    discordant:
+      type: byte
+    heterozygotes:
+      type: keyword
+    heterozygosity:
+      type: half_float
+    homozygotes:
+      type: keyword
+    homozygosity:
+      type: half_float
+    missingGenos:
+      type: keyword
+    missingness:
+      type: half_float
+    ac:
+      type: integer
+    an:
+      type: integer
+    sampleMaf:
+      type: half_float
+    alt:
+      type: text
+    ref:
+      type: keyword
+      normalizer: uppercase_normalizer
+    refSeq:
+      properties:
+        siteType:
+          type: text
+          analyzer: autocomplete_english
+          search_analyzer: search_english_func
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        exonicAlleleFunction:
+          type: text
+          analyzer: autocomplete_english
+          search_analyzer: search_english_func
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        refCodon:
+          type: keyword
+          normalizer: uppercase_normalizer
+        altCodon:
+          type: keyword
+          normalizer: uppercase_normalizer
+        refAminoAcid:
+          type: text
+          analyzer: uppercase_keyword_text
+          search_analyzer: uppercase_keyword_text_amino
+          fields:
+            exact:
+              type: keyword
+              normalizer: uppercase_normalizer
+        altAminoAcid:
+          type: text
+          analyzer: uppercase_keyword_text
+          search_analyzer: uppercase_keyword_text_amino
+          fields:
+            exact:
+              type: keyword
+              normalizer: uppercase_normalizer
+        codonPosition:
+          type: byte
+        codonNumber:
+          type: integer
+        strand:
+          type: keyword
+        kgID:
+          type: keyword
+          normalizer: lowercase_normalizer
+        mRNA:
+          type: keyword
+          normalizer: uppercase_normalizer
+        spID:
+          type: keyword
+          normalizer: uppercase_normalizer
+        spDisplayID:
+          type: keyword
+          normalizer: uppercase_normalizer
+        geneSymbol:
+          type: keyword
+          normalizer: uppercase_normalizer
+        tRnaName:
+          type: keyword
+          normalizer: uppercase_normalizer
+        ensemblID:
+          type: keyword
+          normalizer: uppercase_normalizer
+        name2:
+          type: keyword
+          normalizer: uppercase_normalizer
+        protAcc:
+          type: keyword
+          normalizer: uppercase_normalizer
+        description:
+          type: text
+          analyzer: autocomplete_english_split
+          search_analyzer: search_english_description_synonyms
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        rfamAcc:
+          type: keyword
+          normalizer: uppercase_normalizer
+        name:
+          type: keyword
+          normalizer: uppercase_normalizer
+        clinvar:
+          properties:
+            alleleID:
+              type: integer
+            phenotypeList:
+              type: text
+              analyzer: autocomplete_english_split
+              search_analyzer: search_english_description_synonyms
+              fields:
+                exact:
+                  type: keyword
+                  normalizer: lowercase_normalizer
+            clinicalSignificance:
+              type: text
+              analyzer: autocomplete_english_split
+              search_analyzer: search_english_split
+              fields:
+                exact:
+                  type: keyword
+                  normalizer: lowercase_normalizer
+            type:
+              type: text
+              analyzer: autocomplete_english
+              search_analyzer: search_english_class
+              fields:
+                exact:
+                  type: keyword
+                  normalizer: lowercase_normalizer
+            origin:
+              type: text
+              analyzer: autocomplete_english_split
+              search_analyzer: search_english_split
+              fields:
+                exact:
+                  type: keyword
+                  normalizer: lowercase_normalizer
+            numberSubmitters:
+              type: short
+            reviewStatus:
+              type: text
+              analyzer: autocomplete_english_split
+              search_analyzer: search_english_split
+              fields:
+                exact:
+                  type: keyword
+                  normalizer: lowercase_normalizer
+            chromStart:
+              type: integer
+            chromEnd:
+              type: integer
+    nearest:
+      properties:
+        refSeq:
+          properties:
+            name:
+              type: keyword
+              normalizer: uppercase_normalizer
+            name2:
+              type: keyword
+              normalizer: uppercase_normalizer
+            dist:
+              type: integer
+    nearestTss:
+      properties:
+        refSeq:
+          properties:
+            name:
+              type: keyword
+              normalizer: uppercase_normalizer
+            name2:
+              type: keyword
+              normalizer: uppercase_normalizer
+            dist:
+              type: integer
+    cadd:
+      type: scaled_float
+      scaling_factor: 10
+    caddIndel:
+      properties:
+        alt:
+          type: keyword
+          normalizer: uppercase_normalizer
+        id:
+          type: keyword
+          normalizer: lowercase_normalizer
+        PHRED:
+          type: scaled_float
+          scaling_factor: 10
+    phastCons:
+      type: scaled_float
+      scaling_factor: 100
+    phyloP:
+      type: scaled_float
+      scaling_factor: 100
+    clinvarVcf:
+      properties:
+        alt:
+          type: keyword
+          normalizer: uppercase_normalizer
+        id:
+          type: keyword
+          normalizer: lowercase_normalizer
+        ALLELEID:
+          type: keyword
+          normalizer: lowercase_normalizer
+        RS:
+          type: keyword
+          normalizer: lowercase_normalizer
+        AF_ESP:
+          type: half_float
+        AF_EXAC:
+          type: half_float
+        AF_TGP:
+          type: half_float
+        CLNVCSO:
+          type: keyword
+          normalizer: lowercase_normalizer
+        CLNSIG:
+          type: text
+          analyzer: autocomplete_english_split_clinsig
+          search_analyzer: search_english_split
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        CLNSIGCONF:
+          type: text
+          analyzer: autocomplete_english_split
+          search_analyzer: search_english_split
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        CLNREVSTAT:
+          type: text
+          analyzer: autocomplete_english_split
+          search_analyzer: search_english_description_synonyms
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        CLNDN:
+          type: text
+          analyzer: autocomplete_english_split
+          search_analyzer: search_english_description_synonyms
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        CLNDNINCL:
+          type: text
+          analyzer: search_english_split
+          fields:
+            exact:
+              type: keyword
+              normalizer: lowercase_normalizer
+        CLNHGVS:
+          type: text
+          analyzer: english_graph
+          fields:
+            exact:
+              type: keyword
+        DBVARID:
+          type: keyword
+          normalizer: lowercase_normalizer
+        ORIGIN:
+          type: keyword
+          normalizer: lowercase_normalizer
+        SSR:
+          type: keyword
+          normalizer: lowercase_normalizer
+    dbSNP:
+      properties:
+        alt:
+          type: keyword
+          normalizer: uppercase_normalizer
+        id:
+          type: keyword
+          normalizer: lowercase_normalizer
+        TOMMO:
+          type: half_float
+        ExAC:
+          type: half_float
+        GnomAD:
+          type: half_float
+        Korea1K:
+          type: half_float
+        GoNL:
+          type: half_float
+        KOREAN:
+          type: half_float
+        TWINSUK:
+          type: half_float
+        Vietnamese:
+          type: half_float
+        GENOME_DK:
+          type: half_float
+        GoESP:
+          type: half_float
+        GnomAD_exomes:
+          type: half_float
+        Siberian:
+          type: half_float
+        PRJEB37584:
+          type: half_float
+        SGDP_PRJ:
+          type: half_float
+        1000Genomes:
+          type: half_float
+        dbGaP_PopFreq:
+          type: half_float
+        NorthernSweden:
+          type: half_float
+        HapMap:
+          type: half_float
+        TOPMED:
+          type: half_float
+        ALSPAC:
+          type: half_float
+        Qatari:
+          type: half_float
+        MGP:
+          type: half_float
+    gnomad:
+      properties:
+        genomes:
+          properties:
+            alt:
+              type: keyword
+              normalizer: uppercase_normalizer
+            id:
+              type: keyword
+              normalizer: lowercase_normalizer
+            spliceai_ds_max:
+              type: half_float
+            pangolin_largest_ds:
+              type: half_float
+            phylop:
+              type: half_float
+            sift_max:
+              type: half_float
+            polyphen_max:
+              type: half_float
+            AN:
+              type: integer
+            AF:
+              type: half_float
+            AN_XX:
+              type: integer
+            AF_XX:
+              type: half_float
+            AN_XY:
+              type: integer
+            AF_XY:
+              type: half_float
+            AF_afr:
+              type: half_float
+            AN_afr:
+              type: integer
+            AF_ami:
+              type: half_float
+            AN_ami:
+              type: integer
+            AF_amr:
+              type: half_float
+            AN_amr:
+              type: integer
+            AF_asj:
+              type: half_float
+            AN_asj:
+              type: integer
+            AF_eas:
+              type: half_float
+            AN_eas:
+              type: integer
+            AF_fin:
+              type: half_float
+            AN_fin:
+              type: integer
+            AF_mid:
+              type: half_float
+            AN_mid:
+              type: integer
+            AF_nfe:
+              type: half_float
+            AN_nfe:
+              type: integer
+            AF_remaining:
+              type: half_float
+            AN_remaining:
+              type: integer
+            AF_sas:
+              type: half_float
+            AN_sas:
+              type: integer
+            AF_joint_XX:
+              type: half_float
+            AN_joint_XX:
+              type: integer
+            AF_joint_XY:
+              type: half_float
+            AN_joint_XY:
+              type: integer
+            AF_joint:
+              type: half_float
+            AN_joint:
+              type: integer
+            AF_joint_afr:
+              type: half_float
+            AN_joint_afr:
+              type: integer
+            AF_joint_ami:
+              type: half_float
+            AN_joint_ami:
+              type: integer
+            AF_joint_amr:
+              type: half_float
+            AN_joint_amr:
+              type: integer
+            AF_joint_asj:
+              type: half_float
+            AN_joint_asj:
+              type: integer
+            AF_joint_eas:
+              type: half_float
+            AN_joint_eas:
+              type: integer
+            AF_joint_fin:
+              type: half_float
+            AN_joint_fin:
+              type: integer
+            AF_joint_mid:
+              type: half_float
+            AN_joint_mid:
+              type: integer
+            AF_joint_nfe:
+              type: half_float
+            AN_joint_nfe:
+              type: integer
+            AF_joint_remaining:
+              type: half_float
+            AN_joint_remaining:
+              type: integer
+            AF_joint_sas:
+              type: half_float
+            AN_joint_sas:
+              type: integer
+            AF_grpmax:
+              type: half_float
+            AN_grpmax:
+              type: integer
+            AF_grpmax_joint:
+              type: half_float
+            AN_grpmax_joint:
+              type: integer
+        exomes:
+          properties:
+            alt:
+              type: keyword
+              normalizer: uppercase_normalizer
+            id:
+              type: keyword
+              normalizer: lowercase_normalizer
+            spliceai_ds_max:
+              type: half_float
+            pangolin_largest_ds:
+              type: half_float
+            phylop:
+              type: half_float
+            sift_max:
+              type: half_float
+            polyphen_max:
+              type: half_float
+            AN:
+              type: integer
+            AF:
+              type: half_float
+            AF_XX:
+              type: half_float
+            AN_XX:
+              type: integer
+            AF_XY:
+              type: half_float
+            AN_XY:
+              type: integer
+            AF_afr:
+              type: half_float
+            AN_afr:
+              type: integer
+            AF_amr:
+              type: half_float
+            AN_amr:
+              type: integer
+            AF_asj:
+              type: half_float
+            AN_asj:
+              type: integer
+            AF_eas:
+              type: half_float
+            AN_eas:
+              type: integer
+            AF_fin:
+              type: half_float
+            AN_fin:
+              type: integer
+            AF_mid:
+              type: half_float
+            AN_mid:
+              type: integer
+            AF_nfe:
+              type: half_float
+            AN_nfe:
+              type: integer
+            AF_non_ukb:
+              type: half_float
+            AN_non_ukb:
+              type: integer
+            AF_non_ukb_afr:
+              type: half_float
+            AN_non_ukb_afr:
+              type: integer
+            AF_non_ukb_amr:
+              type: half_float
+            AN_non_ukb_amr:
+              type: integer
+            AF_non_ukb_asj:
+              type: half_float
+            AN_non_ukb_asj:
+              type: integer
+            AF_non_ukb_eas:
+              type: half_float
+            AN_non_ukb_eas:
+              type: integer
+            AF_non_ukb_fin:
+              type: half_float
+            AN_non_ukb_fin:
+              type: integer
+            AF_non_ukb_mid:
+              type: half_float
+            AN_non_ukb_mid:
+              type: integer
+            AF_non_ukb_nfe:
+              type: half_float
+            AN_non_ukb_nfe:
+              type: integer
+            AF_non_ukb_remaining:
+              type: half_float
+            AN_non_ukb_remaining:
+              type: integer
+            AF_non_ukb_sas:
+              type: half_float
+            AN_non_ukb_sas:
+              type: integer
+            AF_remaining:
+              type: half_float
+            AN_remaining:
+              type: integer
+            AF_sas:
+              type: half_float
+            AN_sas:
+              type: integer
+            AF_grpmax:
+              type: half_float
+            AN_grpmax:
+              type: integer
+            AF_grpmax_non_ukb:
+              type: half_float
+            AN_grpmax_non_ukb:
+              type: integer
+            AF_grpmax_joint:
+              type: half_float
+            AN_grpmax_joint:
+              type: integer


### PR DESCRIPTION
* Updates hg38.mapping.yamland hg19.mapping.yaml to support new our new hg19 and hg38 databases
* Updates hg38.clean.yml and hg19.clean.yml to match the bystro annotator definitions of our new databases

hg38.mapping.yml is now a separate definition, rather than a symlink to hg19.mapping.yml. It is identical to hg19.mapping.yml besides the gnomad sections, which have to be different since gnomad v4 was used in the hg38 database.