### PR TITLE
[annotator] Improve configuration filees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,15 +4,4 @@ t/tracks/nearest/db/hg19/index
 t/utils/filterCadd.yml
 t/utils/index/
 *lock.mdb
-config/hg19.yml
-config/hg38.yml
-config/rheMac8.yml
-config/sacCer3.yml
-config/mm10.yml
-config/mm9.yml
-config/dm6.yml
-config/dm3.yml
-config/danRer10.yml
-config/ce11.yml
-config/ensembl.yml
 .coverage*

--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -11,6 +11,7 @@ index_settings:
     refresh_interval: -1
     number_of_replicas: 0
     codec: best_compression
+    max_slices_per_pit: 50000
     mapping:
       total_fields:
         limit: 5000

--- a/config/hg19.yml
+++ b/config/hg19.yml
@@ -47,7 +47,7 @@ statistics:
   programPath: bystro-stats
   refTrackField: ref
   siteTypeField: refSeq.siteType
-temp_dir: /mnt/annotator/tmp
+temp_dir: null
 tracks:
   outputOrder:
     - ref

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -11,6 +11,7 @@ index_settings:
     refresh_interval: -1
     number_of_replicas: 0
     codec: best_compression
+    max_slices_per_pit: 50000
     mapping:
       total_fields:
         limit: 5000

--- a/config/hg38.yml
+++ b/config/hg38.yml
@@ -36,7 +36,7 @@ fileProcessors:
   vcf:
     args: --emptyField NA --sample %sampleList% --keepPos --keepId --dosageOutput %dosageMatrixOutPath%
     program: bystro-vcf
-files_dir: /mnt/files1/bystro_annotator/raw_files/hg38
+files_dir: null
 statistics:
   dbSNPnameField: dbSNP.name
   exonicAlleleFunctionField: refSeq.exonicAlleleFunction
@@ -47,7 +47,7 @@ statistics:
   programPath: bystro-stats
   refTrackField: ref
   siteTypeField: refSeq.siteType
-temp_dir: /mnt/annotator/tmp
+temp_dir: null
 tracks:
   outputOrder:
     - ref
@@ -615,7 +615,6 @@ tracks:
     - build_author: alexkotlar
       build_date: 2024-03-11T12:24:00
       build_field_transformations:
-        CLNDISDB: split [|]
         CLNDN: split [|]
         CLNSIGCONF: split [|]
         CLNSIGINC: split [|]


### PR DESCRIPTION
* Rename hg38.clean.yml -> hg38.yml and hg19.clean.yml -> hg19.yml, to simplify deployment (which relies on hg38/hg19.yml)
* Remove tmp_dir by default. Doing so allows us to scale to much larger datasets by writing to EFS directly. EFS is fast enough and we only write in a sequential manner, which works well from a throughput standpoint
* Add max_slices_per_pit that is above the default (100) for the cluster, to solve saving large jobs (which otherwise crash)