### PR TITLE
[search] Switch to half_float for cadd, caddIndel, and remove phyloP, phastCons

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -411,8 +411,7 @@ mappings:
             dist:
               type: integer
     cadd:
-      type: scaled_float
-      scaling_factor: 10
+      type: half_float
     caddIndel:
       properties:
         alt:
@@ -422,14 +421,7 @@ mappings:
           type: keyword
           normalizer: lowercase_normalizer
         PHRED:
-          type: scaled_float
-          scaling_factor: 10
-    phastCons:
-      type: scaled_float
-      scaling_factor: 100
-    phyloP:
-      type: scaled_float
-      scaling_factor: 100
+          type: half_float
     clinvarVcf:
       properties:
         alt:

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -411,8 +411,7 @@ mappings:
             dist:
               type: integer
     cadd:
-      type: scaled_float
-      scaling_factor: 10
+      type: half_float
     caddIndel:
       properties:
         alt:
@@ -422,14 +421,7 @@ mappings:
           type: keyword
           normalizer: lowercase_normalizer
         PHRED:
-          type: scaled_float
-          scaling_factor: 10
-    phastCons:
-      type: scaled_float
-      scaling_factor: 100
-    phyloP:
-      type: scaled_float
-      scaling_factor: 100
+          type: half_float
     clinvarVcf:
       properties:
         alt:


### PR DESCRIPTION
* Remove phasCons, phyla which are no longer used
* Switch cadd and caddIndel.PHRED to half_float. In practice this very slightly increases index size (e.g. on 6 million sites 10.7GB vs 10.69GB), but speeds up indexing and gains us precision (vs scaled flat with factor 10, 25 minutes vs 24 minutes, 4%).