### PR TITLE
Incorporated basic shrinkage to adversarial model

### DIFF
--- a/python/python/bystro/supervised_ppca/ppca_adversarial.py
+++ b/python/python/bystro/supervised_ppca/ppca_adversarial.py
@@ -11,7 +11,6 @@ latent variables. Two key parameters, 'mu' and 'eps', control the strength
 of the adversarial component and the conditioning of inverses, 
 respectively, enhancing the robustness and stability of the model.
 """
-from typing import Union
 import numpy as np
 import numpy.linalg as la
 
@@ -106,9 +105,7 @@ class PPCAadversarial(BaseGaussianFactorModel):
         p = self.p
         q = Y.shape[1]
 
-        model_cov: Union[
-            LinearShrinkageCovariance, NonLinearShrinkageCovariance
-        ]
+        model_cov: LinearShrinkageCovariance | NonLinearShrinkageCovariance
         if regularization_options["method"] == "Empirical":
             B_11 = X_dm.T @ X_dm
             B_12 = X_dm.T @ Y_dm

--- a/python/python/bystro/supervised_ppca/ppca_adversarial.py
+++ b/python/python/bystro/supervised_ppca/ppca_adversarial.py
@@ -115,7 +115,6 @@ class PPCAadversarial(BaseGaussianFactorModel):
             diag_reg = self.eps * np.eye(X_dm.shape[1])
             XtX = X_dm.T @ X_dm + diag_reg
             B_22 = B_12.T @ la.solve(XtX, B_12)
-
         elif regularization_options["method"] == "NonLinearShrinkage":
             if q == 1:
                 XX = np.zeros((N, p + 1))

--- a/python/python/bystro/supervised_ppca/tests/test_adversarial.py
+++ b/python/python/bystro/supervised_ppca/tests/test_adversarial.py
@@ -35,7 +35,8 @@ def test_fit():
 
     Y = S[:, 0].reshape((-1, 1))
 
-    pca_model = PPCAadversarial(n_components=2, mu=10000.0)
+    reg_ops = {"method":"Empirical"}
+    pca_model = PPCAadversarial(n_components=2, mu=10000.0,regularization_options=reg_ops)
     pca_model.fit(X, Y)
 
     assert pca_model.W_ is not None, "W_ should be set after fitting."
@@ -45,3 +46,12 @@ def test_fit():
     # sensitive information.
     assert np.abs(cosine_similarity(pca_model.W_[0], W[0])) < 0.1
     assert np.abs(cosine_similarity(pca_model.W_[1], W[0])) < 0.1
+
+    reg_ops = {"method":"LinearShrinkage"}
+    pca_model = PPCAadversarial(n_components=2, mu=10000.0,regularization_options=reg_ops)
+    pca_model.fit(X, Y)
+
+    reg_ops = {"method":"NonLinearShrinkage"}
+    pca_model = PPCAadversarial(n_components=2, mu=10000.0,regularization_options=reg_ops)
+    pca_model.fit(X, Y)
+


### PR DESCRIPTION
This adds regularization into the basic adversarial model. This allows for it to effectively learn latent representations with smaller sample sizes, important in many of our applications.