### PR TITLE
fix reporting of total number of filtered variants

### DIFF
--- a/python/python/bystro/search/save/handler.py
+++ b/python/python/bystro/search/save/handler.py
@@ -409,7 +409,7 @@ def filter_annotation(
             p.wait()
             stats_fh.wait()
 
-            reporter.message.remote(f"Annotation: Completed filtering of {n_hits} variants.")  # type: ignore
+            reporter.message.remote(f"Annotation: Completed filtering.")  # type: ignore
 
     reporter.message.remote(f"Annotation: {n_retained} variants survived filtering.")  # type: ignore
 

--- a/python/python/bystro/search/save/handler.py
+++ b/python/python/bystro/search/save/handler.py
@@ -409,7 +409,7 @@ def filter_annotation(
             p.wait()
             stats_fh.wait()
 
-            reporter.message.remote(f"Annotation: Completed filtering of {i} variants.")  # type: ignore
+            reporter.message.remote(f"Annotation: Completed filtering of {n_hits} variants.")  # type: ignore
 
     reporter.message.remote(f"Annotation: {n_retained} variants survived filtering.")  # type: ignore
 


### PR DESCRIPTION
* The row index does not always correspond to the last records, because we stop filtering as soon as we have passed the last locus desired. So instead, just indicate we have completed filtering (we have read all the records the user queried).