### PR TITLE
Support empty dosage matrix outputs; this may occur if combining genotype-free files

### DIFF
--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -6,7 +6,7 @@ ENV GOBIN=/app/bin
 
 # Install the specific versions of the Go programs
 RUN go install github.com/akotlar/bystro-stats@1.0.0
-RUN go install github.com/bystrogenomics/bystro-vcf@2.1.1
+RUN go install github.com/bystrogenomics/bystro-vcf@2.1.2;
 RUN go install github.com/akotlar/bystro-snp@1.0.0
 RUN go install github.com/mikefarah/yq@2.4.1
 

--- a/install/install-go-packages.sh
+++ b/install/install-go-packages.sh
@@ -8,7 +8,7 @@ go mod init bystro
 
 go install github.com/akotlar/bystro-stats@1.0.0;
 
-go install github.com/bystrogenomics/bystro-vcf@2.1.1;
+go install github.com/bystrogenomics/bystro-vcf@2.1.2;
 
 go install github.com/akotlar/bystro-snp@1.0.0;
 

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -6,7 +6,7 @@ ENV GOBIN=/app/bin
 
 # Install the specific versions of the Go programs
 RUN go install github.com/akotlar/bystro-stats@1.0.0
-RUN go install github.com/bystrogenomics/bystro-vcf@2.1.1
+RUN go install github.com/bystrogenomics/bystro-vcf@2.1.2
 RUN go install github.com/akotlar/bystro-snp@1.0.0
 RUN go install github.com/mikefarah/yq@2.4.1
 

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -523,31 +523,54 @@ sub annotateFile {
     if (@dosageMatrixOutPaths) {
       $self->log( "info", "Combining dosage matrix outputs" );
 
+      # Find all non-empty dosageMatrixOutPaths, by stat-ing them
+      my @nonEmptyDosageMatrixOutPaths;
+      for my $dosageMatrixOutPath (@dosageMatrixOutPaths) {
+        if ( -s $dosageMatrixOutPath ) {
+          push @nonEmptyDosageMatrixOutPaths, $dosageMatrixOutPath;
+        }
+      }
+
       my $finalOutPath =
         $self->_workingDir->child( $self->outputFilesInfo->{dosageMatrixOutPath} );
 
-      my $err = $self->safeSystem(
-        'dosage --output ' . $finalOutPath . " " . join( " ", @dosageMatrixOutPaths ) );
+      if ( !@nonEmptyDosageMatrixOutPaths ) {
+        $self->log( "warn", "No non-empty dosage matrix outputs found" );
 
-      if ($err) {
-        my $humanErr = "Failed to combine dosage matrix outputs";
-        $self->_errorWithCleanup($humanErr);
-        return ( $humanErr, undef );
-      }
-
-      # Remove the intermediate dosageMatrixOutPaths
-      for my $dosageMatrixOutPath (@dosageMatrixOutPaths) {
-        $err = $self->safeSystem("rm $dosageMatrixOutPath");
+        # Create an empty file in the final dosageMatrixOutPath destination
+        $err = $self->safeSystem("touch $finalOutPath");
 
         if ($err) {
-          my $humanErr = "Failed to remove intermediate dosage matrix files";
+          my $humanErr = "Failed to create empty dosage matrix output file";
           $self->_errorWithCleanup($humanErr);
           return ( $humanErr, undef );
         }
       }
+      else {
+        my $err =
+          $self->safeSystem( 'dosage --output '
+            . $finalOutPath . " "
+            . join( " ", @nonEmptyDosageMatrixOutPaths ) );
 
-      $self->log( "info", "Finished combining dosage matrix outputs" );
+        if ($err) {
+          my $humanErr = "Failed to combine dosage matrix outputs";
+          $self->_errorWithCleanup($humanErr);
+          return ( $humanErr, undef );
+        }
 
+        # Remove the intermediate dosageMatrixOutPaths
+        for my $dosageMatrixOutPath (@dosageMatrixOutPaths) {
+          $err = $self->safeSystem("rm $dosageMatrixOutPath");
+
+          if ($err) {
+            my $humanErr = "Failed to remove intermediate dosage matrix files";
+            $self->_errorWithCleanup($humanErr);
+            return ( $humanErr, undef );
+          }
+        }
+
+        $self->log( "info", "Finished combining dosage matrix outputs" );
+      }
     }
   }
 

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -535,7 +535,8 @@ sub annotateFile {
         $self->_workingDir->child( $self->outputFilesInfo->{dosageMatrixOutPath} );
 
       if ( @nonEmptyDosageMatrixOutPaths != @dosageMatrixOutPaths ) {
-        $self->log( "warn", "Some empty dosage matrix outputs found. Combining non-empty files" );
+        $self->log( "warn",
+          "Some empty dosage matrix outputs found. Combining non-empty files" );
       }
 
       if ( !@nonEmptyDosageMatrixOutPaths ) {

--- a/perl/lib/Seq.pm
+++ b/perl/lib/Seq.pm
@@ -534,6 +534,10 @@ sub annotateFile {
       my $finalOutPath =
         $self->_workingDir->child( $self->outputFilesInfo->{dosageMatrixOutPath} );
 
+      if ( @nonEmptyDosageMatrixOutPaths != @dosageMatrixOutPaths ) {
+        $self->log( "warn", "Some empty dosage matrix outputs found. Combining non-empty files" );
+      }
+
       if ( !@nonEmptyDosageMatrixOutPaths ) {
         $self->log( "warn", "No non-empty dosage matrix outputs found" );
 


### PR DESCRIPTION
This aims to prevent crashing when combining genotype-free files. I also don't prevent combining runs that have genotypes and those that don't. For now this feels safer and a tremendous edge case. We will likely disallow that in a followup PR.