### PR TITLE
Issue #421: Make discordant an actual boolean field, by outputting 'false'/'true' labels

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -258,7 +258,7 @@ mappings:
           type: keyword
           normalizer: lowercase_normalizer
     discordant:
-      type: byte
+      type: boolean
     heterozygotes:
       type: keyword
     heterozygosity:

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -258,7 +258,7 @@ mappings:
           type: keyword
           normalizer: lowercase_normalizer
     discordant:
-      type: byte
+      type: boolean
     heterozygotes:
       type: keyword
     heterozygosity:

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -305,7 +305,7 @@ sub annotateFile {
 
       # 3 holds the input reference, we'll replace this with the discordant status
       $fields[$discordantIdx] =
-        $refTrackGetter->get($dataFromDbAref) ne $fields[3] ? 1 : 0;
+        $refTrackGetter->get($dataFromDbAref) ne $fields[3] ? "true" : "false";
 
       push @lines, \@fields;
     }


### PR DESCRIPTION
* Make discordant an actual boolean field, by outputting 'false'/'true' labels

This makes it easier to search the field, as well as to import it as a boolean in Pandas/R.