### PR TITLE
Bugfix marginal likelihood supervision + SVAE

### DIFF
--- a/python/python/bystro/supervised_ppca/_base.py
+++ b/python/python/bystro/supervised_ppca/_base.py
@@ -100,44 +100,44 @@ def _get_projection_matrix(W_: Tensor, sigma_: Tensor, device: Any):
     Cov = torch.linalg.inv(M) * sigma_
     return Proj_X, Cov
 
+
 def kl_divergence_vae(
     mu1: torch.Tensor,
     sigma1: torch.Tensor,
 ) -> torch.Tensor:
     """
-    Computes the Kullback-Leibler divergence between two multivariate 
+    Computes the Kullback-Leibler divergence between two multivariate
     normal distributions.
-    
-    This function assumes the first distribution, N(mu1, sigma1), 
-    represents the conditional distribution of latent variables given 
-    observations (approximate posterior), and the second distribution 
-    is the standard multivariate normal distribution N(0, I) representing 
+
+    This function assumes the first distribution, N(mu1, sigma1),
+    represents the conditional distribution of latent variables given
+    observations (approximate posterior), and the second distribution
+    is the standard multivariate normal distribution N(0, I) representing
     the marginal latent distribution (prior).
 
     The KL divergence is computed using the formula:
-    KL(N(mu1, sigma1) || N(0, I)) = 0.5 * (tr(sigma1) + 
+    KL(N(mu1, sigma1) || N(0, I)) = 0.5 * (tr(sigma1) +
                             mu1^T * mu1 - log(det(sigma1)) - d)
     where `d` is the dimensionality of the latent space.
 
     Parameters:
-    - mu1 (torch.Tensor): Mean vector of the first Gaussian 
+    - mu1 (torch.Tensor): Mean vector of the first Gaussian
       distribution (approximate posterior), shape (batch_size, d).
-    - sigma1 (torch.Tensor): Covariance matrix of the first Gaussian 
-      distribution (approximate posterior), expected to be a diagonal 
+    - sigma1 (torch.Tensor): Covariance matrix of the first Gaussian
+      distribution (approximate posterior), expected to be a diagonal
       matrix represented as a tensor of shape (batch_size, d).
 
     Returns:
-    - torch.Tensor: A tensor containing the KL divergence for each 
+    - torch.Tensor: A tensor containing the KL divergence for each
       instance in the batch, shape (batch_size,).
     """
     d = sigma1.shape[1]  # Dimensionality of the latent space
-    term1 = -1 * torch.logdet(sigma1)  # Log determinant 
+    term1 = -1 * torch.logdet(sigma1)  # Log determinant
     term2 = -d  # Negative of the latent space dimensionality
     term3 = torch.trace(sigma1)  # Trace of the covariance matrix
-    term4 = torch.sum(torch.square(mu1), dim=1)  # Sum of squares 
+    term4 = torch.sum(torch.square(mu1), dim=1)  # Sum of squares
     kl_div = 0.5 * (term1 + term2 + term3 + term4)
     return kl_div
-
 
 
 class BaseGaussianFactorModel(BaseSGDModel, ABC):

--- a/python/python/bystro/supervised_ppca/_base.py
+++ b/python/python/bystro/supervised_ppca/_base.py
@@ -100,6 +100,45 @@ def _get_projection_matrix(W_: Tensor, sigma_: Tensor, device: Any):
     Cov = torch.linalg.inv(M) * sigma_
     return Proj_X, Cov
 
+def kl_divergence_vae(
+    mu1: torch.Tensor,
+    sigma1: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Computes the Kullback-Leibler divergence between two multivariate 
+    normal distributions.
+    
+    This function assumes the first distribution, N(mu1, sigma1), 
+    represents the conditional distribution of latent variables given 
+    observations (approximate posterior), and the second distribution 
+    is the standard multivariate normal distribution N(0, I) representing 
+    the marginal latent distribution (prior).
+
+    The KL divergence is computed using the formula:
+    KL(N(mu1, sigma1) || N(0, I)) = 0.5 * (tr(sigma1) + 
+                            mu1^T * mu1 - log(det(sigma1)) - d)
+    where `d` is the dimensionality of the latent space.
+
+    Parameters:
+    - mu1 (torch.Tensor): Mean vector of the first Gaussian 
+      distribution (approximate posterior), shape (batch_size, d).
+    - sigma1 (torch.Tensor): Covariance matrix of the first Gaussian 
+      distribution (approximate posterior), expected to be a diagonal 
+      matrix represented as a tensor of shape (batch_size, d).
+
+    Returns:
+    - torch.Tensor: A tensor containing the KL divergence for each 
+      instance in the batch, shape (batch_size,).
+    """
+    d = sigma1.shape[1]  # Dimensionality of the latent space
+    term1 = -1 * torch.logdet(sigma1)  # Log determinant 
+    term2 = -d  # Negative of the latent space dimensionality
+    term3 = torch.trace(sigma1)  # Trace of the covariance matrix
+    term4 = torch.sum(torch.square(mu1), dim=1)  # Sum of squares 
+    kl_div = 0.5 * (term1 + term2 + term3 + term4)
+    return kl_div
+
+
 
 class BaseGaussianFactorModel(BaseSGDModel, ABC):
     def __init__(self, n_components=2):

--- a/python/python/bystro/supervised_ppca/gf_comparisons.py
+++ b/python/python/bystro/supervised_ppca/gf_comparisons.py
@@ -44,10 +44,11 @@ from sklearn.linear_model import LogisticRegression, Ridge
 import sklearn.decomposition as dp
 
 from bystro.supervised_ppca.gf_generative_pt import PPCA
-from bystro.supervised_ppca._base import _get_projection_matrix,kl_divergence_vae
+from bystro.supervised_ppca._base import (
+    _get_projection_matrix,
+    kl_divergence_vae,
+)
 from bystro.supervised_ppca._misc_np import softplus_inverse_np
-
-from torch.nn.utils import clip_grad_value_
 
 
 def kl_divergence_gaussian(

--- a/python/python/bystro/supervised_ppca/gf_marginal.py
+++ b/python/python/bystro/supervised_ppca/gf_marginal.py
@@ -11,7 +11,48 @@ from bystro.supervised_ppca.gf_generative_pt import PPCA
 from bystro.supervised_ppca._base import _get_projection_matrix
 
 
-class PPCAMarginal(PPCA):
+class BaseMarginal(PPCA):
+
+    def _test_inputs(  # type: ignore[override]
+        self,
+        X: NDArray[np.float_],
+        idx_list: List[NDArray[np.bool_]],
+        lamb: Optional[NDArray[np.float_]],
+    ) -> None:
+        """
+        Validate the input parameters.
+
+        Parameters
+        ----------
+        X : NDArray[np.float_]
+            The input data array.
+        idx_list : List[NDArray[np.bool_]]
+            List of boolean arrays indicating observed dimensions.
+        lamb : Optional[NDArray[np.float_]]
+            Array of regularization parameters for each group.
+
+        Raises
+        ------
+        ValueError
+            If input parameters are invalid, such as mismatched dimensions.
+        """
+        if not isinstance(X, np.ndarray):
+            raise ValueError("Data must be numpy array")
+        if self.training_options["batch_size"] > X.shape[0]:
+            raise ValueError("Batch size exceeds number of samples")
+        for idx_array in idx_list:
+            if idx_array.dtype != np.bool_:
+                raise ValueError(
+                    "idx_list must be a list of NumPy boolean arrays"
+                )
+        if lamb is not None and not isinstance(lamb, np.ndarray):
+            raise ValueError("lamb must be a NumPy array if it's not None")
+        if lamb is not None and len(lamb) != len(idx_list):
+            raise ValueError(
+                "Mismatch in lamb length and number of groups in idx_list"
+            )
+
+class PPCAMarginal(BaseMarginal):
     """
     Probabilistic Principal Component Analysis (PPCA) with marginal
     supervision.
@@ -53,6 +94,7 @@ class PPCAMarginal(PPCA):
             prior_options=prior_options,
             training_options=training_options,
         )
+        self.losses_pred = np.zeros(self.training_options["n_iterations"])
         self._initialize_save_losses()
 
     # override needed for mypy to ignore the non-optional `y` argument
@@ -158,14 +200,16 @@ class PPCAMarginal(PPCA):
                 m = MultivariateNormal(z_vecs[k], Sigma_marg)
                 like_gens.append(torch.mean(m.log_prob(X_o)))
 
-                P_x, Sigma_pred = _get_projection_matrix(
-                    W_[:, idxs[k]], sigma, device
-                )
-                mean_z = torch.matmul(X_o, torch.transpose(P_x, 0, 1))
+                Sigma_21 = Sigma[torch.meshgrid(idxs_c[k], idxs[k])] 
+                Sigma_11 = Sigma[torch.meshgrid(idxs_c[k], idxs_c[k])] 
 
-                X_bar = X_m - mean_z
+                X_o_s = torch.linalg.solve(Sigma_marg,torch.transpose(X_o,0,1))
+
+                projection = torch.matmul(Sigma_21,X_o_s)
+
+                X_bar = X_m - torch.transpose(projection,0,1)
                 m2 = MultivariateNormal(
-                    torch.zeros(p - n_g_indiv[k], device=device), Sigma_pred
+                    torch.zeros(p - n_g_indiv[k], device=device), Sigma_11
                 )
                 like_preds.append(Lamb[k] * torch.mean(m2.log_prob(X_bar)))
 
@@ -174,7 +218,8 @@ class PPCAMarginal(PPCA):
             loss_i = torch.linalg.matrix_norm(off_diag)
 
             like_gen = torch.sum(torch.stack(like_gens))
-            like_pred = torch.sum(torch.stack(like_gens))
+            like_pred = torch.sum(torch.stack(like_preds))
+            self.losses_pred[i] = like_pred.detach().cpu().numpy()
 
             posterior = like_gen + like_pred + 1 / N * like_prior
             loss = -1 * posterior + self.gamma * loss_i
@@ -189,41 +234,185 @@ class PPCAMarginal(PPCA):
 
         return self
 
-    def _test_inputs(  # type: ignore[override]
+class PPCAMarginalKL(BaseMarginal):
+    """
+    Probabilistic Principal Component Analysis (PPCA) with marginal
+    supervision.
+
+    This class extends PPCA to handle cases where certain dimensions of
+    the data are missing. It weights the marginal predictive distribution
+    integrating out the latent variables to perform supervision. This
+    yields a model which is more predictive of the missing data.
+
+    Parameters
+    ----------
+    n_components : int, default=2
+        Number of components to keep.
+    prior_options : dict or None, optional, default=None
+        Dictionary specifying the prior options. Currently not
+        used in this implementation.
+    gamma : float, default=10.0
+        Parameter to ensure independence of factors
+    training_options : dict or None, optional, default=None
+        Dictionary specifying training options. Keys can include
+        'learning_rate' and 'momentum' for the SGD optimizer.
+
+    Attributes
+    ----------
+    gamma : float
+        Regularization parameter.
+    """
+
+    def __init__(
+        self,
+        n_components: int = 2,
+        prior_options: dict | None = None,
+        gamma: float = 10.0,
+        training_options: dict | None = None,
+    ) -> None:
+        self.gamma: float = float(gamma)
+        super().__init__(
+            n_components=n_components,
+            prior_options=prior_options,
+            training_options=training_options,
+        )
+        self.losses_pred = np.zeros(self.training_options["n_iterations"])
+        self._initialize_save_losses()
+
+    # override needed for mypy to ignore the non-optional `y` argument
+    def fit(  # type: ignore[override]
         self,
         X: NDArray[np.float_],
         idx_list: List[NDArray[np.bool_]],
-        lamb: Optional[NDArray[np.float_]],
-    ) -> None:
+        lamb: NDArray[np.float_],
+        progress_bar: bool = True,
+        seed: int = 2021,
+    ) -> "PPCAMarginal":
         """
-        Validate the input parameters.
+        Fit the PPCA model with marginalization to the given data.
 
         Parameters
         ----------
         X : NDArray[np.float_]
-            The input data array.
+            The input data array. Must be 2-dimensional.
         idx_list : List[NDArray[np.bool_]]
-            List of boolean arrays indicating observed dimensions.
-        lamb : Optional[NDArray[np.float_]]
-            Array of regularization parameters for each group.
+            List of boolean arrays where True indicates observed dimensions and
+            False indicates dimensions to marginalize over.
+        lamb : Optional[NDArray[np.float_]], default=None
+            Array of regularization parameters for each group in idx_list. If
+            None, uses uniform regularization.
+        progress_bar : bool, default=True
+            Whether to display a progress bar during training.
+        seed : int, default=2021
+            Seed for the random number generator.
 
-        Raises
-        ------
-        ValueError
-            If input parameters are invalid, such as mismatched dimensions.
+        Returns
+        -------
+        self : PPCAMarginal
+            The fitted model.
         """
-        if not isinstance(X, np.ndarray):
-            raise ValueError("Data must be numpy array")
-        if self.training_options["batch_size"] > X.shape[0]:
-            raise ValueError("Batch size exceeds number of samples")
-        for idx_array in idx_list:
-            if idx_array.dtype != np.bool_:
-                raise ValueError(
-                    "idx_list must be a list of NumPy boolean arrays"
-                )
-        if lamb is not None and not isinstance(lamb, np.ndarray):
-            raise ValueError("lamb must be a NumPy array if it's not None")
-        if lamb is not None and len(lamb) != len(idx_list):
-            raise ValueError(
-                "Mismatch in lamb length and number of groups in idx_list"
+        self._test_inputs(X, idx_list, lamb)
+        rng = np.random.default_rng(int(seed))
+        training_options = self.training_options
+        N, p = X.shape
+        device = torch.device(
+            "cuda"
+            if torch.cuda.is_available() and training_options["use_gpu"]
+            else "cpu"
+        )
+
+        n_groups = len(idx_list)
+        self.idx_list = idx_list
+        self.n_groups, self.p = n_groups, p
+        n_g_indiv = np.zeros(n_groups)
+        vals = np.arange(p)
+        for i in range(n_groups):
+            n_g_indiv[i] = np.sum(1 * idx_list[i])
+        n_g_indiv = n_g_indiv.astype(int)
+        idxs = [
+            torch.tensor(vals[idx_list[i]], device=device)
+            for i in range(n_groups)
+        ]
+        idxs_c = [
+            torch.tensor(vals[~idx_list[i]], device=device)
+            for i in range(n_groups)
+        ]
+
+        W_, sigmal_ = self._initialize_variables(device, X)
+        X_ = self._transform_training_data(device, X)[0]
+
+        trainable_variables = [W_, sigmal_]
+
+        optimizer = torch.optim.SGD(
+            trainable_variables,
+            lr=training_options["learning_rate"],
+            momentum=training_options["momentum"],
+        )
+        eye = torch.tensor(np.eye(p).astype(np.float32), device=device)
+        softplus = nn.Softplus()
+
+        _prior = self._create_prior(device)
+        z_vecs = [
+            torch.zeros(n_g_indiv[i], device=device) for i in range(n_groups)
+        ]
+
+        Lamb = torch.tensor(lamb, device=device)
+
+        for i in trange(
+            int(training_options["n_iterations"]), disable=not progress_bar
+        ):
+            idx = rng.choice(
+                X_.shape[0], size=training_options["batch_size"], replace=False
             )
+            X_batch = X_[idx]
+
+            sigma = softplus(sigmal_)
+            WWT = torch.matmul(torch.transpose(W_, 0, 1), W_)
+            Sigma = WWT + sigma * eye
+
+            like_prior = _prior(trainable_variables)
+
+            like_gens = []
+            like_preds = []
+
+            for k in range(n_groups):
+                Sigma_marg = Sigma[torch.meshgrid(idxs[k], idxs[k])]
+                X_o = X_batch[:, idxs[k]]
+                X_m = X_batch[:, idxs_c[k]]
+                m = MultivariateNormal(z_vecs[k], Sigma_marg)
+                like_gens.append(torch.mean(m.log_prob(X_o)))
+
+                Sigma_21 = Sigma[torch.meshgrid(idxs_c[k], idxs[k])] 
+                Sigma_11 = Sigma[torch.meshgrid(idxs_c[k], idxs_c[k])] 
+
+                X_o_s = torch.linalg.solve(Sigma_marg,torch.transpose(X_o,0,1))
+
+                projection = torch.matmul(Sigma_21,X_o_s)
+
+                X_bar = X_m - torch.transpose(projection,0,1)
+                m2 = MultivariateNormal(
+                    torch.zeros(p - n_g_indiv[k], device=device), Sigma_11
+                )
+                like_preds.append(Lamb[k] * torch.mean(m2.log_prob(X_bar)))
+
+            WTW = torch.matmul(W_, torch.transpose(W_, 0, 1))
+            off_diag = WTW - torch.diag(torch.diag(WTW))
+            loss_i = torch.linalg.matrix_norm(off_diag)
+
+            like_gen = torch.sum(torch.stack(like_gens))
+            like_pred = torch.sum(torch.stack(like_preds))
+            self.losses_pred[i] = like_pred.detach().cpu().numpy()
+
+            posterior = like_gen + like_pred + 1 / N * like_prior
+            loss = -1 * posterior + self.gamma * loss_i
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            self._save_losses(i, device, like_gen, like_prior, posterior)
+
+        self._store_instance_variables(device, trainable_variables)
+
+        return self
+

--- a/python/python/bystro/supervised_ppca/gf_marginal.py
+++ b/python/python/bystro/supervised_ppca/gf_marginal.py
@@ -12,7 +12,6 @@ from bystro.supervised_ppca._base import _get_projection_matrix
 
 
 class BaseMarginal(PPCA):
-
     def _test_inputs(  # type: ignore[override]
         self,
         X: NDArray[np.float_],
@@ -51,6 +50,7 @@ class BaseMarginal(PPCA):
             raise ValueError(
                 "Mismatch in lamb length and number of groups in idx_list"
             )
+
 
 class PPCAMarginal(BaseMarginal):
     """
@@ -200,14 +200,16 @@ class PPCAMarginal(BaseMarginal):
                 m = MultivariateNormal(z_vecs[k], Sigma_marg)
                 like_gens.append(torch.mean(m.log_prob(X_o)))
 
-                Sigma_21 = Sigma[torch.meshgrid(idxs_c[k], idxs[k])] 
-                Sigma_11 = Sigma[torch.meshgrid(idxs_c[k], idxs_c[k])] 
+                Sigma_21 = Sigma[torch.meshgrid(idxs_c[k], idxs[k])]
+                Sigma_11 = Sigma[torch.meshgrid(idxs_c[k], idxs_c[k])]
 
-                X_o_s = torch.linalg.solve(Sigma_marg,torch.transpose(X_o,0,1))
+                X_o_s = torch.linalg.solve(
+                    Sigma_marg, torch.transpose(X_o, 0, 1)
+                )
 
-                projection = torch.matmul(Sigma_21,X_o_s)
+                projection = torch.matmul(Sigma_21, X_o_s)
 
-                X_bar = X_m - torch.transpose(projection,0,1)
+                X_bar = X_m - torch.transpose(projection, 0, 1)
                 m2 = MultivariateNormal(
                     torch.zeros(p - n_g_indiv[k], device=device), Sigma_11
                 )
@@ -233,6 +235,7 @@ class PPCAMarginal(BaseMarginal):
         self._store_instance_variables(device, trainable_variables)
 
         return self
+
 
 class PPCAMarginalKL(BaseMarginal):
     """
@@ -287,7 +290,7 @@ class PPCAMarginalKL(BaseMarginal):
         lamb: NDArray[np.float_],
         progress_bar: bool = True,
         seed: int = 2021,
-    ) -> "PPCAMarginal":
+    ) -> "PPCAMarginalKL":
         """
         Fit the PPCA model with marginalization to the given data.
 
@@ -382,14 +385,16 @@ class PPCAMarginalKL(BaseMarginal):
                 m = MultivariateNormal(z_vecs[k], Sigma_marg)
                 like_gens.append(torch.mean(m.log_prob(X_o)))
 
-                Sigma_21 = Sigma[torch.meshgrid(idxs_c[k], idxs[k])] 
-                Sigma_11 = Sigma[torch.meshgrid(idxs_c[k], idxs_c[k])] 
+                Sigma_21 = Sigma[torch.meshgrid(idxs_c[k], idxs[k])]
+                Sigma_11 = Sigma[torch.meshgrid(idxs_c[k], idxs_c[k])]
 
-                X_o_s = torch.linalg.solve(Sigma_marg,torch.transpose(X_o,0,1))
+                X_o_s = torch.linalg.solve(
+                    Sigma_marg, torch.transpose(X_o, 0, 1)
+                )
 
-                projection = torch.matmul(Sigma_21,X_o_s)
+                projection = torch.matmul(Sigma_21, X_o_s)
 
-                X_bar = X_m - torch.transpose(projection,0,1)
+                X_bar = X_m - torch.transpose(projection, 0, 1)
                 m2 = MultivariateNormal(
                     torch.zeros(p - n_g_indiv[k], device=device), Sigma_11
                 )
@@ -415,4 +420,3 @@ class PPCAMarginalKL(BaseMarginal):
         self._store_instance_variables(device, trainable_variables)
 
         return self
-

--- a/python/python/bystro/supervised_ppca/tests/test_comparisons.py
+++ b/python/python/bystro/supervised_ppca/tests/test_comparisons.py
@@ -124,23 +124,29 @@ def test_vae_dropout():
 
 def test_svae():
     X, y, X_hat, S, W, logits = PPCA_generate_data(L=3, p=200)
-    training_options = {"n_iterations": 1000}
+    training_options = {"n_iterations": 10, "learning_rate": 1e-4}
     model = PPCASVAE(
-        2, mu=100.0, gamma=10.0, delta=5.0, training_options=training_options
+        2,
+        mu=1.0,
+        gamma=10.0,
+        delta=5.0,
+        lamb=10.0,
+        training_options=training_options,
     )
     model.fit(X, y)
-    S_ = model.transform(X)
-    Y_hat = S_[:, 0] + model.B_
-    model2 = LogisticRegression(C=0.1)
-    model2.fit(X, y)
-    y_hat = model2.decision_function(X)
-    roc_model = roc_auc_score(y, y_hat)
-    roc_linear = roc_auc_score(y, Y_hat)
-    assert roc_model > roc_linear - 0.05
 
-    training_options = {"n_iterations": 1000, "use_gpu": False}
+    training_options = {
+        "n_iterations": 10,
+        "use_gpu": False,
+        "learning_rate": 1e-4,
+    }
     model = PPCASVAE(
-        2, mu=100.0, gamma=10.0, delta=5.0, training_options=training_options
+        2,
+        mu=10.0,
+        gamma=10.0,
+        delta=5.0,
+        lamb=10.0,
+        training_options=training_options,
     )
     model.fit(X, y)
     model.transform(X)


### PR DESCRIPTION
This combines two tasks into a single PR. We fix one of the formulas in the marginal supervision model, which can be seen in lines 166-168 of gf_marginal, where the wrong loss function for the predictive likelihood is used. We also implemented a linear Supervised Variational Autoencoder, which offers no practical advantages, but is an important comparison method in our paper.