### PR TITLE
[annotation] Add isCanonical transcript annotation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,47 +95,41 @@ Once Bystro is installed, it needs to be configured. The easiest step is choosin
 
 1. Download the Bystro database for your species/assembly
 
-- **Example:** hg38 (human reference GRCh38): `wget https://s3.amazonaws.com/bystro-db/hg38.tar.gz`</strong>
-  - You need ~270GB of free space for human and mouse databases (less for all other species by at least half)
-  - Databases are ~4.5x their compressed size when unpacked
+- **Example:** hg38 (human reference GRCh38): `wget https://s3.amazonaws.com/bystro-db/hg38_v7.tar.gz`</strong>
+  - You need ~700GB of free space for hg38 and  ~400GB of free space for hg19, including the space for the tar.gz archives
 
-The downloaded databases are tar balls, in which the database files that Bystro needs to access are located in `<assembly>/index`
-
-2. Expand within some folder:
+2. To install the database:
 
    **Example:**
 
    ```shell
-   pigz -d -c hg38.tar.gz | (cd /where/to/ && tar xvf -)
+   cd /mnt/annotator/
+   wget https://s3.amazonaws.com/bystro-db/hg38_v7.tar.gz
+   bgzip -d -c --threads 32 hg38_v7.tar.gz | tar xvf -
    ```
 
-   In this example the hg38 database would located in `/where/to/hg38/index`
+   In this example the hg38 database would located in `/mnt/annotator/hg38`
 
-3. Create a copy of the assembly config YAML file, and update its `database_dir` property to point to `index` folder
+3. Update the YAML configuration for the species/assembly to point to the database.
 
-   - Since in our downloaded tarballs, the database is within a folder called `index`
+   For human genome assemblies, we provide pre-configured hg19.yml and hg38.yml, which assume `/mnt/annotator/hg19_v9` and `/mnt/annotator/hg38_v7` database directories respectively.
 
-   **Example:**
+   If using a different mount point, different database folder name, or a different (or custom-built) database altogether,
+   you will need to update the `database_dir` property of the yaml config.
+     - Note for a custom database, you would also need to ensure the track `outputOrder` lists all tracks, and that each track has all desired `features` listed
+
+   For instance, using `yq` to can configure the `database_dir` and set `temp_dir` to have in-progress annotations written to local disk
 
    ```shell
-   cp config/hg38.clean.yml config/hg38.yml;
-   yq write -i config/hg38.yml database_dir /mnt/annotator/hg38/index
-   yq write -i config/hg38.yml temp_dir /mnt/annotator/tmp
+   yq write -i config/hg38.yml database_dir /mnt/my_fast_local_storage/hg38_v7
+   yq write -i config/hg38.yml temp_dir /mnt/my_fast_local_storage/tmp
    ```
-
-   The config file editing could of course be also done using vim/nano/vi/emacs
 
 ## Databases:
 
-1. Human (hg38): https://s3.amazonaws.com/bystro-db/hg38.tar.gz
-2. Human (hg19): https://s3.amazonaws.com/bystro-db/hg19.tar.gz
-3. Mouse (mm10): https://s3.amazonaws.com/bystro-db/mm10.tar.gz
-4. Mouse (mm9): https://s3.amazonaws.com/bystro-db/mm9.tar.gz
-5. Fly (dm6): https://s3.amazonaws.com/bystro-db/dm6.tar.gz
-6. Rat (rn6): https://s3.amazonaws.com/bystro-db/rn6.tar.gz
-7. Rhesus (rheMac8): https://s3.amazonaws.com/bystro-db/rheMac8.tar.gz
-8. S.cerevisae (sacCer3): https://s3.amazonaws.com/bystro-db/sacCer3.tar.gz
-9. C.elegans (ce11): https://s3.amazonaws.com/bystro-db/ce11.tar.gz
+1. Human (hg38): https://s3.amazonaws.com/bystro-db/hg38_v7.tar.gz
+2. Human (hg19): https://s3.amazonaws.com/bystro-db/hg19_v9.tar.gz
+3. There are no restrictions on species support, but we currently only build human genomes. Please create a GitHub issue if you would like us to support others.
 
 ## Running your first annotation
 

--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -387,6 +387,8 @@ mappings:
         name:
           type: keyword
           normalizer: uppercase_normalizer
+        isCanonical:
+          type: boolean
     nearest:
       properties:
         refSeq:

--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -701,3 +701,7 @@ mappings:
               type: integer
             AF_eas_kor:
               type: half_float
+            controls_AN:
+              type: integer
+            controls_AF:
+              type: half_float

--- a/config/hg19.yml
+++ b/config/hg19.yml
@@ -28,7 +28,7 @@ chromosomes:
   - chrM
   - chrX
   - chrY
-database_dir: /mnt/annotator/hg19_v9
+database_dir: /mnt/ssd2/annotator/hg19_v9
 fileProcessors:
   snp:
     args: --emptyField NA --minGq .95
@@ -189,10 +189,10 @@ tracks:
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.tRnaName, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS tRnaName,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spDisplayID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spDisplayID,
-                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.protAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(rl.protAcc, '') SEPARATOR ';') FROM hgFixed.refLink rl WHERE rl.mrnaAcc=r.name) AS protAcc,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.mRNA, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS mRNA,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.rfamAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc,
-                  CASE WHEN k.transcript IS NOT NULL THEN 'TRUE' ELSE 'FALSE' END AS isCanonical
+                  CASE WHEN k.transcript IS NOT NULL THEN 'true' ELSE 'false' END AS isCanonical
               FROM
                   refGene r
               LEFT JOIN
@@ -200,8 +200,8 @@ tracks:
               LEFT JOIN
                   knownCanonical k ON k.transcript = x.kgID
               WHERE
-                  r.chrom = %chromosomes%;
-          completed: 2023-11-09T20:18:00
+                  r.chrom = %chromosomes%
+          completed: 2024-05-02T01:01:00
           name: fetch
       version: 4
     - build_author: alexkotlar
@@ -397,31 +397,31 @@ tracks:
         - Qatari: number
         - MGP: number
       local_files:
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.1.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.2.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.3.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.4.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.5.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.6.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.7.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.8.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.9.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.10.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.11.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.12.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.13.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.14.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.15.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.16.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.17.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.18.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.19.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.20.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.21.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.22.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.X.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.Y.vcf.gz
-        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155_processed.vcf.MT.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.1_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.2_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.3_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.4_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.5_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.6_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.7_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.8_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.9_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.10_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.11_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.12_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.13_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.14_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.15_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.16_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.17_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.18_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.19_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.20_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.21_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.22_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.X_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.Y_processed.vcf.gz
+        - /mnt/files1/bystro_annotator/raw_files/hg19/dbSNP/GRCh37.dbSNP155.vcf.MT_processed.vcf.gz
       name: dbSNP
       type: vcf
       utils:
@@ -461,7 +461,7 @@ tracks:
         - args:
             remoteFiles:
               - https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz
-          completed: 2024-03-07T12:50:00
+          completed: 2024-05-02T01:02:00
           name: fetch
       version: 4
     - build_author: alexkotlar

--- a/config/hg19.yml
+++ b/config/hg19.yml
@@ -191,7 +191,7 @@ tracks:
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.protAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.mRNA, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS mRNA,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.rfamAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc,
-                  CASE WHEN k.transcript IS NOT NULL THEN TRUE ELSE FALSE END AS IsCanonical
+                  CASE WHEN k.transcript IS NOT NULL THEN 'TRUE' ELSE 'FALSE' END AS isCanonical
               FROM
                   refGene r
               LEFT JOIN

--- a/config/hg19.yml
+++ b/config/hg19.yml
@@ -147,6 +147,7 @@ tracks:
         - rfamAcc
         - tRnaName
         - ensemblID
+        - isCanonical
       local_files:
         - hg19.kgXref.chr1.gz
         - hg19.kgXref.chr2.gz

--- a/config/hg19.yml
+++ b/config/hg19.yml
@@ -28,7 +28,7 @@ chromosomes:
   - chrM
   - chrX
   - chrY
-database_dir: /mnt/annotator/hg19_v8
+database_dir: /mnt/annotator/hg19_v9
 fileProcessors:
   snp:
     args: --emptyField NA --minGq .95

--- a/config/hg19.yml
+++ b/config/hg19.yml
@@ -179,22 +179,27 @@ tracks:
         - args:
             connection:
               database: hg19
-            sql:
-              SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
-              ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
-              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
-              e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
-              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
-              kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
-              GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
-              x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
-              GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
-              x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
-              refGene r WHERE chrom=%chromosomes%;
+            sql: |
+              SELECT
+                  r.*,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.kgID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.description, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(e.value, '') SEPARATOR ';') FROM knownToEnsembl e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.tRnaName, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS tRnaName,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spDisplayID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spDisplayID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.protAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.mRNA, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS mRNA,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.rfamAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc,
+                  CASE WHEN k.transcript IS NOT NULL THEN TRUE ELSE FALSE END AS IsCanonical
+              FROM
+                  refGene r
+              LEFT JOIN
+                  kgXref x ON x.refseq = r.name
+              LEFT JOIN
+                  knownCanonical k ON k.transcript = x.kgID
+              WHERE
+                  r.chrom = %chromosomes%;
           completed: 2023-11-09T20:18:00
           name: fetch
       version: 4

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -387,6 +387,8 @@ mappings:
         name:
           type: keyword
           normalizer: uppercase_normalizer
+        isCanonical:
+          type: boolean
     nearest:
       properties:
         refSeq:

--- a/config/hg38.yml
+++ b/config/hg38.yml
@@ -191,7 +191,7 @@ tracks:
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.protAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.mRNA, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS mRNA,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.rfamAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc,
-                  CASE WHEN k.transcript IS NOT NULL THEN TRUE ELSE FALSE END AS IsCanonical
+                  CASE WHEN k.transcript IS NOT NULL THEN 'TRUE' ELSE 'FALSE' END AS isCanonical
               FROM
                   refGene r
               LEFT JOIN

--- a/config/hg38.yml
+++ b/config/hg38.yml
@@ -28,7 +28,7 @@ chromosomes:
   - chrM
   - chrX
   - chrY
-database_dir: /mnt/annotator/hg38_v4
+database_dir: /mnt/annotator/hg38_v5
 fileProcessors:
   snp:
     args: --emptyField NA --minGq .95
@@ -36,7 +36,7 @@ fileProcessors:
   vcf:
     args: --emptyField NA --sample %sampleList% --keepPos --keepId --dosageOutput %dosageMatrixOutPath%
     program: bystro-vcf
-files_dir: null
+files_dir: /mnt/files1/bystro_annotator/raw_files/hg38
 statistics:
   dbSNPnameField: dbSNP.name
   exonicAlleleFunctionField: refSeq.exonicAlleleFunction
@@ -179,22 +179,27 @@ tracks:
         - args:
             connection:
               database: hg38
-            sql:
-              SELECT r.*, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.kgID, '')) SEPARATOR
-              ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.description,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
-              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(e.value, '')) SEPARATOR ';') FROM knownToEnsembl
-              e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
-              (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.tRnaName, '')) SEPARATOR ';') FROM
-              kgXref x WHERE x.refseq=r.name) AS tRnaName, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.spID,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID, (SELECT
-              GROUP_CONCAT(DISTINCT(NULLIF(x.spDisplayID, '')) SEPARATOR ';') FROM kgXref
-              x WHERE x.refseq=r.name) AS spDisplayID, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.protAcc,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc, (SELECT
-              GROUP_CONCAT(DISTINCT(NULLIF(x.mRNA, '')) SEPARATOR ';') FROM kgXref x WHERE
-              x.refseq=r.name) AS mRNA, (SELECT GROUP_CONCAT(DISTINCT(NULLIF(x.rfamAcc,
-              '')) SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc FROM
-              refGene r WHERE chrom=%chromosomes%;
+            sql: |
+              SELECT
+                  r.*,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.kgID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS kgID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.description, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS description,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(e.value, '') SEPARATOR ';') FROM knownToEnsembl e JOIN kgXref x ON x.kgID = e.name WHERE x.refseq = r.name) AS ensemblID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.tRnaName, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS tRnaName,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spDisplayID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spDisplayID,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.protAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.mRNA, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS mRNA,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.rfamAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc,
+                  CASE WHEN k.transcript IS NOT NULL THEN TRUE ELSE FALSE END AS IsCanonical
+              FROM
+                  refGene r
+              LEFT JOIN
+                  kgXref x ON x.refseq = r.name
+              LEFT JOIN
+                  knownCanonical k ON k.transcript = x.kgID
+              WHERE
+                  r.chrom = %chromosomes%;
           completed: 2024-03-10T18:58:00
           name: fetch
       version: 34

--- a/config/hg38.yml
+++ b/config/hg38.yml
@@ -200,8 +200,6 @@ tracks:
               LEFT JOIN
                   kgXref x ON x.refseq = r.name
               LEFT JOIN
-                  hgFixed.refLink rl ON rl.mrnaAcc = r.name
-              LEFT JOIN
                   knownCanonical k ON k.transcript = x.kgID
               WHERE
                   r.chrom = %chromosomes%

--- a/config/hg38.yml
+++ b/config/hg38.yml
@@ -1,7 +1,7 @@
 ---
 assembly: hg38
 build_author: alexkotlar
-build_date: 2024-03-11T12:24:00
+build_date: 2024-05-01T01:58:00
 chromosomes:
   - chr1
   - chr2
@@ -28,13 +28,15 @@ chromosomes:
   - chrM
   - chrX
   - chrY
-database_dir: /mnt/annotator/hg38_v5
+database_dir: /mnt/annotator/hg38_v7
 fileProcessors:
   snp:
     args: --emptyField NA --minGq .95
     program: bystro-snp
   vcf:
-    args: --emptyField NA --sample %sampleList% --keepPos --keepId --dosageOutput %dosageMatrixOutPath%
+    args:
+      --emptyField NA --sample %sampleList% --keepPos --keepId --dosageOutput
+      %dosageMatrixOutPath%
     program: bystro-vcf
 files_dir: /mnt/files1/bystro_annotator/raw_files/hg38
 statistics:
@@ -62,7 +64,7 @@ tracks:
     - clinvarVcf
   tracks:
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       local_files:
         - chr1.fa.gz
         - chr2.fa.gz
@@ -122,9 +124,9 @@ tracks:
               - chrM.fa.gz
           completed: 2024-03-11T12:19:00
           name: fetch
-      version: 34
+      version: 36
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       build_field_transformations:
         description: split [;]
         ensemblID: split [;]
@@ -189,23 +191,25 @@ tracks:
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.tRnaName, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS tRnaName,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spID,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.spDisplayID, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS spDisplayID,
-                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.protAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS protAcc,
+                  (SELECT GROUP_CONCAT(DISTINCT NULLIF(rl.protAcc, '') SEPARATOR ';') FROM hgFixed.refLink rl WHERE rl.mrnaAcc=r.name) AS protAcc,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.mRNA, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS mRNA,
                   (SELECT GROUP_CONCAT(DISTINCT NULLIF(x.rfamAcc, '') SEPARATOR ';') FROM kgXref x WHERE x.refseq=r.name) AS rfamAcc,
-                  CASE WHEN k.transcript IS NOT NULL THEN 'TRUE' ELSE 'FALSE' END AS isCanonical
+                  CASE WHEN k.transcript IS NOT NULL THEN 'true' ELSE 'false' END AS isCanonical
               FROM
                   refGene r
               LEFT JOIN
                   kgXref x ON x.refseq = r.name
               LEFT JOIN
+                  hgFixed.refLink rl ON rl.mrnaAcc = r.name
+              LEFT JOIN
                   knownCanonical k ON k.transcript = x.kgID
               WHERE
-                  r.chrom = %chromosomes%;
-          completed: 2024-03-10T18:58:00
+                  r.chrom = %chromosomes%
+          completed: 2024-04-30T01:28:00
           name: fetch
-      version: 34
+      version: 36
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       features:
         - alt
         - id
@@ -320,7 +324,7 @@ tracks:
               - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/exomes/gnomad.exomes.v4.0.sites.chrY.vcf.bgz
           completed: 2024-03-07T14:23:00
           name: fetch
-      version: 29
+      version: 31
     - based: 1
       build_author: alexkotlar
       build_date: 2023-09-20T00:17:00
@@ -370,7 +374,7 @@ tracks:
           name: fetch
       version: 24
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       local_files:
         - whole_genome_SNVs.tsv.chr1.organized-by-chr.txt.sorted.txt.gz
         - whole_genome_SNVs.tsv.chr10.organized-by-chr.txt.sorted.txt.gz
@@ -402,9 +406,9 @@ tracks:
       utils:
         - completed: 2023-09-09T11:18:00
           name: SortCadd
-      version: 4
+      version: 6
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       features:
         - alt
         - PHRED: number
@@ -412,9 +416,9 @@ tracks:
         - /mnt/files1/bystro_annotator/raw_files/hg38/caddIndel/gnomad.genomes.r4.0.indel.vcf.gz
       name: caddIndel
       type: vcf
-      version: 6
+      version: 8
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       dist: true
       features:
         - name2
@@ -424,9 +428,9 @@ tracks:
       ref: refSeq
       to: txEnd
       type: nearest
-      version: 9
+      version: 11
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       dist: true
       features:
         - name2
@@ -435,9 +439,9 @@ tracks:
       name: nearestTss.refSeq
       ref: refSeq
       type: nearest
-      version: 4
+      version: 6
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       features:
         - alt
         - id
@@ -558,9 +562,9 @@ tracks:
               - https://gnomad-public-us-east-1.s3.amazonaws.com/release/4.0/vcf/genomes/gnomad.genomes.v4.0.sites.chrY.vcf.bgz
           completed: 2024-03-07T15:59:00
           name: fetch
-      version: 27
+      version: 29
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       features:
         - id
         - alt
@@ -617,9 +621,9 @@ tracks:
       utils:
         - completed: 2024-03-10T16:30:00
           name: DbSnp2FormatInfo
-      version: 6
+      version: 8
     - build_author: alexkotlar
-      build_date: 2024-03-11T12:24:00
+      build_date: 2024-05-01T01:58:00
       build_field_transformations:
         CLNDN: split [|]
         CLNSIGCONF: split [|]
@@ -652,5 +656,5 @@ tracks:
               - https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz
           completed: 2024-03-07T22:09:00
           name: fetch
-      version: 2
-version: 229
+      version: 4
+version: 231

--- a/config/hg38.yml
+++ b/config/hg38.yml
@@ -147,6 +147,7 @@ tracks:
         - rfamAcc
         - tRnaName
         - ensemblID
+        - isCanonical
       local_files:
         - hg38.kgXref.chr1.gz
         - hg38.kgXref.chr2.gz

--- a/perl/bin/bystro-build.pl
+++ b/perl/bin/bystro-build.pl
@@ -38,7 +38,7 @@ GetOptions(
   'skipCompletionCheck|skip_completion_check' => \$skipCompletionCheck,
   'dry_run_insertions|dry|dryRun'             => \$dryRunInsertions,
   'log_dir=s'                                 => \$logDir,
-  'maxThreads=i'                              => \$maxThreads,
+  'threads=i'                                 => \$maxThreads,
   'meta_only'                                 => \$metaOnly,
 );
 
@@ -76,7 +76,6 @@ if ($debug) {
 
 # read config file to determine genome name for log and check validity
 my $config_href = LoadFile($yaml_config);
-
 # get absolute path for YAML file and db_location
 $yaml_config = path($yaml_config)->absolute->stringify;
 


### PR DESCRIPTION
* Creates isCanonical transcript feature, which will be outputted as 'TRUE' or 'FALSE' depending on whether there is a matching UCSC knownCanonical feature


We output 'TRUE', 'FALSE' here instead of 1/0, because pandas, polars (the most popular data science libraries in python), R standard dataframe library, and opensearch will interpret this as the boolean True, or False. We also use TRUE, FALSE for discordant for similar reasons. In the case of refSeq this isn't as useful because we often have multiple transcripts, so I'm open to going back to using 0/1.