### PR TITLE
Add back support for nulls in fast dosage matrix calculation

### DIFF
--- a/.github/workflows/perl-package-build.yml
+++ b/.github/workflows/perl-package-build.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install one-off Bystro dependencies
         shell: bash
         run: |
-          go install github.com/bystrogenomics/bystro-vcf@2.2.1
+          go install github.com/bystrogenomics/bystro-vcf@2.2.2
           cpm install -g https://github.com/bystrogenomics/msgpack-perl.git
           cpm install -g --no-test MouseX::Getopt
           cpm install -g DBD::mysql@4.051

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -6,7 +6,7 @@ ENV GOBIN=/app/bin
 
 # Install the specific versions of the Go programs
 RUN go install github.com/akotlar/bystro-stats@1.0.0
-RUN go install github.com/bystrogenomics/bystro-vcf@2.2.1;
+RUN go install github.com/bystrogenomics/bystro-vcf@2.2.2;
 RUN go install github.com/akotlar/bystro-snp@1.0.0
 RUN go install github.com/mikefarah/yq@2.4.1
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please read: [INSTALL.md](INSTALL.md) for instructions on how to download and us
 
 Bystro relies on pluggable (via Bystro's YAML config) pre-processors to normalize variant inputs (**dealing with VCF issues such as padding**), calculate whether a site is a transition or transversion, calculate sample maf, identify hets/homozygotes/missing samples, calculate heterozygosity, homozygosity, missingness, and more.
 
-1. VCF format: [Bystro-Vcf](https://github.com/bystrogenomics/bystro-vcf/tree/2.1.0)
+1. VCF format: [Bystro-Vcf](https://github.com/bystrogenomics/bystro-vcf/tree/2.2.2)
 2. SNP format: [Bystro-SNP](https://github.com/akotlar/bystro-snp)
 3. Create your own to support other formats!
 

--- a/go/cmd/dosage-filter/main.go
+++ b/go/cmd/dosage-filter/main.go
@@ -146,33 +146,37 @@ func processRecordAt(fr *ipc.FileReader, loci *btree.Set[string], arrowWriter *b
 				// Fill the builder with values from the original columns, filtering by selectedIndices
 				for colIdx := 0; colIdx < int(record.NumCols()); colIdx++ {
 					column := record.Column(colIdx)
-					switch column := column.(type) {
-					case *array.String:
-						builder.Field(colIdx).(*array.StringBuilder).Append(column.Value(j))
-					case *array.Uint8:
-						builder.Field(colIdx).(*array.Uint8Builder).Append(column.Value(j))
-					case *array.Uint16:
-						builder.Field(colIdx).(*array.Uint16Builder).Append(column.Value(j))
-					case *array.Uint32:
-						builder.Field(colIdx).(*array.Uint32Builder).Append(column.Value(j))
-					case *array.Uint64:
-						builder.Field(colIdx).(*array.Uint64Builder).Append(column.Value(j))
-					case *array.Int8:
-						builder.Field(colIdx).(*array.Int8Builder).Append(column.Value(j))
-					case *array.Int16:
-						builder.Field(colIdx).(*array.Int16Builder).Append(column.Value(j))
-					case *array.Int32:
-						builder.Field(colIdx).(*array.Int32Builder).Append(column.Value(j))
-					case *array.Int64:
-						builder.Field(colIdx).(*array.Int64Builder).Append(column.Value(j))
-					case *array.Float16:
-						builder.Field(colIdx).(*array.Float16Builder).Append(column.Value(j))
-					case *array.Float32:
-						builder.Field(colIdx).(*array.Float32Builder).Append(column.Value(j))
-					case *array.Float64:
-						builder.Field(colIdx).(*array.Float64Builder).Append(column.Value(j))
-					default:
-						log.Fatalf("Unsupported column type: %T", column)
+					if column.IsNull(j) {
+						builder.Field(colIdx).AppendNull() // Appends a null value to the field
+					} else {
+						switch column := column.(type) {
+						case *array.String:
+							builder.Field(colIdx).(*array.StringBuilder).Append(column.Value(j))
+						case *array.Uint8:
+							builder.Field(colIdx).(*array.Uint8Builder).Append(column.Value(j))
+						case *array.Uint16:
+							builder.Field(colIdx).(*array.Uint16Builder).Append(column.Value(j))
+						case *array.Uint32:
+							builder.Field(colIdx).(*array.Uint32Builder).Append(column.Value(j))
+						case *array.Uint64:
+							builder.Field(colIdx).(*array.Uint64Builder).Append(column.Value(j))
+						case *array.Int8:
+							builder.Field(colIdx).(*array.Int8Builder).Append(column.Value(j))
+						case *array.Int16:
+							builder.Field(colIdx).(*array.Int16Builder).Append(column.Value(j))
+						case *array.Int32:
+							builder.Field(colIdx).(*array.Int32Builder).Append(column.Value(j))
+						case *array.Int64:
+							builder.Field(colIdx).(*array.Int64Builder).Append(column.Value(j))
+						case *array.Float16:
+							builder.Field(colIdx).(*array.Float16Builder).Append(column.Value(j))
+						case *array.Float32:
+							builder.Field(colIdx).(*array.Float32Builder).Append(column.Value(j))
+						case *array.Float64:
+							builder.Field(colIdx).(*array.Float64Builder).Append(column.Value(j))
+						default:
+							log.Fatalf("Unsupported column type: %T", column)
+						}
 					}
 				}
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow/go/v14 v14.0.2
 	github.com/beanstalkd/go-beanstalk v0.2.0
 	github.com/biogo/hts v1.4.4
-	github.com/bystrogenomics/bystro-vcf v0.0.0-20240406002905-a9a245f1ffb0
+	github.com/bystrogenomics/bystro-vcf v0.0.0-20240425204515-a3bed256638d
 	github.com/bytedance/sonic v1.10.2
 	github.com/dolthub/swiss v0.2.1
 	github.com/klauspost/compress v1.17.4

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,3 +1,4 @@
+github.com/akotlar/bystro-utils v0.0.0-20180921004542-b5183a523f20 h1:DTPJA8O7qs7Dc+YRg9wZusDy/SoVHqn9udRQlr+TSFA=
 github.com/akotlar/bystro-utils v0.0.0-20180921004542-b5183a523f20/go.mod h1:BHUTiQAFM7OSW8+09I/OwWMhgbsonqQ6J8jTlnpOPnk=
 github.com/apache/arrow/go/v14 v14.0.2 h1:N8OkaJEOfI3mEZt07BIkvo4sC6XDbL+48MBPWO5IONw=
 github.com/apache/arrow/go/v14 v14.0.2/go.mod h1:u3fgh3EdgN/YQ8cVQRguVW3R+seMybFg8QBQ5LU+eBY=
@@ -21,6 +22,8 @@ github.com/biogo/hts v1.4.4 h1:Z+TminqAKRE/t6nyy5PwI/DL90kdew4GpghB+QdjjFk=
 github.com/biogo/hts v1.4.4/go.mod h1:AfPn4uJQ2zxi04Q/4vccdmCX16W+IsHXVguPsdh4HE4=
 github.com/bystrogenomics/bystro-vcf v0.0.0-20240406002905-a9a245f1ffb0 h1:iAbMGYoCpvqcPLuolyHMH6HKdiYIg8EVzb/lbUjCZwI=
 github.com/bystrogenomics/bystro-vcf v0.0.0-20240406002905-a9a245f1ffb0/go.mod h1:ssLIZJL1hUm8xIFZO33X2Mp0b3Ju7oJ2liBW0Qov0KQ=
+github.com/bystrogenomics/bystro-vcf v0.0.0-20240425204515-a3bed256638d h1:Y3qdBlf9Q1DJfGFP47GNwU7ytJklAqpuxgoapAs4U80=
+github.com/bystrogenomics/bystro-vcf v0.0.0-20240425204515-a3bed256638d/go.mod h1:ssLIZJL1hUm8xIFZO33X2Mp0b3Ju7oJ2liBW0Qov0KQ=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.10.0-rc/go.mod h1:ElCzW+ufi8qKqNW0FY314xriJhyJhuoJ3gFZdAHF7NM=
 github.com/bytedance/sonic v1.10.2 h1:GQebETVBxYB7JGWJtLBi07OVzWwt+8dWA00gEVW2ZFE=

--- a/install/install-go-packages.sh
+++ b/install/install-go-packages.sh
@@ -8,7 +8,7 @@ go mod init bystro
 
 go install github.com/akotlar/bystro-stats@1.0.0;
 
-go install github.com/bystrogenomics/bystro-vcf@2.2.1;
+go install github.com/bystrogenomics/bystro-vcf@2.2.2;
 
 go install github.com/akotlar/bystro-snp@1.0.0;
 

--- a/perl/Dockerfile
+++ b/perl/Dockerfile
@@ -6,7 +6,7 @@ ENV GOBIN=/app/bin
 
 # Install the specific versions of the Go programs
 RUN go install github.com/akotlar/bystro-stats@1.0.0
-RUN go install github.com/bystrogenomics/bystro-vcf@2.2.1
+RUN go install github.com/bystrogenomics/bystro-vcf@2.2.2
 RUN go install github.com/akotlar/bystro-snp@1.0.0
 RUN go install github.com/mikefarah/yq@2.4.1
 

--- a/python/python/bystro/search/save/handler.py
+++ b/python/python/bystro/search/save/handler.py
@@ -409,7 +409,7 @@ def filter_annotation(
             p.wait()
             stats_fh.wait()
 
-            reporter.message.remote(f"Annotation: Completed filtering of {i} variants.")  # type: ignore
+            reporter.message.remote("Annotation: Completed filtering.")  # type: ignore
 
     reporter.message.remote(f"Annotation: {n_retained} variants survived filtering.")  # type: ignore
 


### PR DESCRIPTION
* Add back support for nulls
* Change final message about annotation filtering to reflect the fact that we don't actually know the total number of rows, since we only read the file once.