### PR TITLE
Feature/no null dosage

### DIFF
--- a/python/python/bystro/ancestry/inference.py
+++ b/python/python/bystro/ancestry/inference.py
@@ -273,7 +273,7 @@ def infer_ancestry(ancestry_models: AncestryModels, genotypes: Dataset) -> Ances
                 )
                 genotypes_df = pd.concat([genotypes_df, missing_rows_df])
 
-            genotypes_df[genotypes_df.isna()] = 1
+            genotypes_df[genotypes_df.isna() | (genotypes_df < 0)] = 1
 
             pcs_for_plotting, pop_probs_df = ancestry_model.predict_proba(genotypes_df)
 


### PR DESCRIPTION
* This saves considerable memory by 1) avoid the missingness bit mask, 2) avoiding the forced conversion in pandas to float64 when nulls (interpreted as nans) are encountered.

This PR assumes https://github.com/bystrogenomics/bystro-vcf/pull/22 is merged