### PR TITLE
[search] Add back autocomplete to CLNSIG

### DIFF
--- a/config/hg19.mapping.yml
+++ b/config/hg19.mapping.yml
@@ -129,14 +129,6 @@ index_settings:
           - catenate_filter_split
           - english_stemmer
           - autocomplete_filter
-      autocomplete_english_split_clinsig:
-        type: custom
-        tokenizer: whitespace
-        filter:
-          - lowercase
-          - exclude_pathogenic
-          - asciifolding
-          - catenate_filter_split
       autocomplete_english_graph:
         type: custom
         tokenizer: keyword
@@ -450,7 +442,7 @@ mappings:
           normalizer: lowercase_normalizer
         CLNSIG:
           type: text
-          analyzer: autocomplete_english_split_clinsig
+          analyzer: autocomplete_english_split
           search_analyzer: search_english_simple
           fields:
             exact:

--- a/config/hg38.mapping.yml
+++ b/config/hg38.mapping.yml
@@ -129,14 +129,6 @@ index_settings:
           - catenate_filter_split
           - english_stemmer
           - autocomplete_filter
-      autocomplete_english_split_clinsig:
-        type: custom
-        tokenizer: whitespace
-        filter:
-          - lowercase
-          - exclude_pathogenic
-          - asciifolding
-          - catenate_filter_split
       autocomplete_english_graph:
         type: custom
         tokenizer: keyword
@@ -450,7 +442,7 @@ mappings:
           normalizer: lowercase_normalizer
         CLNSIG:
           type: text
-          analyzer: autocomplete_english_split_clinsig
+          analyzer: autocomplete_english_split
           search_analyzer: search_english_simple
           fields:
             exact:


### PR DESCRIPTION
* CLNSIG currently does not use an autocomplete filter, which means "patho" will not match any terms in CLNSIG. With this change "patho" and "pathogenic" will both match `pathogenic` and `likely_pathogenic`. While this slightly decreases specificity (because it now matches "likely_pathogenic", that can always be added back using quotes: "pathogenic"