### PR TITLE
Issue #421 Bystro Python API Dockerfile & Ancestry API/CLI  & Reduce Ancestry Memory Usage

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -18,10 +18,10 @@ jobs:
           auto-activate-base: true
           activate-environment: true
           python-version: ${{ matrix.python-version }}   
-    - name: Build Bystro using Maturin
+    - name: Install Bystro using Maturin
       run: |
         . .initialize_conda_env.sh
-        make build
+        make install
       shell: bash
     - name: Verify Bystro wheel exists
       run: |
@@ -30,3 +30,8 @@ jobs:
           exit 1
         fi
         echo "Bystro wheel found! Build succeeded."
+    - name: Verify bystro-api is installed
+      run: |
+        set -e
+        bystro-api --help
+        echo "bystro-api installed successfully"

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         . .initialize_conda_env.sh
         make install
+        echo "PATH=$CONDA/bin:$PATH" >> $GITHUB_ENV
       shell: bash
     - name: Verify Bystro wheel exists
       run: |

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,0 +1,64 @@
+# ---- Build Golang Binaries ----
+FROM golang:1.21.3 AS go-builder
+
+# Set the environment variable for Go binaries. This makes sure the binaries are saved to a defined path.
+ENV GOBIN=/app/bin
+
+# Install the specific versions of the Go programs
+RUN go install github.com/akotlar/bystro-stats@1.0.0
+RUN go install github.com/bystrogenomics/bystro-vcf@2.1.1
+RUN go install github.com/akotlar/bystro-snp@1.0.0
+RUN go install github.com/mikefarah/yq@2.4.1
+
+COPY ./go /app/bystro-go-tools
+
+RUN cd /app/bystro-go-tools && go install bystro/cmd/opensearch
+
+# Use Ubuntu as the base image to match the GitHub Actions environment
+FROM python:3.11.8-bookworm
+
+# Copy the compiled Go binaries from the builder stage
+COPY --from=go-builder /app/bin/ /app/bin/
+
+# Add app/bin to PATH
+ENV PATH="/app/bin:${PATH}"
+
+# # Install common dependencies and utilities
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    wget curl\
+    openssl libcurl4-openssl-dev libssl-dev \
+    tar lz4 pigz tabix unzip \
+    patch \
+    awscli \
+    unzip \
+    libssl-dev \
+    pkg-config \ 
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && . $HOME/.cargo/env
+
+# Make sure Cargo is in the PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Set up the workspace
+WORKDIR /workspace
+
+# Copy the entire monorepo
+COPY ./python ./python
+
+# Install Python and dependencies
+RUN pip install --upgrade pip && pip install -r python/requirements.txt -r python/requirements-dev.txt
+
+COPY ./Makefile ./
+
+# This CMD should be replaced with the command(s) to run your application
+# For example, you might start a server, run a script, etc.
+# This is just a placeholder for demonstration.
+
+RUN make install-python
+
+ENTRYPOINT ["bystro-api"]
+
+CMD ["--help"]

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -53,10 +53,6 @@ RUN pip install --upgrade pip && pip install -r python/requirements.txt -r pytho
 
 COPY ./Makefile ./
 
-# This CMD should be replaced with the command(s) to run your application
-# For example, you might start a server, run a script, etc.
-# This is just a placeholder for demonstration.
-
 RUN make install-python
 
 ENTRYPOINT ["bystro-api"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,13 +68,24 @@ source "$HOME/.cargo/env"
 source .initialize_conda_env.sh;
 ```
 
-to install the Python package dependencies. Then, run:
+
+The easiest way to get started:
+```sh
+# Installs the Bystro Python library and cli, and starts the Ray cluster
+# alternatively you could have run `make install && make ray-start-local`
+# or just `make install` if you only wished to install Bystro
+make run-local
 ```
-# Build the Python package for local use
-make build
+- This will create a local Ray server, which is needed for some Bystro operations
+- To stop Ray: `ray stop`
+
+
+If you are developing/contributing to the Bystro library, for a faster build use:
+```sh
+make develop
 ```
 
-to intall the Bystro Python library.
+To start a local beanstalkd listener, use either `make serve-local` or `make serve-dev`, depending on whether you are in a product environment, or development.
 
 Follow the instructions below to install the Bystro annotator:
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ install-python: build-python
 	pip install python/target/wheels/*.whl
 
 install-go:
-	(cd ./go && go install bystro/cmd/dosage)
 	(cd ./go && go install bystro/cmd/opensearch)
 
 install: install-python install-go

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install-python: build-python
 	pip install python/target/wheels/*.whl
 
 install-go:
+	(cd ./go && go install bystro/cmd/dosage)
 	(cd ./go && go install bystro/cmd/opensearch)
 
 install: install-python install-go
@@ -26,9 +27,11 @@ develop: install-go build-python-dev ray-start-local
 
 run-local: install ray-start-local
 
-# Currently assumes that Perl package has been separately installed
-serve-local: ray-stop-local run-local
+pm2:
 	pm2 delete all 2> /dev/null || true && pm2 start startup.yml
 
 # Currently assumes that Perl package has been separately installed
-serve-dev: ray-stop-local start-local develop pm2
+serve-local: ray-stop-local run-local pm2
+
+# Currently assumes that Perl package has been separately installed
+serve-dev: ray-stop-local develop pm2

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -3,295 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "const-random",
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "arrow"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6619cab21a0cdd8c9b9f1d9e09bfaa9b1974e5ef809a6566aef0b998caf38ace"
-dependencies = [
- "ahash",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dc95485623a76e00929bda8caa40c1f838190952365c4f43a7b9ae86d03e94"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3267847f53d3042473cfd2c769afd8d74a6d7d201fc3a34f5cb84c0282ef47a7"
-dependencies = [
- "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "hashbrown 0.13.2",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f66553e66e120ac4b21570368ee9ebf35ff3f5399f872b0667699e145678f5"
-dependencies = [
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e6f3579dbf0d97c683d451b2550062b0f0e62a3169bf74238b5f59f44ad6d8"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "chrono",
- "lexical-core",
- "num",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373579c4c1a8f5307d3125b7a89c700fcf8caf85821c77eb4baab3855ae0aba5"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "lexical-core",
- "regex",
-]
-
-[[package]]
-name = "arrow-data"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bc8df9912cca6642665fdf989d6fa0de2570f18a7f709bcf59d29de96d2097"
-dependencies = [
- "arrow-buffer",
- "arrow-schema",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0105dcf5f91daa7182d87b713ee0b32b3bfc88e0c48e7dc3e9d6f1277a07d1ae"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "flatbuffers",
-]
-
-[[package]]
-name = "arrow-json"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73134fb5b5ec8770f8cbb214c2c487b2d350081e403ca4eeeb6f8f5e19846ac"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "indexmap 1.9.2",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f25bc66e18d4c2aa1fe2f9bb03e2269da60e636213210385ae41a107f9965a"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-row"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1095ff85ea4f5ff02d17b30b089de31b51a50be01c6b674f0a0509ab771232f1"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "half",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25187bbef474151a2e4ddec67b9e34bda5cbfba292dc571392fa3a1f71ff5a82"
-
-[[package]]
-name = "arrow-select"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0d4ee884aec3aa05e41478e3cd312bf609de9babb5d187a43fb45931da4da4"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d71c3ffe4c07e66ce8fdc6aed5b00e0e60c5144911879b10546f5b72d8fa1c"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "regex",
- "regex-syntax 0.7.2",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -300,54 +15,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
-name = "bumpalo"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
 name = "bystro"
 version = "0.1.0"
 dependencies = [
- "arrow",
- "flate2",
- "heed",
- "opensearch",
  "pyo3",
- "serde_json",
- "tar",
- "tokio",
 ]
-
-[[package]]
-name = "bytemuck"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
-
-[[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -356,762 +28,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.26"
+name = "heck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "winapi",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "const-random"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
-dependencies = [
- "getrandom",
- "once_cell",
- "proc-macro-hack",
- "tiny-keccak",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "csv"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "flatbuffers"
-version = "23.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f5399c2c9c50ae9418e522842ad362f61ee48b346ac106807bd355a8a7c619"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
-
-[[package]]
-name = "futures-task"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
-
-[[package]]
-name = "futures-util"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap 2.1.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
-dependencies = [
- "crunchy",
- "num-traits",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
-name = "heed"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269c7486ed6def5d7b59a427cec3e87b4d4dd4381d01e21c8c9f2d3985688392"
-dependencies = [
- "bytemuck",
- "byteorder",
- "heed-traits",
- "heed-types",
- "libc",
- "lmdb-rkv-sys",
- "once_cell",
- "page_size",
- "serde",
- "synchronoise",
- "url",
-]
-
-[[package]]
-name = "heed-traits"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53a94e5b2fd60417e83ffdfe136c39afacff0d4ac1d8d01cd66928ac610e1a2"
-
-[[package]]
-name = "heed-types"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6cf0a6952fcedc992602d5cddd1e3fff091fbe87d38636e3ec23a31f32acbd"
-dependencies = [
- "bincode",
- "bytemuck",
- "byteorder",
- "heed-traits",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "hyper"
-version = "0.14.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
-dependencies = [
- "equivalent",
- "hashbrown 0.14.3",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indoc"
-version = "1.0.9"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
-
-[[package]]
-name = "itoa"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
-
-[[package]]
-name = "js-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
-
-[[package]]
-name = "libm"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "lmdb-rkv-sys"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b9ce6b3be08acefa3003c57b7565377432a89ec24476bbe72e11d101f852fe"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
 ]
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -1123,216 +65,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-
-[[package]]
-name = "opensearch"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6024cf389648eefe4ff215561fe0d7c64c9c5193ed6c054987a3ee3c969d61b"
-dependencies = [
- "base64 0.11.0",
- "bytes",
- "dyn-clone",
- "lazy_static",
- "percent-encoding",
- "reqwest",
- "rustc_version 0.2.3",
- "serde",
- "serde_json",
- "serde_with",
- "url",
- "void",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.96"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "page_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
-dependencies = [
- "libc",
- "winapi",
-]
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
@@ -1346,67 +82,44 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.2.0"
+name = "portable-atomic"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffef52f74ec3b1a1baf295d9b8fcc3070327aefc39a6d00656b13c1d0b8885c"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1415,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713eccf888fb05f1a96eb78c0dbc51907fee42b3377272dc902eb38985f418d5"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1425,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ecbdcfb01cbbf56e179ce969a048fd7305a66d4cdf3303e0da09d69afe4c3"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1435,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78fdc0899f2ea781c463679b20cb08af9247febc8d052de941951024cd8aea0"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1447,305 +160,52 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60da7b84f1227c3e2fe7593505de274dcf4c8928b4e0a1c23d551a14e4e80a0f"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
 dependencies = [
+ "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "regex"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.6.28",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
-
-[[package]]
-name = "reqwest"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
-dependencies = [
- "async-compression",
- "base64 0.21.0",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.16",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "schannel"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
-dependencies = [
- "windows-sys 0.42.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
-
-[[package]]
-name = "security-framework"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "serde"
-version = "1.0.152"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.152"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
-dependencies = [
- "autocfg",
-]
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1753,394 +213,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "synchronoise"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
-dependencies = [
- "crossbeam-queue",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
-
-[[package]]
-name = "tempfile"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
-dependencies = [
- "autocfg",
- "bytes",
- "libc",
- "memchr",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "socket2",
- "tokio-macros",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
-name = "tracing"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
-
-[[package]]
-name = "url"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "want"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = [
- "log",
- "try-lock",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
-]
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "windows-targets"
@@ -2148,20 +236,14 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2171,21 +253,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2195,21 +265,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2219,42 +277,12 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "xattr"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
-dependencies = [
- "libc",
-]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,11 +10,4 @@ name = "bystro"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-arrow = "40.0.0"
-flate2 = "1.0.25"
-heed = "0.11.0"
-opensearch = "2.0.0"
-pyo3 = { version = "0.19.0", features = ["extension-module"] }
-serde_json = "1.0.93"
-tar = "0.4.38"
-tokio = { version = "1.26.0", features = ["rt", "rt-multi-thread", "macros"] }
+pyo3 = { version = "0.20.3", features = ["extension-module"] }

--- a/python/python/bystro/ancestry/ancestry_types.py
+++ b/python/python/bystro/ancestry/ancestry_types.py
@@ -110,23 +110,22 @@ class AncestryScoresOneSample(Struct, frozen=True, rename="camel"):
 
     Represents ancestry model output for an individual study
     participant (identified by sample_id) with estimates for
-    populations and superpopulations, and the overall fraction of
-    expected variants found missing in the sample.
+    populations and superpopulations, and the overall number of snps
+    retained for calculating ancestry
     """
 
     sample_id: str
     top_hit: AncestryTopHit
     populations: PopulationVector
     superpops: SuperpopVector
-    missingness: float
+    n_snps: int
 
     def __post_init__(self):
-        if not isinstance(self.missingness, float):
-            raise TypeError(f"missingness must be a float, not {type(self.missingness)}")
+        if not isinstance(self.n_snps, int):
+            raise TypeError(f"n_snps must be an int, not {type(self.n_snps)}")
 
-        if self.missingness < LOWER_UNIT_BOUND or self.missingness > UPPER_UNIT_BOUND:
-            raise TypeError(f"missingness must be between {LOWER_UNIT_BOUND} and {UPPER_UNIT_BOUND}")
-
+        if self.n_snps < 0:
+            raise TypeError("n_snps must be non-negative")
 
 class AncestryResults(Struct, frozen=True):
     """An outgoing response from the ancestry worker.

--- a/python/python/bystro/ancestry/inference.py
+++ b/python/python/bystro/ancestry/inference.py
@@ -4,6 +4,7 @@ import logging
 import os
 from typing import Generator
 import psutil
+import warnings
 
 from msgspec import Struct
 import numpy as np
@@ -12,7 +13,7 @@ import pandas as pd
 import pyarrow.compute as pc  # type: ignore
 from pyarrow.dataset import Dataset, Scanner  # type: ignore
 
-from sklearn.ensemble import RandomForestClassifier # type: ignore
+from sklearn.ensemble import RandomForestClassifier  # type: ignore
 
 from bystro.ancestry.ancestry_types import (
     AncestryResults,
@@ -27,6 +28,7 @@ from bystro.ancestry.train import POPS, SUPERPOP_FROM_POP, SUPERPOPS
 from bystro.utils.timer import Timer
 
 logger = logging.getLogger(__name__)
+warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 class AncestryModel(Struct, frozen=True, forbid_unknown_fields=True, rename="camel"):

--- a/python/python/bystro/ancestry/inference.py
+++ b/python/python/bystro/ancestry/inference.py
@@ -250,8 +250,12 @@ def infer_ancestry(ancestry_models: AncestryModels, genotypes: Dataset) -> Ances
                 psutil.Process(os.getpid()).memory_info().rss / 1024**2,
             )
 
-            genotypes_df = genotypes_chunk_table.to_pandas()
-            genotypes_df = genotypes_df.set_index("locus")
+            genotypes_df = genotypes_chunk_table.to_pandas().set_index("locus")
+
+            # If there are duplicates, log them and remove them
+            if genotypes_df.index.duplicated().any():
+                logger.warning("Found duplicate loci in genotypes, removing duplicates")
+                genotypes_df = genotypes_df[~genotypes_df.index.duplicated(keep="first")]
 
             logger.info(
                 "Memory usage after converting table to Pandas dataframe, for samples %d to %d: %s (MB)",

--- a/python/python/bystro/ancestry/inference.py
+++ b/python/python/bystro/ancestry/inference.py
@@ -10,7 +10,7 @@ from msgspec import Struct
 import numpy as np
 import pandas as pd
 
-import pyarrow as pa # type: ignore
+import pyarrow as pa  # type: ignore
 import pyarrow.compute as pc  # type: ignore
 from pyarrow.dataset import Dataset  # type: ignore
 

--- a/python/python/bystro/ancestry/model.py
+++ b/python/python/bystro/ancestry/model.py
@@ -51,7 +51,13 @@ def get_one_model_from_s3(
     """
     s3_client = boto3.client("s3")
 
-    logger.info("Downloading PCA file %s", pca_file_key)
+    logger.info(
+        "Downloading PCA file %s and RFC file %s to %s and %s",
+        pca_file_key,
+        rfc_file_key,
+        pca_local_path,
+        rfc_local_path,
+    )
 
     with Timer() as timer:
         try:
@@ -107,23 +113,17 @@ def get_models_from_s3(assembly: str) -> AncestryModels:
         )
         models = AncestryModels(gnomad_model, array_model)
     else:
-        pca_file_key_gnomad = paths["gnomad"]["pca_basename"]
-        rfc_file_key_gnomad = paths["gnomad"]["rfc_basename"]
-
-        pca_file_key_array = paths["array"]["pca_basename"]
-        rfc_file_key_array = paths["array"]["rfc_basename"]
-
         gnomad_model = get_one_model_from_s3(
             paths["gnomad"]["pca_local_path"],
             paths["gnomad"]["rfc_local_path"],
-            pca_file_key_gnomad,
-            rfc_file_key_gnomad,
+            paths["gnomad"]["pca_remote_path"],
+            paths["gnomad"]["rfc_remote_path"],
         )
         array_model = get_one_model_from_s3(
             paths["array"]["pca_local_path"],
             paths["array"]["rfc_local_path"],
-            pca_file_key_array,
-            rfc_file_key_array,
+            paths["array"]["pca_remote_path"],
+            paths["array"]["rfc_remote_path"],
         )
 
         models = AncestryModels(gnomad_model, array_model)
@@ -221,16 +221,25 @@ def _get_local_paths(assembly: str) -> dict[str, dict[str, str]]:
     pca_local_path_array = local_dir / array_pca_basename
     rfc_local_path_array = local_dir / array_rfc_basename
 
+    pca_remote_path_gnomad = f"{assembly}/{gnomad_pca_basename}"
+    rfc_remote_path_gnomad = f"{assembly}/{gnomad_rfc_basename}"
+    pca_remote_path_array = f"{assembly}/{array_pca_basename}"
+    rfc_remote_path_array = f"{assembly}/{array_rfc_basename}"
+
     return {
         "gnomad": {
             "pca_local_path": str(pca_local_path_gnomad),
             "rfc_local_path": str(rfc_local_path_gnomad),
+            "pca_remote_path": pca_remote_path_gnomad,
+            "rfc_remote_path": rfc_remote_path_gnomad,
             "pca_basename": gnomad_pca_basename,
             "rfc_basename": gnomad_rfc_basename,
         },
         "array": {
             "pca_local_path": str(pca_local_path_array),
             "rfc_local_path": str(rfc_local_path_array),
+            "pca_remote_path": pca_remote_path_array,
+            "rfc_remote_path": rfc_remote_path_array,
             "pca_basename": array_pca_basename,
             "rfc_basename": array_rfc_basename,
         },

--- a/python/python/bystro/ancestry/model.py
+++ b/python/python/bystro/ancestry/model.py
@@ -1,0 +1,185 @@
+"""Provide a worker for the ancestry model."""
+
+import logging
+from pathlib import Path
+
+import boto3  # type: ignore
+from botocore.exceptions import ClientError  # type: ignore
+import pandas as pd
+from skops.io import load as skops_load  # type: ignore
+
+from bystro.ancestry.inference import AncestryModel, AncestryModels
+
+from bystro.utils.timer import Timer
+
+logging.basicConfig(
+    filename="ancestry_model.log",
+    level=logging.DEBUG,
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger()
+
+ANCESTRY_BUCKET = "bystro-ancestry"
+GNOMAD_PCA_FILE = "gnomadset_pca.csv"
+GNOMAD_RFC_FILE = "gnomadset_rfc.skop"
+ARRAY_PCA_FILE = "arrayset_pca.csv"
+ARRAY_RFC_FILE = "arrayset_rfc.skop"
+
+models_cache: dict[str, AncestryModels] = {}
+
+
+def get_one_model_from_s3(pca_local_path, rfc_local_path, pca_file_key, rfc_file_key) -> AncestryModel:
+    """_summary_
+
+    Args:
+        pca_local_path (_type_): The local path to save the PCA file.
+        rfc_local_path (_type_): The local path to save the RFC file.
+        pca_file_key (_type_): The remove path to the PCA file.
+        rfc_file_key (_type_): The remove path to the RFC file.
+
+    Raises:
+        ValueError: If the PCA or RFC file is not found.
+
+    Returns:
+        AncestryModel: The loaded ancestry model.
+    """
+    s3_client = boto3.client("s3")
+
+    logger.info("Downloading PCA file %s", pca_file_key)
+
+    with Timer() as timer:
+        try:
+            s3_client.download_file(Bucket=ANCESTRY_BUCKET, Key=pca_file_key, Filename=pca_local_path)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                raise ValueError(f"{pca_file_key} not found. This assembly is not supported.") from e
+            raise  # Re-raise the exception if it's not a "NoSuchKey" error
+
+        try:
+            s3_client.download_file(Bucket=ANCESTRY_BUCKET, Key=rfc_file_key, Filename=rfc_local_path)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                raise ValueError(
+                    f"{rfc_file_key} ancestry model not found. This assembly is not supported."
+                ) from e
+            raise
+
+    logger.debug("Downloaded PCA file and RFC file in %f seconds", timer.elapsed_time)
+
+    return get_one_model_from_file_system(pca_local_path, rfc_local_path)
+
+
+def get_models_from_s3(assembly: str) -> AncestryModels:
+    """
+    Load the ancestry models for the given assembly from S3.
+
+    Args:
+        assembly (str): The genome assembly to load the models for.
+            Example: "hg38" or "hg19"
+
+    Returns:
+        AncestryModels: The loaded models for the given assembly.
+    """
+    if assembly in models_cache:
+        logger.info("Model for assembly %s found in cache.", assembly)
+        return models_cache[assembly]
+
+    pca_local_key_gnomad = f"{assembly}_{GNOMAD_PCA_FILE}"
+    rfc_local_key_gnomad = f"{assembly}_{GNOMAD_RFC_FILE}"
+
+    pca_file_key_gnomad = f"{assembly}/{pca_local_key_gnomad}"
+    rfc_file_key_gnomad = f"{assembly}/{rfc_local_key_gnomad}"
+
+    pca_local_key_array = f"{assembly}_{ARRAY_PCA_FILE}"
+    rfc_local_key_array = f"{assembly}_{ARRAY_RFC_FILE}"
+
+    pca_file_key_array = f"{assembly}/{pca_local_key_array}"
+    rfc_file_key_array = f"{assembly}/{rfc_local_key_array}"
+
+    gnomad_model = get_one_model_from_s3(
+        pca_local_key_gnomad, rfc_local_key_gnomad, pca_file_key_gnomad, rfc_file_key_gnomad
+    )
+    array_model = get_one_model_from_s3(
+        pca_local_key_array, rfc_local_key_array, pca_file_key_array, rfc_file_key_array
+    )
+
+    models = AncestryModels(gnomad_model, array_model)
+
+    # Update the cache with the new model
+    if len(models_cache) >= 1:
+        # Remove the oldest loaded model to maintain cache size
+        oldest_assembly = next(iter(models_cache))
+        del models_cache[oldest_assembly]
+    models_cache[assembly] = models
+
+    return models
+
+
+def get_one_model_from_file_system(pca_path: str, rfc_path: str) -> AncestryModel:
+    """
+    Load an ancestry model from the local file system.
+
+    Args:
+        pca_path (str): The path to the PCA file.
+        rfc_path (str): The path to the RFC file.
+
+    Returns:
+        AncestryModel: The loaded ancestry model.
+    """
+    with Timer() as timer:
+        logger.info("Loading PCA file %s", pca_path)
+        pca_loadings_df = pd.read_csv(pca_path, index_col=0)
+
+        logger.info("Loading RFC file %s", rfc_path)
+        rfc = skops_load(rfc_path)
+
+    logger.debug("Loaded PCA and RFC files in %f seconds", timer.elapsed_time)
+
+    return AncestryModel(pca_loadings_df, rfc)
+
+
+def get_models_from_file_system(model_dir: str, assembly: str) -> AncestryModels:
+    """
+    Load the ancestry models for the given assembly from the local file system.
+
+    Args:
+        model_dir (str): The local directory where the models are stored.
+            We expect the models to be stored in the following format:
+            ```
+            model_dir/
+                assembly/
+                    gnomadset_pca.csv
+                    gnomadset_rfc.skop
+                    arrayset_pca.csv
+                    arrayset_rfc.skop
+            ```
+        assembly (str): The genome assembly to load the models for.
+            Example: "hg38" or "hg19"
+
+    Returns:
+        AncestryModels: The loaded models for the given assembly.
+    """
+    if assembly in models_cache:
+        logger.info("Model for assembly %s found in cache.", assembly)
+        return models_cache[assembly]
+
+    pca_local_key_gnomad = str(Path(model_dir) / assembly / f"{assembly}_{GNOMAD_PCA_FILE}")
+    rfc_local_key_gnomad = str(Path(model_dir) / assembly / f"{assembly}_{GNOMAD_RFC_FILE}")
+
+    pca_local_key_array = str(Path(model_dir) / assembly / f"{assembly}_{ARRAY_PCA_FILE}")
+    rfc_local_key_array = str(Path(model_dir) / assembly / f"{assembly}_{ARRAY_RFC_FILE}")
+
+    gnomad_model = get_one_model_from_file_system(pca_local_key_gnomad, rfc_local_key_gnomad)
+    array_model = get_one_model_from_file_system(pca_local_key_array, rfc_local_key_array)
+
+    models = AncestryModels(gnomad_model, array_model)
+
+    # Update the cache with the new model
+    if len(models_cache) >= 1:
+        # Remove the oldest loaded model to maintain cache size
+        oldest_assembly = next(iter(models_cache))
+        del models_cache[oldest_assembly]
+    models_cache[assembly] = models
+
+    return models

--- a/python/python/bystro/ancestry/tests/test_ancestry_types.py
+++ b/python/python/bystro/ancestry/tests/test_ancestry_types.py
@@ -64,6 +64,7 @@ def test_expected_population_vector():
     }
     assert msgspec.structs.asdict(PopulationVector(**pop_kwargs)) == expected
 
+
 def test_ProbabilityInterval_accepts_valid_bounds() -> None:
     """Ensure we can instantiate, validate ProbabilityInterval correctly."""
     prob_int = ProbabilityInterval(lower_bound=0.1, upper_bound=0.9)
@@ -136,28 +137,28 @@ def test_AncestryScoresOneSample_accepts_valid_args() -> None:
         top_hit=AncestryTopHit(probability=0.6, populations=["SAS"]),
         populations=PopulationVector(**pop_kwargs),
         superpops=SuperpopVector(**superpop_kwargs),
-        missingness=0.5,
+        n_snps=10,
     )
-    assert type(ancestry_result.missingness) is float
+    assert type(ancestry_result.n_snps) is int
 
 
-def test_AncestryScoresOneSample_rejects_invalid_missingness() -> None:
-    with pytest.raises(TypeError, match="missingness must be between 0.0 and 1.0"):
+def test_AncestryScoresOneSample_rejects_invalid_n_snps() -> None:
+    with pytest.raises(TypeError, match="n_snps must be non-negative"):
         AncestryScoresOneSample(
             sample_id="my_sample_id",
             top_hit=AncestryTopHit(probability=0.6, populations=["SAS"]),
             populations=PopulationVector(**pop_kwargs),
             superpops=SuperpopVector(**superpop_kwargs),
-            missingness=1.1,
+            n_snps=-10,
         )
 
-    with pytest.raises(TypeError, match="missingness must be a float, not <class 'int'>"):
+    with pytest.raises(TypeError, match="n_snps must be an int, not <class 'float'>"):
         AncestryScoresOneSample(
             sample_id="my_sample_id",
             top_hit=AncestryTopHit(probability=0.6, populations=["SAS"]),
             populations=PopulationVector(**pop_kwargs),
             superpops=SuperpopVector(**superpop_kwargs),
-            missingness=int(1),
+            n_snps=float(10), # type: ignore
         )
 
 
@@ -169,21 +170,21 @@ def test_AncestryResults_accepts_valid_args() -> None:
                 top_hit=AncestryTopHit(probability=0.6, populations=["EAS"]),
                 populations=PopulationVector(**pop_kwargs),
                 superpops=SuperpopVector(**superpop_kwargs),
-                missingness=0.5,
+                n_snps=5
             ),
             AncestryScoresOneSample(
                 sample_id="bar",
                 top_hit=AncestryTopHit(probability=0.7, populations=["EUR"]),
                 populations=PopulationVector(**pop_kwargs),
                 superpops=SuperpopVector(**superpop_kwargs),
-                missingness=0.5,
+                n_snps=5
             ),
             AncestryScoresOneSample(
                 sample_id="baz",
                 top_hit=AncestryTopHit(probability=0.5, populations=["AFR", "AMR"]),
                 populations=PopulationVector(**pop_kwargs),
                 superpops=SuperpopVector(**superpop_kwargs),
-                missingness=0.5,
+                n_snps=5
             ),
         ],
         pcs={"SampleID1": [0.1, 0.2, 0.3], "SampleID2": [0.4, 0.5, 0.6], "SampleID3": [0.7, 0.8, 0.9]},
@@ -203,7 +204,7 @@ def test_AncestryResults_rejects_invalid_pcs() -> None:
                     top_hit=AncestryTopHit(probability=0.6, populations=["EAS"]),
                     populations=PopulationVector(**pop_kwargs),
                     superpops=SuperpopVector(**superpop_kwargs),
-                    missingness=0.5,
+                    n_snps=0,
                 ),
             ],
             pcs=({"SampleID1": [0.1]}, {"SampleID2": [0.4]}, {"SampleID3": [0.7]}),  # type: ignore

--- a/python/python/bystro/ancestry/tests/test_inference.py
+++ b/python/python/bystro/ancestry/tests/test_inference.py
@@ -10,7 +10,7 @@ import pyarrow.dataset as ds  # type: ignore
 
 from bystro.ancestry.inference import AncestryModel, AncestryModels, infer_ancestry
 from bystro.ancestry.train import POPS
-from bystro.ancestry.listener import _get_models_from_s3
+from bystro.ancestry.model import get_models_from_s3
 
 SAMPLES = [f"sample{i}" for i in range(len(POPS))]
 VARIANTS = ["variant1", "variant2", "variant3"]
@@ -84,7 +84,7 @@ def test_infer_ancestry():
 
 @pytest.mark.integration()
 def test_infer_ancestry_from_model():
-    ancestry_models = _get_models_from_s3("hg38")
+    ancestry_models = get_models_from_s3("hg38")
 
     # Generate an arrow table that contains genotype dosages for 1000 samples
     variants = list(ancestry_models.gnomad_model.pca_loadings_df.index)

--- a/python/python/bystro/ancestry/tests/test_inference.py
+++ b/python/python/bystro/ancestry/tests/test_inference.py
@@ -95,10 +95,10 @@ def test_infer_ancestry_from_model():
         columns=samples,  # noqa: NPY002
     )
     # randomly set 10% of the genotypes to missing to ensure we test missing data handling
-    genotypes = genotypes.mask(np.random.random(genotypes.shape) < 0.1)
-
-    # get missingness per sample
-    missingness = genotypes.isna().mean(axis=0)
+    drop_snps_n = int(0.1 * len(genotypes))
+    retained_snps_n = len(genotypes) - drop_snps_n
+    drop_indices = np.random.choice(genotypes.index, size=drop_snps_n, replace=False) # noqa: NPY002
+    genotypes = genotypes.drop(list(drop_indices))
 
     genotypes = genotypes.reset_index()
     genotypes = genotypes.rename(columns={"index": "locus"})
@@ -119,7 +119,7 @@ def test_infer_ancestry_from_model():
 
         samples_seen.add(result.sample_id)
 
-        assert result.missingness == missingness[result.sample_id]
+        assert result.n_snps == retained_snps_n
 
     assert samples_seen == sample_set
     assert len(top_hits) > 1

--- a/python/python/bystro/ancestry/tests/test_listener.py
+++ b/python/python/bystro/ancestry/tests/test_listener.py
@@ -9,8 +9,8 @@ from bystro.ancestry.listener import (
     SubmittedJobMessage,
     AncestryJobCompleteMessage,
     AncestryResults,
-    AncestryModels,
 )
+from bystro.ancestry.inference import AncestryModels
 from bystro.ancestry.tests.test_inference import (
     ANCESTRY_MODEL,
     FAKE_GENOTYPES,
@@ -35,7 +35,7 @@ def test_submit_fn():
 
 def test_handler_fn_happy_path(mocker, tmpdir):
     mocker.patch(
-        "bystro.ancestry.listener._get_models_from_s3",
+        "bystro.ancestry.listener.get_models_from_s3",
         return_value=AncestryModels(ANCESTRY_MODEL, ANCESTRY_MODEL),
     )
     dosage_path = "some_dosage.feather"

--- a/python/python/bystro/api/ancestry.py
+++ b/python/python/bystro/api/ancestry.py
@@ -41,7 +41,7 @@ def calculate_ancestry_scores(
         path_out_dir = Path(out_dir)
         path_out_dir.mkdir(parents=True, exist_ok=True)
 
-    if dosage is None:
+    if not dosage:
         dosage_matrix_path = tempfile.mktemp(suffix=".feather")
     else:
         if path_out_dir is None:
@@ -66,7 +66,7 @@ def calculate_ancestry_scores(
     json_data = msgspec.json.encode(results)
 
     if path_out_dir is not None:
-        with open(str(path_out_dir / "ancestry_results.json"), "wb") as f:
-            f.write(json_data)
+        with open(str(path_out_dir / "ancestry_results.json"), "w") as f:
+            f.write(str(json_data, "utf-8"))
 
     return results

--- a/python/python/bystro/api/ancestry.py
+++ b/python/python/bystro/api/ancestry.py
@@ -1,0 +1,72 @@
+from os import system
+from pathlib import Path
+import tempfile
+
+import msgspec
+from pyarrow import dataset as ds  # type: ignore
+
+from bystro.utils.compress import get_decompress_to_pipe_cmd
+from bystro.ancestry.model import get_models_from_file_system
+from bystro.ancestry.inference import AncestryResults, infer_ancestry
+
+
+# Data is located in bystro/ancestry/data, relative to this script it is ../bystr/ancestry/data
+# get that location from this script's path
+DATA_DIR = str(Path(__file__).parent.parent / "ancestry" / "data")
+
+
+def calculate_ancestry_scores(
+    vcf: str, assembly: str, dosage: bool = False, out_dir: str | None = None
+) -> AncestryResults:
+    """Calculate ancestry scores from a VCF file and write the results to a file.
+
+    Args:
+        vcf (str): The input VCF file path
+        assembly (str): The assembly version (hg19 or hg38)
+        out_dir (str, optional): If not provided, the results are not written to a file.
+                                 Defaults to None.
+        dosage (bool, optional):
+            Whether or not to write the dosage matrix output to the output directory.
+            If no `out_dir` is not provided, this option cannot be True. Defaults to False.
+
+    Raises:
+        RuntimeError: If the bystro-vcf command fails
+        ValueError: If `dosage` is True and `out_dir` is not provided
+
+    Returns:
+        AncestryResults: The ancestry results
+    """
+    path_out_dir = None
+    if out_dir is not None:
+        path_out_dir = Path(out_dir)
+        path_out_dir.mkdir(parents=True, exist_ok=True)
+
+    if dosage is None:
+        dosage_matrix_path = tempfile.mktemp(suffix=".feather")
+    else:
+        if path_out_dir is None:
+            raise ValueError("If `dosage` is True, `out_dir` must be provided")
+        dosage_matrix_path = str(path_out_dir / "dosage_matrix.feather")
+
+    # Input command
+    bystro_vcf_command = f"bystro-vcf --noOut --dosageOutput {dosage_matrix_path}"
+    cmd = get_decompress_to_pipe_cmd(vcf, bystro_vcf_command)
+    res = system(cmd)
+    if res != 0:
+        raise RuntimeError(f"Failed to run bystro-vcf command: {cmd}")
+
+    # Ancestry command
+    dataset = ds.dataset(dosage_matrix_path, format="arrow")
+
+    ancestry_models = get_models_from_file_system(DATA_DIR, assembly)
+
+    results = infer_ancestry(ancestry_models, dataset)
+
+    # Write results to output file
+    json_data = msgspec.json.encode(results)
+
+    if path_out_dir is not None:
+        with open(str(path_out_dir / "ancestry_results.json"), "wb") as f:
+            f.write(json_data)
+
+    return results

--- a/python/python/bystro/api/auth.py
+++ b/python/python/bystro/api/auth.py
@@ -12,7 +12,6 @@ CREDENTIALS_PATH = os.path.join(DEFAULT_DIR, STATE_FILE)
 
 if not os.path.exists(DEFAULT_DIR):
     os.makedirs(DEFAULT_DIR, exist_ok=True)
-    print(f"Created default credentials path: {CREDENTIALS_PATH}")
 
 
 class SignupResponse(Struct):

--- a/python/python/bystro/cli/ancestry.py
+++ b/python/python/bystro/cli/ancestry.py
@@ -1,0 +1,98 @@
+import argparse
+import io
+
+import msgspec
+
+from bystro.api.ancestry import calculate_ancestry_scores
+
+
+def add_ancestry_subparser(subparsers):
+    parser = subparsers.add_parser(
+        "ancestry",
+        help="Ancestry analysis fun",
+    )
+
+    ancestry_subparser = parser.add_subparsers(
+        title="commands", dest="command", help="Commands for ancestry analysis"
+    )
+
+    def ancestry_default_help(_args):
+        buffer = io.StringIO()
+        parser.print_help(file=buffer)
+        help_message = buffer.getvalue()
+        custom_message = "Process VCF files with bystro-vcf and perform ancestry analysis.\n\n"
+        insertion_point = help_message.find("options:")
+        if insertion_point != -1:
+            help_message = (
+                help_message[:insertion_point] + custom_message + help_message[insertion_point:]
+            )
+        else:
+            help_message = custom_message + help_message
+        print(help_message)
+        parser.exit()
+
+    parser.set_defaults(func=ancestry_default_help)
+
+    ancestry_score_parser = ancestry_subparser.add_parser(
+        "score",
+        help=(
+            "Using a vcf file, calculate the ancestry scores of the samples in the vcf file "
+            "using the best-fitting ancestry model for the given assembly version."
+        ),
+    )
+
+    ancestry_score_parser.add_argument(
+        "--in", dest="input_vcf", type=str, required=True, help="The input VCF file"
+    )
+    ancestry_score_parser.add_argument(
+        "--assembly",
+        type=str,
+        required=True,
+        choices=["hg19", "hg38"],
+        help="The assembly version (hg19 or hg38)",
+    )
+    ancestry_score_parser.add_argument(
+        "--out-dir",
+        type=str,
+        default=None,
+        help=(
+            "The output directory for the ancestry results. "
+            "If blank, the results are written to stdout. (optional)"
+        ),
+    )
+    ancestry_score_parser.add_argument(
+        "--dosage",
+        action="store_true",
+        help="Whether or not to write the dosage matrix output to the output directory (optional)",
+    )
+
+    ancestry_score_parser.set_defaults(func=_calculate_and_write_ancestry_scores)
+
+
+def _calculate_and_write_ancestry_scores(args: argparse.Namespace):
+    """Calculate ancestry scores from a VCF file and write the results to a file.
+
+    Args:
+        args (argparse.Namespace): The parsed arguments from the command line.
+         Arguments expected:
+            - assembly: str
+                The assembly version (hg19 or hg38)
+            - input_vcf: str
+                The input VCF file
+            - out: str | None
+                The output directory for the ancestry results.
+                If not provided, the results are written to stdout.
+            - dosage: bool
+                Whether or not to write the dosage matrix output to the output directory.
+
+    Returns:
+        None
+    """
+    res = calculate_ancestry_scores(
+        vcf=args.input_vcf, assembly=args.assembly, dosage=args.dosage, out_dir=args.out_dir
+    )
+
+    if args.out_dir is None:
+        json_data = msgspec.json.encode(res)
+
+        print(json_data)

--- a/python/python/bystro/cli/ancestry.py
+++ b/python/python/bystro/cli/ancestry.py
@@ -62,6 +62,7 @@ def add_ancestry_subparser(subparsers):
     )
     ancestry_score_parser.add_argument(
         "--dosage",
+        default=False,
         action="store_true",
         help="Whether or not to write the dosage matrix output to the output directory (optional)",
     )
@@ -95,4 +96,7 @@ def _calculate_and_write_ancestry_scores(args: argparse.Namespace):
     if args.out_dir is None:
         json_data = msgspec.json.encode(res)
 
-        print(json_data)
+        print(str(json_data, "utf-8"))
+
+    else:
+        print(f"Ancestry results written to {args.out_dir}")

--- a/python/python/bystro/cli/cli.py
+++ b/python/python/bystro/cli/cli.py
@@ -6,6 +6,7 @@ from bystro.api.annotation import get_jobs, create_jobs, query, JobBasicResponse
 
 from bystro.cli.proteomics_cli import add_proteomics_subparser
 
+from bystro.cli.ancestry import add_ancestry_subparser
 
 def signup_cli(args: argparse.Namespace, print_result=True) -> CachedAuth:
     """
@@ -273,6 +274,7 @@ def main():
     query_parser.add_argument("--job_id", required=True, type=str, help="The job id to query")
     query_parser.set_defaults(func=query_cli)
     add_proteomics_subparser(subparsers)
+    add_ancestry_subparser(subparsers)
 
     args = parser.parse_args()
     if hasattr(args, "func"):

--- a/python/python/bystro/search/index/listener.py
+++ b/python/python/bystro/search/index/listener.py
@@ -91,8 +91,10 @@ def run_handler_with_config(
         opensearch_config (str): The path to the OpenSearch configuration file.
         annotation_path (str): The path to the annotation file.
         no_queue (bool, optional): Whether to disable the queue. Defaults to False.
-        submission_id (SubmissionID | None, optional): The submission ID. Required when no_queue is not False. Defaults to None.
-        queue_config (str | None, optional): The path to the queue configuration file. Required when no_queue is not False. Defaults to None.
+        submission_id (SubmissionID | None, optional):
+            The submission ID. Required when no_queue is not False (optional).
+        queue_config (str | None, optional):
+            The path to the queue configuration file. Required when no_queue is not False (optional).
 
     Returns:
         list[str]: The header fields.

--- a/python/python/bystro/utils/compress.py
+++ b/python/python/bystro/utils/compress.py
@@ -31,7 +31,20 @@ IS_GZIP = GZIP_EXECUTABLE.endswith("gzip")
 IS_BGZIP = GZIP_EXECUTABLE.endswith("bgzip")
 
 
-def get_compress_from_pipe_cmd(out: str, pipe_from_cmd: str = None, pipe_to_cmd: str = None) -> str:
+def get_compress_from_pipe_cmd(
+    out: str, pipe_from_cmd: str | None = None, pipe_to_cmd: str | None = None
+) -> str:
+    """
+    Generate a command string for compressing data from a pipe.
+
+    Args:
+        out (str): The output path for the compressed data.
+        pipe_from_cmd (str | None, optional): The command to pipe data from. Defaults to None.
+        pipe_to_cmd (str | None, optional): The command to pipe data to. Defaults to None.
+
+    Returns:
+        str: The command string for compressing data from a pipe.
+    """
     cmd = None
     if (IS_PIGZ or IS_BGZIP or IS_GZIP) and not out.endswith(".gz"):
         raise ValueError("Output path must end with .gz")
@@ -52,14 +65,24 @@ def get_compress_from_pipe_cmd(out: str, pipe_from_cmd: str = None, pipe_to_cmd:
     return f"{cmd} > {out}"
 
 
-def get_decompress_to_pipe_cmd(input_path: str, pipe_to_cmd: str = None) -> str:
+def get_decompress_to_pipe_cmd(input_path: str, pipe_to_cmd: str | None = None) -> str:
+    """
+    Generate a command for decompressing a file to a pipe.
+
+    Args:
+        input_path (str): The path to the input file.
+        pipe_to_cmd (str, optional): The command to pipe the decompressed output to. Defaults to None.
+
+    Returns:
+        str: The command for decompressing the file to a pipe.
+    """
+
     cmd = None
-    if IS_PIGZ:
-        # pigz doesn't benefit much from more than 2 threads during decompression
-        cmd = f"{GZIP_EXECUTABLE} -d -c {input_path} -p 2"
-    elif IS_BGZIP:
+   
+    if IS_BGZIP:
         cmd = f"{GZIP_EXECUTABLE} -d -c {input_path} --threads {NUM_CPUS}"
     else:
+        # pigz decompression is multithreaded by default
         cmd = f"{GZIP_EXECUTABLE} -d -c {input_path}"
 
     if pipe_to_cmd:

--- a/python/python/bystro/utils/compress.py
+++ b/python/python/bystro/utils/compress.py
@@ -31,24 +31,38 @@ IS_GZIP = GZIP_EXECUTABLE.endswith("gzip")
 IS_BGZIP = GZIP_EXECUTABLE.endswith("bgzip")
 
 
-def get_compress_from_pipe_cmd(out: str) -> str:
+def get_compress_from_pipe_cmd(out: str, pipe_from_cmd: str = None, pipe_to_cmd: str = None) -> str:
+    cmd = None
     if (IS_PIGZ or IS_BGZIP or IS_GZIP) and not out.endswith(".gz"):
         raise ValueError("Output path must end with .gz")
 
     if IS_PIGZ:
-        return f"{GZIP_EXECUTABLE} -c -p {NUM_CPUS} > {out}"
+        cmd = f"{GZIP_EXECUTABLE} -c -p {NUM_CPUS}"
+    elif IS_BGZIP:
+        cmd = f"{GZIP_EXECUTABLE} -c --index --index-name {out}.gzi --threads {NUM_CPUS}"
+    else:
+        cmd = f"{GZIP_EXECUTABLE} -c"
 
-    if IS_BGZIP:
-        return f"{GZIP_EXECUTABLE} -c --index --index-name {out}.gzi --threads {NUM_CPUS} > {out}"
+    if pipe_from_cmd:
+        cmd = f"{pipe_from_cmd} | {cmd}"
 
-    return f"{GZIP_EXECUTABLE} -c > {out}"
+    if pipe_to_cmd:
+        cmd = f"{cmd} | {pipe_to_cmd}"
+
+    return f"{cmd} > {out}"
 
 
-def get_decompress_to_pipe_cmd(input_path: str) -> str:
+def get_decompress_to_pipe_cmd(input_path: str, pipe_to_cmd: str = None) -> str:
+    cmd = None
     if IS_PIGZ:
         # pigz doesn't benefit much from more than 2 threads during decompression
-        return f"{GZIP_EXECUTABLE} -d -c {input_path} -p 2"
-    if IS_BGZIP:
-        return f"{GZIP_EXECUTABLE} -d -c {input_path} --threads {NUM_CPUS}"
+        cmd = f"{GZIP_EXECUTABLE} -d -c {input_path} -p 2"
+    elif IS_BGZIP:
+        cmd = f"{GZIP_EXECUTABLE} -d -c {input_path} --threads {NUM_CPUS}"
+    else:
+        cmd = f"{GZIP_EXECUTABLE} -d -c {input_path}"
 
-    return f"{GZIP_EXECUTABLE} -d -c {input_path}"
+    if pipe_to_cmd:
+        cmd = f"{cmd} | {pipe_to_cmd}"
+
+    return cmd

--- a/python/python/bystro/utils/tests/test_compress.py
+++ b/python/python/bystro/utils/tests/test_compress.py
@@ -70,7 +70,7 @@ def test_get_compress_from_pipe_cmd(
     "executable, is_pigz, is_bgzip, is_gzip, expected_cmd",
     [
         ("/usr/bin/bgzip", False, True, False, f"/usr/bin/bgzip -d -c input.gz --threads {NUM_CPUS}"),
-        ("/usr/bin/pigz", True, False, False, "/usr/bin/pigz -d -c input.gz -p 2"),
+        ("/usr/bin/pigz", True, False, False, "/usr/bin/pigz -d -c input.gz"),
         ("/usr/bin/gzip", False, False, True, "/usr/bin/gzip -d -c input.gz"),
     ],
 )


### PR DESCRIPTION
* Adds docker file for Bystro's python library
* Creates ancestry api and cli code for calculating ancestry scores
* Removes unneeded dependencies from Cargo.toml, to speed up builds
* Improves Makefile by introducing the ability to make production builds and install from wheel.
* Reduce ancestry memory usage by reading in sample chunks
* Cache ancestry scores to local disk to reduce S3 fetching

To test what is here:

```
docker pull akotlar/bystro-api
docker run -v /path/to/local/data:/data  akotlar/bystro-api ancestry score --in /data/trio.trim.vep.vcf.gz --assembly hg19 
```

[trio.trim.vep.vcf.gz](https://github.com/bystrogenomics/bystro/files/14730266/trio.trim.vep.vcf.gz)

The api function is a port of ancestry/listener.py handler_fn.