### PR TITLE
Feature/issue 421 remove refseq clinvar

### DIFF
--- a/config/hg19.clean.yml
+++ b/config/hg19.clean.yml
@@ -147,18 +147,6 @@ tracks:
         - rfamAcc
         - tRnaName
         - ensemblID
-      join:
-        features:
-          - alleleID
-          - phenotypeList
-          - clinicalSignificance
-          - type
-          - origin
-          - numberSubmitters
-          - reviewStatus
-          - chromStart
-          - chromEnd
-        track: clinvar
       local_files:
         - hg19.kgXref.chr1.gz
         - hg19.kgXref.chr2.gz

--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -369,56 +369,6 @@ mappings:
         name:
           type: keyword
           normalizer: uppercase_normalizer
-        clinvar:
-          properties:
-            alleleID:
-              type: integer
-            phenotypeList:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_description_synonyms
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            clinicalSignificance:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            type:
-              type: text
-              analyzer: autocomplete_english
-              search_analyzer: search_english_class
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            origin:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            numberSubmitters:
-              type: short
-            reviewStatus:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            chromStart:
-              type: integer
-            chromEnd:
-              type: integer
     nearest:
       properties:
         refSeq:

--- a/config/hg38.clean.yml
+++ b/config/hg38.clean.yml
@@ -147,18 +147,6 @@ tracks:
         - rfamAcc
         - tRnaName
         - ensemblID
-      join:
-        features:
-          - alleleID
-          - phenotypeList
-          - clinicalSignificance
-          - type
-          - origin
-          - numberSubmitters
-          - reviewStatus
-          - chromStart
-          - chromEnd
-        track: clinvar
       local_files:
         - hg38.kgXref.chr1.gz
         - hg38.kgXref.chr2.gz

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -369,56 +369,6 @@ mappings:
         name:
           type: keyword
           normalizer: uppercase_normalizer
-        clinvar:
-          properties:
-            alleleID:
-              type: integer
-            phenotypeList:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_description_synonyms
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            clinicalSignificance:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            type:
-              type: text
-              analyzer: autocomplete_english
-              search_analyzer: search_english_class
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            origin:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            numberSubmitters:
-              type: short
-            reviewStatus:
-              type: text
-              analyzer: autocomplete_english_split
-              search_analyzer: search_english_split
-              fields:
-                exact:
-                  type: keyword
-                  normalizer: lowercase_normalizer
-            chromStart:
-              type: integer
-            chromEnd:
-              type: integer
     nearest:
       properties:
         refSeq:


### PR DESCRIPTION
* We do not currently handle refSeq.clinvar in a way that makes sense compared to our current annotations; order between fields in the struct is not necessarily preserved. Once we fix it, we can add back.


Dave Cutler agreed that refSeq.clinvar is no longer useful

Stacked on https://github.com/bystrogenomics/bystro/pull/432