### PR TITLE
Issue#421: fix missing bystro-vcf fields in mapping

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -242,13 +242,25 @@ index_settings:
           - amino_synonym_filter
 mappings:
   properties:
+    id:
+      type: keyword
+      normalizer: lowercase_normalizer
     chrom:
       type: keyword
       normalizer: lowercase_normalizer
     pos:
       type: integer
-    trTv:
-      type: byte
+    vcfPos:
+      type: integer
+    ref:
+      type: keyword
+      normalizer: uppercase_normalizer
+    inputRef:
+      type: keyword
+      normalizer: uppercase_normalizer
+    alt:
+      type: keyword
+      normalizer: uppercase_normalizer
     type:
       type: text
       analyzer: autocomplete_english
@@ -257,8 +269,10 @@ mappings:
         exact:
           type: keyword
           normalizer: lowercase_normalizer
-    discordant:
+    trTv:
       type: byte
+    discordant:
+      type: boolean
     heterozygotes:
       type: keyword
     heterozygosity:
@@ -277,11 +291,6 @@ mappings:
       type: integer
     sampleMaf:
       type: half_float
-    alt:
-      type: text
-    ref:
-      type: keyword
-      normalizer: uppercase_normalizer
     refSeq:
       properties:
         siteType:

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -242,13 +242,25 @@ index_settings:
           - amino_synonym_filter
 mappings:
   properties:
+    id:
+      type: keyword
+      normalizer: lowercase_normalizer
     chrom:
       type: keyword
       normalizer: lowercase_normalizer
     pos:
       type: integer
-    trTv:
-      type: byte
+    vcfPos:
+      type: integer
+    ref:
+      type: keyword
+      normalizer: uppercase_normalizer
+    inputRef:
+      type: keyword
+      normalizer: uppercase_normalizer
+    alt:
+      type: keyword
+      normalizer: uppercase_normalizer
     type:
       type: text
       analyzer: autocomplete_english
@@ -257,8 +269,10 @@ mappings:
         exact:
           type: keyword
           normalizer: lowercase_normalizer
-    discordant:
+    trTv:
       type: byte
+    discordant:
+      type: boolean
     heterozygotes:
       type: keyword
     heterozygosity:
@@ -277,11 +291,6 @@ mappings:
       type: integer
     sampleMaf:
       type: half_float
-    alt:
-      type: text
-    ref:
-      type: keyword
-      normalizer: uppercase_normalizer
     refSeq:
       properties:
         siteType:
@@ -290,7 +299,7 @@ mappings:
           search_analyzer: search_english_func
           fields:
             exact:
-              type: keyword
+              type: keywordd
               normalizer: lowercase_normalizer
         exonicAlleleFunction:
           type: text

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -305,7 +305,7 @@ sub annotateFile {
 
       # 3 holds the input reference, we'll replace this with the discordant status
       $fields[$discordantIdx] =
-        $refTrackGetter->get($dataFromDbAref) ne $fields[3] ? 1 : 0;
+        $refTrackGetter->get($dataFromDbAref) ne $fields[3] ? "true" : "false";
 
       push @lines, \@fields;
     }


### PR DESCRIPTION
* We were missing id, inputRef, vcfPos, and had "alt" as a text field, rather than keyword. Text fields cannot be aggregated on, and I don't see a use case for full text matches on alt fields anyway (only use case would be insertions, but there it would be of extremely limited use, matching "+ATCGGGG" if the user entered "+ATCG"

We can revisit the alt decision later if in practical use that becomes limiting