### PR TITLE
Issue#421: Improve hg19 and hg38 opensearch index definitions

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -35,7 +35,7 @@ index_settings:
         catenate_words: true
         catenate_numbers: true
         catenate_all: true
-        preserve_original: false
+        preserve_original: true
         generate_word_parts: false
         stem_english_possessive: true
         generate_number_parts: false
@@ -46,7 +46,7 @@ index_settings:
         catenate_words: true
         catenate_numbers: true
         catenate_all: true
-        preserve_original: false
+        preserve_original: true
         generate_word_parts: true
         stem_english_possessive: true
         generate_number_parts: false
@@ -203,6 +203,14 @@ index_settings:
           - english_stemmer
           - description_synonyms
           - disease_synonyms
+      search_english_simple:
+        type: custom
+        tokenizer: whitespace
+        filter:
+          - lowercase
+          - asciifolding
+          - catenate_filter_split
+          - english_stemmer
       search_english_class:
         type: custom
         tokenizer: standard
@@ -448,7 +456,7 @@ mappings:
         CLNSIG:
           type: text
           analyzer: autocomplete_english_split_clinsig
-          search_analyzer: search_english_split
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -456,7 +464,7 @@ mappings:
         CLNSIGCONF:
           type: text
           analyzer: autocomplete_english_split
-          search_analyzer: search_english_split
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -464,7 +472,7 @@ mappings:
         CLNREVSTAT:
           type: text
           analyzer: autocomplete_english_split
-          search_analyzer: search_english_description_synonyms
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -472,7 +480,7 @@ mappings:
         CLNDN:
           type: text
           analyzer: autocomplete_english_split
-          search_analyzer: search_english_description_synonyms
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -480,6 +488,7 @@ mappings:
         CLNDNINCL:
           type: text
           analyzer: search_english_split
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword

--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -242,13 +242,25 @@ index_settings:
           - amino_synonym_filter
 mappings:
   properties:
+    id:
+      type: keyword
+      normalizer: lowercase_normalizer
     chrom:
       type: keyword
       normalizer: lowercase_normalizer
     pos:
       type: integer
-    trTv:
-      type: byte
+    vcfPos:
+      type: integer
+    ref:
+      type: keyword
+      normalizer: uppercase_normalizer
+    inputRef:
+      type: keyword
+      normalizer: uppercase_normalizer
+    alt:
+      type: keyword
+      normalizer: uppercase_normalizer
     type:
       type: text
       analyzer: autocomplete_english
@@ -257,6 +269,8 @@ mappings:
         exact:
           type: keyword
           normalizer: lowercase_normalizer
+    trTv:
+      type: byte
     discordant:
       type: boolean
     heterozygotes:
@@ -277,11 +291,6 @@ mappings:
       type: integer
     sampleMaf:
       type: half_float
-    alt:
-      type: text
-    ref:
-      type: keyword
-      normalizer: uppercase_normalizer
     refSeq:
       properties:
         siteType:

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -35,7 +35,7 @@ index_settings:
         catenate_words: true
         catenate_numbers: true
         catenate_all: true
-        preserve_original: false
+        preserve_original: true
         generate_word_parts: false
         stem_english_possessive: true
         generate_number_parts: false
@@ -46,7 +46,7 @@ index_settings:
         catenate_words: true
         catenate_numbers: true
         catenate_all: true
-        preserve_original: false
+        preserve_original: true
         generate_word_parts: true
         stem_english_possessive: true
         generate_number_parts: false
@@ -203,6 +203,14 @@ index_settings:
           - english_stemmer
           - description_synonyms
           - disease_synonyms
+      search_english_simple:
+        type: custom
+        tokenizer: whitespace
+        filter:
+          - lowercase
+          - asciifolding
+          - catenate_filter_split
+          - english_stemmer
       search_english_class:
         type: custom
         tokenizer: standard
@@ -448,7 +456,7 @@ mappings:
         CLNSIG:
           type: text
           analyzer: autocomplete_english_split_clinsig
-          search_analyzer: search_english_split
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -456,7 +464,7 @@ mappings:
         CLNSIGCONF:
           type: text
           analyzer: autocomplete_english_split
-          search_analyzer: search_english_split
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -464,7 +472,7 @@ mappings:
         CLNREVSTAT:
           type: text
           analyzer: autocomplete_english_split
-          search_analyzer: search_english_description_synonyms
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -472,7 +480,7 @@ mappings:
         CLNDN:
           type: text
           analyzer: autocomplete_english_split
-          search_analyzer: search_english_description_synonyms
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword
@@ -480,6 +488,7 @@ mappings:
         CLNDNINCL:
           type: text
           analyzer: search_english_split
+          search_analyzer: search_english_simple
           fields:
             exact:
               type: keyword

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -242,13 +242,25 @@ index_settings:
           - amino_synonym_filter
 mappings:
   properties:
+    id:
+      type: keyword
+      normalizer: lowercase_normalizer
     chrom:
       type: keyword
       normalizer: lowercase_normalizer
     pos:
       type: integer
-    trTv:
-      type: byte
+    vcfPos:
+      type: integer
+    ref:
+      type: keyword
+      normalizer: uppercase_normalizer
+    inputRef:
+      type: keyword
+      normalizer: uppercase_normalizer
+    alt:
+      type: keyword
+      normalizer: uppercase_normalizer
     type:
       type: text
       analyzer: autocomplete_english
@@ -257,6 +269,8 @@ mappings:
         exact:
           type: keyword
           normalizer: lowercase_normalizer
+    trTv:
+      type: byte
     discordant:
       type: boolean
     heterozygotes:
@@ -277,11 +291,6 @@ mappings:
       type: integer
     sampleMaf:
       type: half_float
-    alt:
-      type: text
-    ref:
-      type: keyword
-      normalizer: uppercase_normalizer
     refSeq:
       properties:
         siteType:


### PR DESCRIPTION
* We were missing id, inputRef, vcfPos, and had "alt" as a text field, rather than keyword. Text fields cannot be aggregated on, and I don't see a use case for full text matches on alt fields anyway (only use case would be insertions, but there it would be of extremely limited use, matching "+ATCGGGG" if the user entered "+ATCG"
* Fixes clinvar queries, making queries on fields like CLNSIG, such as "pathogenic likely_pathogenic Benign(2)" work without stripping special characters


Much more extensive testing is needed in the future, but this fixes a large number of queries on clinvar fields.

We do as a result lose disease synonyms on clinvar (because catenate_filter is, in Elasticsearch > 6 incompatible with synonyms filters) but that is not as much of a problem as not being able to search for terms that appear directly in results. We will resolve synonyms in the future by following the advice on this topic mentioned in https://discuss.elastic.co/t/unable-to-bypass-restriction-with-synonym-token-filter/195334/4