### PR TITLE
Update hg19.yml database_dir to match documentation

### DIFF
--- a/config/hg19.yml
+++ b/config/hg19.yml
@@ -28,7 +28,7 @@ chromosomes:
   - chrM
   - chrX
   - chrY
-database_dir: /mnt/ssd2/annotator/hg19_v9
+database_dir: /mnt/annotator/hg19_v9
 fileProcessors:
   snp:
     args: --emptyField NA --minGq .95


### PR DESCRIPTION
* hg19.yml database_dir should be /mnt/annotator/hg19_v9 to match documentation