### PR TITLE
Covariance Module Improvements

### DIFF
--- a/python/python/bystro/covariance/_base_covariance.py
+++ b/python/python/bystro/covariance/_base_covariance.py
@@ -100,18 +100,11 @@ import pytz
 
 
 class BaseCovariance:
-    """
-    This object basically contains all the methods asides for fitting
-    a covariance matrix.
-    """
 
     def __init__(self):
         self.creationDate = dt.now(pytz.timezone("US/Pacific"))
         self.covariance: NDArray | None = None
 
-    #################
-    # Miscellaneous #
-    #################
     def get_precision(self) -> NDArray[np.float_]:
         if self.covariance is None:
             raise ValueError("Covariance matrix has not been fit")
@@ -130,9 +123,6 @@ class BaseCovariance:
 
         return _predict(self.covariance, Xobs, idxs)
 
-    #####################################
-    # Gaussian Likelihood-based methods #
-    #####################################
     def conditional_score(self, X: NDArray, idxs: NDArray, weights=None):
         if self.covariance is None:
             raise ValueError("Covariance matrix has not been fit")
@@ -169,9 +159,6 @@ class BaseCovariance:
 
         return _score_samples(self.covariance, X)
 
-    #################################
-    # Information-theoretic methods #
-    #################################
     def entropy(self):
         if self.covariance is None:
             raise ValueError("Covariance matrix has not been fit")
@@ -189,19 +176,6 @@ class BaseCovariance:
             raise ValueError("Covariance matrix has not been fit")
 
         return _mutual_information(self.covariance, idxs1, idxs2)
-
-
-###########################################
-###########################################
-###########################################
-###                                     ###
-###                                     ###
-###   Methods for covariance matrices   ###
-###                                     ###
-###                                     ###
-###########################################
-###########################################
-###########################################
 
 
 def _get_precision(covariance: NDArray[np.float_]) -> NDArray[np.float_]:

--- a/python/python/bystro/covariance/_base_covariance.py
+++ b/python/python/bystro/covariance/_base_covariance.py
@@ -177,6 +177,15 @@ class BaseCovariance:
 
         return _mutual_information(self.covariance, idxs1, idxs2)
 
+    def _test_inputs(self, X: NDArray[np.float_]):
+        """ 
+        Just tests to make sure data is numpy array
+        """
+        if not isinstance(X, np.ndarray):
+            raise ValueError("Data is numpy array")
+        if np.sum(np.isnan(X))>0:
+            raise ValueError("Data has nans")
+
 
 def _get_precision(covariance: NDArray[np.float_]) -> NDArray[np.float_]:
     """

--- a/python/python/bystro/covariance/_base_covariance.py
+++ b/python/python/bystro/covariance/_base_covariance.py
@@ -100,7 +100,6 @@ import pytz
 
 
 class BaseCovariance:
-
     def __init__(self):
         self.creationDate = dt.now(pytz.timezone("US/Pacific"))
         self.covariance: NDArray | None = None
@@ -171,19 +170,21 @@ class BaseCovariance:
 
         return _entropy_subset(self.covariance, idxs)
 
-    def mutual_information(self, idxs1: NDArray[np.float_], idxs2: NDArray[np.float_]):
+    def mutual_information(
+        self, idxs1: NDArray[np.float_], idxs2: NDArray[np.float_]
+    ):
         if self.covariance is None:
             raise ValueError("Covariance matrix has not been fit")
 
         return _mutual_information(self.covariance, idxs1, idxs2)
 
     def _test_inputs(self, X: NDArray[np.float_]):
-        """ 
+        """
         Just tests to make sure data is numpy array
         """
         if not isinstance(X, np.ndarray):
             raise ValueError("Data is numpy array")
-        if np.sum(np.isnan(X))>0:
+        if np.sum(np.isnan(X)) > 0:
             raise ValueError("Data has nans")
 
 
@@ -225,7 +226,9 @@ def _get_stable_rank(covariance: NDArray[np.float_]) -> np.float_:
 
 
 def _predict(
-    covariance: NDArray[np.float_], Xobs: NDArray[np.float_], idxs: NDArray[np.float_]
+    covariance: NDArray[np.float_],
+    Xobs: NDArray[np.float_],
+    idxs: NDArray[np.float_],
 ) -> NDArray[np.float_]:
     """
     Predicts missing data using observed data. This uses the conditional
@@ -286,7 +289,9 @@ def _conditional_score(
     avg_score : np.float_
         Average log likelihood
     """
-    weights = np.ones(X.shape[0]) if weights is None else weights / np.mean(weights)
+    weights = (
+        np.ones(X.shape[0]) if weights is None else weights / np.mean(weights)
+    )
 
     return np.mean(weights * _conditional_score_samples(covariance, X, idxs))
 
@@ -326,15 +331,20 @@ def _conditional_score_sherman_woodbury(
     avg_score : np.float_
         Average log likelihood
     """
-    weights = np.ones(X.shape[0]) if weights is None else weights / np.mean(weights)
+    weights = (
+        np.ones(X.shape[0]) if weights is None else weights / np.mean(weights)
+    )
 
     return np.mean(
-        weights * _conditional_score_samples_sherman_woodbury(Lambda, W, X, idxs)
+        weights
+        * _conditional_score_samples_sherman_woodbury(Lambda, W, X, idxs)
     )
 
 
 def _conditional_score_samples(
-    covariance: NDArray[np.float_], X: NDArray[np.float_], idxs: NDArray[np.float_]
+    covariance: NDArray[np.float_],
+    X: NDArray[np.float_],
+    idxs: NDArray[np.float_],
 ) -> np.float_:
     """
     Return the conditional log likelihood of each sample, that is
@@ -589,7 +599,9 @@ def _marginal_score_sherman_woodbury(
 
 
 def _marginal_score_samples(
-    covariance: NDArray[np.float_], X: NDArray[np.float_], idxs: NDArray[np.float_]
+    covariance: NDArray[np.float_],
+    X: NDArray[np.float_],
+    idxs: NDArray[np.float_],
 ) -> np.float_:
     """
     Returns the marginal log-likelihood of a subset of data
@@ -730,7 +742,9 @@ def _score_sherman_woodbury(
     return np.mean(weights * _score_samples_sherman_woodbury(Lambda, W, X))
 
 
-def _score_samples(covariance: NDArray[np.float_], X: NDArray[np.float_]) -> np.float_:
+def _score_samples(
+    covariance: NDArray[np.float_], X: NDArray[np.float_]
+) -> np.float_:
     """
     Return the log likelihood of each sample
 
@@ -822,7 +836,9 @@ def _entropy(covariance: NDArray[np.float_]) -> np.float_:
     return 0.5 * logdet
 
 
-def _entropy_subset(covariance: NDArray[np.float_], idxs: NDArray[np.float_]) -> np.float_:
+def _entropy_subset(
+    covariance: NDArray[np.float_], idxs: NDArray[np.float_]
+) -> np.float_:
     """
     Computes the entropy of a subset of the Gaussian distribution
     parameterized by covariance.
@@ -848,7 +864,9 @@ def _entropy_subset(covariance: NDArray[np.float_], idxs: NDArray[np.float_]) ->
 
 
 def _mutual_information(
-    covariance: NDArray[np.float_], idxs1: NDArray[np.float_], idxs2: NDArray[np.float_]
+    covariance: NDArray[np.float_],
+    idxs1: NDArray[np.float_],
+    idxs2: NDArray[np.float_],
 ) -> np.float_:
     """
     This computes the mutual information bewteen the two sets of
@@ -872,7 +890,9 @@ def _mutual_information(
     idxs1_sub = idxs1[idxs == 1]
     Hy = _entropy(cov_sub[np.ix_(idxs1_sub == 1, idxs1_sub == 1)])
 
-    _, covariance_conditional = _get_conditional_parameters(cov_sub, 1 - idxs1_sub)
+    _, covariance_conditional = _get_conditional_parameters(
+        cov_sub, 1 - idxs1_sub
+    )
     H_y_given_x = _entropy(covariance_conditional)
     mutual_information = Hy - H_y_given_x
 

--- a/python/python/bystro/covariance/_base_precision.py
+++ b/python/python/bystro/covariance/_base_precision.py
@@ -76,9 +76,6 @@ class BasePrecision(BaseCovariance):
         if self.covariance is None:
             self.covariance = self.get_covariance()
 
-    #################
-    # Miscellaneous #
-    #################
     def get_covariance(self):
         if self.precision is None:
             raise ValueError(
@@ -98,9 +95,6 @@ class BasePrecision(BaseCovariance):
 
         return super(BasePrecision, self).predict(Xobs, idxs)
 
-    #####################################
-    # Gaussian Likelihood-based methods #
-    #####################################
     def conditional_score(
         self,
         X: NDArray[np.float_],
@@ -143,9 +137,6 @@ class BasePrecision(BaseCovariance):
 
         return super(BasePrecision, self).score_samples(X)
 
-    #################################
-    # Information-theoretic methods #
-    #################################
     def entropy(self):
         self._set_covariance_if_none()
 

--- a/python/python/bystro/covariance/_base_precision.py
+++ b/python/python/bystro/covariance/_base_precision.py
@@ -103,7 +103,9 @@ class BasePrecision(BaseCovariance):
     ):
         self._set_covariance_if_none()
 
-        return super(BasePrecision, self).conditional_score(X, idxs, weights=weights)
+        return super(BasePrecision, self).conditional_score(
+            X, idxs, weights=weights
+        )
 
     def conditional_score_samples(
         self, X: NDArray[np.float_], idxs: NDArray[np.float_]
@@ -120,14 +122,20 @@ class BasePrecision(BaseCovariance):
     ):
         self._set_covariance_if_none()
 
-        return super(BasePrecision, self).marginal_score(X, idxs, weights=weights)
+        return super(BasePrecision, self).marginal_score(
+            X, idxs, weights=weights
+        )
 
-    def marginal_score_samples(self, X: NDArray[np.float_], idxs: NDArray[np.float_]):
+    def marginal_score_samples(
+        self, X: NDArray[np.float_], idxs: NDArray[np.float_]
+    ):
         self._set_covariance_if_none()
 
         return super(BasePrecision, self).marginal_score_samples(X, idxs)
 
-    def score(self, X: NDArray[np.float_], weights: NDArray[np.float_] | None = None):
+    def score(
+        self, X: NDArray[np.float_], weights: NDArray[np.float_] | None = None
+    ):
         self._set_covariance_if_none()
 
         return super(BasePrecision, self).score(X, weights=weights)
@@ -147,7 +155,9 @@ class BasePrecision(BaseCovariance):
 
         return super(BasePrecision, self).entropy_subset(idxs)
 
-    def mutual_information(self, idxs1: NDArray[np.float_], idxs2: NDArray[np.float_]):
+    def mutual_information(
+        self, idxs1: NDArray[np.float_], idxs2: NDArray[np.float_]
+    ):
         self._set_covariance_if_none()
 
         return super(BasePrecision, self).mutual_information(idxs1, idxs2)

--- a/python/python/bystro/covariance/_covariance_np.py
+++ b/python/python/bystro/covariance/_covariance_np.py
@@ -98,7 +98,24 @@ class BayesianCovariance(BaseCovariance):
 
 
 class LinearShrinkageCovariance(BaseCovariance):
+
     def fit(self, X: NDArray[np.float_]) -> "LinearShrinkageCovariance":
+        """
+        This fits a covariance matrix using the linear shrinkage approach 
+        to combine the empirical covariance matrix with a structured 
+        estimator.
+
+        Parameters
+        ----------
+        X : np.array-like, (n_samples, n_covariates)
+            The centered data
+
+        Returns
+        -------
+        self : LinearShrinkageCovariance
+            The model, with updated covariance attribute
+        """
+
         self._test_inputs(X)
         self.N, self.p = X.shape
 
@@ -109,7 +126,7 @@ class LinearShrinkageCovariance(BaseCovariance):
         lambd = np.mean(evalues)
 
         temp = [
-            np.linalg.norm(np.outer(X[:, i], X[:, i]) - S, "fro") ** 2
+            np.linalg.norm(np.outer(X[i], X[i]) - S, "fro") ** 2
             for i in range(self.N)
         ]
 
@@ -126,16 +143,54 @@ class LinearShrinkageCovariance(BaseCovariance):
 
         return self
 
-
 class NonLinearShrinkageCovariance(BaseCovariance):
+    """
+    This method adjusts each eigenvalue of the sample covariance matrix 
+    individually according to a nonlinear shrinkage formula, based on the 
+    Hilbert transform. This approach contrasts with linear shrinkage methods 
+    that apply a uniform adjustment across all eigenvalues. The nonlinear 
+    technique allows for a more nuanced adjustment that is particularly 
+    beneficial in scenarios with clusters of eigenvalues, optimizing the 
+    shrinkage based on local eigenvalue densities. The method assumes a 
+    sample matrix composed of i.i.d. random variables with mean zero and 
+    finite 16th moment, and is suitable for large-dimensional data sets where 
+    the ratio of variables p to n is significant.
+
+    The theoretical basis of this approach is built around the optimal 
+    estimation of p parameters, which balances between overfitting p^2
+    parameters and underfitting with only 1 parameter. The nonlinear shrinkage 
+    is calculated using an oracle estimator that depends on a sample spectral density 
+    function approximated via kernel estimation using the Epanechnikov kernel. 
+    This estimation facilitates the derivation of shrinkage intensities for each 
+    eigenvalue, tailoring the adjustment to improve estimations under various 
+    data conditions. Practical implementation details are provided, adapted from a 
+    Matlab script by the authors, ensuring that users can apply this method effectively 
+    to empirical data sets. The docstring also underscores the utility of this estimator 
+    in practical settings, providing a more parameter-efficient approach compared 
+    to traditional methods, which often rely on unfeasibly large parameter sets.
+    """
+
     def fit(self, X: NDArray[np.float_]) -> "NonLinearShrinkageCovariance":
+        """
+        This fits a covariance matrix using the nonlinear shrinkage approach, which
+        adjusts the empirical eigenvalues based on asymptotic results.
+
+        Parameters
+        ----------
+        X : np.array-like, (n_samples, n_covariates)
+            The centered data
+
+        Returns
+        -------
+        self : NonLinearShrinkageCovariance
+            The model, with updated covariance attribute
+        """
         self._test_inputs(X)
         self.N, self.p = X.shape
         N, p = X.shape
         S = np.cov(X.T)
         lambd, u = np.linalg.eigh(S)
 
-        # compute analytical nonlinear shrinkage kernel formula.
         lambd = lambd[np.maximum(0, p - N) :]
         L = np.tile(lambd, (np.minimum(p, N), 1)).T
         h = N ** (-1 / 3)

--- a/python/python/bystro/covariance/_covariance_np.py
+++ b/python/python/bystro/covariance/_covariance_np.py
@@ -25,6 +25,12 @@ class EmpiricalCovariance(BaseCovariance):
         -------
         self : EmpiricalCovariance
             The model
+
+        Raises
+        ------
+        ValueError:
+            A value error will be raised if missing data is found in X ( 
+            np.isnan(X) evaluates to true ), or if X is not an NDArray
         """
         self._test_inputs(X)
         self.N, self.p = X.shape
@@ -59,6 +65,12 @@ class BayesianCovariance(BaseCovariance):
         -------
         self : BayesianCovariance
             The model
+
+        Raises
+        ------
+        ValueError:
+            A value error will be raised if missing data is found in X ( 
+            np.isnan(X) evaluates to true ), or if X is not an NDArray
         """
         self._test_inputs(X)
         self.N, self.p = X.shape
@@ -113,6 +125,12 @@ class LinearShrinkageCovariance(BaseCovariance):
         -------
         self : LinearShrinkageCovariance
             The model, with updated covariance attribute
+
+        Raises
+        ------
+        ValueError:
+            A value error will be raised if missing data is found in X ( 
+            np.isnan(X) evaluates to true ), or if X is not an NDArray
         """
 
         self._test_inputs(X)
@@ -180,6 +198,12 @@ class NonLinearShrinkageCovariance(BaseCovariance):
         -------
         self : NonLinearShrinkageCovariance
             The model, with updated covariance attribute
+
+        Raises
+        ------
+        ValueError:
+            A value error will be raised if missing data is found in X ( 
+            np.isnan(X) evaluates to true ), or if X is not an NDArray
         """
         self._test_inputs(X)
         self.N, self.p = X.shape

--- a/python/python/bystro/covariance/_covariance_np.py
+++ b/python/python/bystro/covariance/_covariance_np.py
@@ -98,11 +98,10 @@ class BayesianCovariance(BaseCovariance):
 
 
 class LinearShrinkageCovariance(BaseCovariance):
-
     def fit(self, X: NDArray[np.float_]) -> "LinearShrinkageCovariance":
         """
-        This fits a covariance matrix using the linear shrinkage approach 
-        to combine the empirical covariance matrix with a structured 
+        This fits a covariance matrix using the linear shrinkage approach
+        to combine the empirical covariance matrix with a structured
         estimator.
 
         Parameters
@@ -143,30 +142,31 @@ class LinearShrinkageCovariance(BaseCovariance):
 
         return self
 
+
 class NonLinearShrinkageCovariance(BaseCovariance):
     """
-    This method adjusts each eigenvalue of the sample covariance matrix 
-    individually according to a nonlinear shrinkage formula, based on the 
-    Hilbert transform. This approach contrasts with linear shrinkage methods 
-    that apply a uniform adjustment across all eigenvalues. The nonlinear 
-    technique allows for a more nuanced adjustment that is particularly 
-    beneficial in scenarios with clusters of eigenvalues, optimizing the 
-    shrinkage based on local eigenvalue densities. The method assumes a 
-    sample matrix composed of i.i.d. random variables with mean zero and 
-    finite 16th moment, and is suitable for large-dimensional data sets where 
+    This method adjusts each eigenvalue of the sample covariance matrix
+    individually according to a nonlinear shrinkage formula, based on the
+    Hilbert transform. This approach contrasts with linear shrinkage methods
+    that apply a uniform adjustment across all eigenvalues. The nonlinear
+    technique allows for a more nuanced adjustment that is particularly
+    beneficial in scenarios with clusters of eigenvalues, optimizing the
+    shrinkage based on local eigenvalue densities. The method assumes a
+    sample matrix composed of i.i.d. random variables with mean zero and
+    finite 16th moment, and is suitable for large-dimensional data sets where
     the ratio of variables p to n is significant.
 
-    The theoretical basis of this approach is built around the optimal 
+    The theoretical basis of this approach is built around the optimal
     estimation of p parameters, which balances between overfitting p^2
-    parameters and underfitting with only 1 parameter. The nonlinear shrinkage 
-    is calculated using an oracle estimator that depends on a sample spectral density 
-    function approximated via kernel estimation using the Epanechnikov kernel. 
-    This estimation facilitates the derivation of shrinkage intensities for each 
-    eigenvalue, tailoring the adjustment to improve estimations under various 
-    data conditions. Practical implementation details are provided, adapted from a 
-    Matlab script by the authors, ensuring that users can apply this method effectively 
-    to empirical data sets. The docstring also underscores the utility of this estimator 
-    in practical settings, providing a more parameter-efficient approach compared 
+    parameters and underfitting with only 1 parameter. The nonlinear shrinkage
+    is calculated using an oracle estimator that depends on a sample spectral density
+    function approximated via kernel estimation using the Epanechnikov kernel.
+    This estimation facilitates the derivation of shrinkage intensities for each
+    eigenvalue, tailoring the adjustment to improve estimations under various
+    data conditions. Practical implementation details are provided, adapted from a
+    Matlab script by the authors, ensuring that users can apply this method effectively
+    to empirical data sets. The docstring also underscores the utility of this estimator
+    in practical settings, providing a more parameter-efficient approach compared
     to traditional methods, which often rely on unfeasibly large parameter sets.
     """
 

--- a/python/python/bystro/covariance/_covariance_np.py
+++ b/python/python/bystro/covariance/_covariance_np.py
@@ -8,7 +8,7 @@ class EmpiricalCovariance(BaseCovariance):
     def __init__(self):
         """
         This object just fits the covariance matrix as the standard sample
-        covariance matrix
+        covariance matrix. Does not handle missing values
         """
         super().__init__()
 
@@ -38,7 +38,7 @@ class BayesianCovariance(BaseCovariance):
     def __init__(self, prior_options=None):
         """
         This object fits the covariance matrix as the MAP estimator using
-        user-defined priors.
+        user-defined priors. Does not handle missing values
         """
         super().__init__()
         if prior_options is None:
@@ -163,11 +163,7 @@ class NonLinearShrinkageCovariance(BaseCovariance):
     function approximated via kernel estimation using the Epanechnikov kernel.
     This estimation facilitates the derivation of shrinkage intensities for each
     eigenvalue, tailoring the adjustment to improve estimations under various
-    data conditions. Practical implementation details are provided, adapted from a
-    Matlab script by the authors, ensuring that users can apply this method effectively
-    to empirical data sets. The docstring also underscores the utility of this estimator
-    in practical settings, providing a more parameter-efficient approach compared
-    to traditional methods, which often rely on unfeasibly large parameter sets.
+    data conditions. 
     """
 
     def fit(self, X: NDArray[np.float_]) -> "NonLinearShrinkageCovariance":

--- a/python/python/bystro/covariance/tests/test_base_covariance.py
+++ b/python/python/bystro/covariance/tests/test_base_covariance.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numpy.linalg as la
-import scipy.stats as st # type: ignore
+import scipy.stats as st  # type: ignore
 from bystro.covariance._base_covariance import (
     BaseCovariance,
     _score_samples,
@@ -60,7 +60,7 @@ def test_predict():
 
 def test_conditional_score_samples():
     """
-    Test conditional likelihood calculations from samples using the 
+    Test conditional likelihood calculations from samples using the
     direct method in `BaseCovariance`. Verifies against expected outcomes.
     """
     rng = np.random.default_rng(2021)

--- a/python/python/bystro/covariance/tests/test_base_covariance.py
+++ b/python/python/bystro/covariance/tests/test_base_covariance.py
@@ -20,6 +20,11 @@ from bystro.covariance._base_covariance import (
 
 
 def test_get_stable_rank():
+    """
+    Test the `get_stable_rank` method of the `BaseCovariance` class to ensure
+    it returns the correct rank of the covariance matrix. Tests with identity
+    and modified zero matrices.
+    """
     model = BaseCovariance()
 
     model.covariance = np.eye(10)
@@ -31,6 +36,11 @@ def test_get_stable_rank():
 
 
 def test_predict():
+    """
+    Test the `predict` method of the `BaseCovariance` class to ensure it
+    correctly predicts based on the model's state using a normally distributed
+    dataset.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     model = BaseCovariance()
@@ -49,6 +59,10 @@ def test_predict():
 
 
 def test_conditional_score_samples():
+    """
+    Test conditional likelihood calculations from samples using the 
+    direct method in `BaseCovariance`. Verifies against expected outcomes.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     model = BaseCovariance()
@@ -71,6 +85,10 @@ def test_conditional_score_samples():
 
 
 def test_conditional_score_samples_sherman_woodbury():
+    """
+    Test the Sherman-Woodbury formula for conditional score calculations from
+    samples. Ensures consistency with the standard method.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     W = rng.normal(size=(3, 10))
@@ -88,6 +106,10 @@ def test_conditional_score_samples_sherman_woodbury():
 
 
 def test_conditional_score():
+    """
+    Test calculation of conditional scores in the `BaseCovariance` class.
+    Verifies mathematical accuracy for given conditions.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     model = BaseCovariance()
@@ -125,6 +147,10 @@ def test_conditional_score_sherman_woodbury():
 
 
 def test_marginal_score_samples():
+    """
+    Test marginal score calculations from samples in `BaseCovariance`.
+    Confirms accuracy of scores reflecting marginal probabilities.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(150, 10))
     model = BaseCovariance()
@@ -140,6 +166,10 @@ def test_marginal_score_samples():
 
 
 def test_marginal_score_samples_sherman_woodbury():
+    """
+    Verify Sherman-Woodbury for marginal score calculations from samples.
+    Compares results with traditional methods for consistency.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(150, 10))
     W = rng.normal(size=(3, 10))
@@ -158,6 +188,10 @@ def test_marginal_score_samples_sherman_woodbury():
 
 
 def test_marginal_score():
+    """
+    Test direct computation of marginal scores using `BaseCovariance`.
+    Validates accuracy of marginal probabilities.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(15, 10))
     model = BaseCovariance()
@@ -173,6 +207,10 @@ def test_marginal_score():
 
 
 def test_marginal_score_sherman_woodbury():
+    """
+    Evaluate Sherman-Woodbury for computing marginal scores. Ensures formula
+    provides accurate and efficient results.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(150, 10))
     W = rng.normal(size=(3, 10))
@@ -189,6 +227,10 @@ def test_marginal_score_sherman_woodbury():
 
 
 def test_score():
+    """
+    Test overall score computation in `BaseCovariance`. Checks accuracy and
+    robustness of score outputs under various conditions.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     model = BaseCovariance()
@@ -200,6 +242,10 @@ def test_score():
 
 
 def test_score_sherman_woodbury():
+    """
+    Test Sherman-Woodbury formula for overall score computation. Ensures
+    optimized method maintains accuracy with standard techniques.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     W = rng.normal(size=(3, 10))
@@ -213,6 +259,10 @@ def test_score_sherman_woodbury():
 
 
 def test_score_samples():
+    """
+    Test computation of scores from samples in `BaseCovariance`. Verifies
+    the method's ability to compute scores accurately from data.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     model = BaseCovariance()
@@ -224,6 +274,10 @@ def test_score_samples():
 
 
 def test_score_samples_sherman_woodbury():
+    """
+    Assess Sherman-Woodbury optimization in score calculation from samples.
+    Verifies consistent and reliable results compared to basic method.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     W = rng.normal(size=(3, 10))
@@ -236,6 +290,10 @@ def test_score_samples_sherman_woodbury():
 
 
 def test_entropy():
+    """
+    Test entropy calculation within `BaseCovariance`. Ensures computed
+    entropy is correct for different covariance matrix states.
+    """
     model = BaseCovariance()
     model.covariance = np.eye(10)
     _, logdet = la.slogdet(model.covariance)
@@ -260,6 +318,10 @@ def test_entropy_subset():
 
 
 def test_mutual_information():
+    """
+    Test mutual information calculation between variable sets in the covariance
+    matrix. Confirms accuracy of the mutual information values.
+    """
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(1000, 10))
     model = BaseCovariance()
@@ -279,6 +341,10 @@ def test_mutual_information():
 
 
 def test_inv_sherman_woodbury_fa():
+    """
+    Test Sherman-Woodbury formula for inverse of factor analysis model's
+    covariance matrix. Checks accuracy of inverse calculation.
+    """
     rng = np.random.default_rng(2021)
     p = 20
     Lambda = np.diag(rng.gamma(1, 1, size=p))
@@ -290,6 +356,10 @@ def test_inv_sherman_woodbury_fa():
 
 
 def test_inv_sherman_woodbury_full():
+    """
+    Verify full covariance matrix inversion using Sherman-Woodbury. Ensures
+    correct performance and matches results from traditional methods.
+    """
     rng = np.random.default_rng(2021)
     p = 20
     L = 4
@@ -305,6 +375,10 @@ def test_inv_sherman_woodbury_full():
 
 
 def test_ldet_sherman_woodbury_fa():
+    """
+    Test log-determinant computation using Sherman-Woodbury for factor analysis
+    models. Checks if computed values are correct versus conventional methods.
+    """
     rng = np.random.default_rng(2021)
     p = 20
     Lambda = np.diag(rng.gamma(1, 1, size=p))

--- a/python/python/bystro/covariance/tests/test_covariance_np.py
+++ b/python/python/bystro/covariance/tests/test_covariance_np.py
@@ -15,7 +15,7 @@ def test_empirical_covariance():
     model = EmpiricalCovariance()
     model.fit(X)
 
-    assert model.covariance is not None 
+    assert model.covariance is not None
     assert model.covariance.shape == (10, 10)
 
     s_vals = la.svd(model.covariance, compute_uv=False)
@@ -49,7 +49,8 @@ def test_linearshrinkage_covariance():
     s_vals = la.svd(model.covariance, compute_uv=False)
     assert np.abs(1 - s_vals[0]) <= 5e-2
 
-def test_bayesian_covariance():
+
+def test_nonlinear_covariance():
     rng = np.random.default_rng(2021)
     X = rng.normal(size=(100000, 10))
 

--- a/python/python/bystro/covariance/tests/test_covariance_np.py
+++ b/python/python/bystro/covariance/tests/test_covariance_np.py
@@ -3,6 +3,8 @@ import numpy.linalg as la
 from bystro.covariance._covariance_np import (
     EmpiricalCovariance,
     BayesianCovariance,
+    LinearShrinkageCovariance,
+    NonLinearShrinkageCovariance,
 )
 
 
@@ -25,6 +27,33 @@ def test_bayesian_covariance():
     X = rng.normal(size=(100000, 10))
 
     model = BayesianCovariance()
+    model.fit(X)
+
+    assert model.covariance is not None
+    assert model.covariance.shape == (10, 10)
+
+    s_vals = la.svd(model.covariance, compute_uv=False)
+    assert np.abs(1 - s_vals[0]) <= 5e-2
+
+
+def test_linearshrinkage_covariance():
+    rng = np.random.default_rng(2021)
+    X = rng.normal(size=(100000, 10))
+
+    model = LinearShrinkageCovariance()
+    model.fit(X)
+
+    assert model.covariance is not None
+    assert model.covariance.shape == (10, 10)
+
+    s_vals = la.svd(model.covariance, compute_uv=False)
+    assert np.abs(1 - s_vals[0]) <= 5e-2
+
+def test_bayesian_covariance():
+    rng = np.random.default_rng(2021)
+    X = rng.normal(size=(100000, 10))
+
+    model = NonLinearShrinkageCovariance()
     model.fit(X)
 
     assert model.covariance is not None


### PR DESCRIPTION
We are now realizing that fitting covariance matrices is a critical task and while there is extensive work in the statistics community on improving finite-sample properties of estimation, very little has migrated to other fields. Part of this is likely due to scattered implementations across a variety of github repositories. We are implementing a large quantity of these estimators ourselves with a common format similar to sklearn. Here I implement two shrinkage estimators by Ledoit and Wolfe.