### PR TITLE
fix install to reflect the fact that we're still using beta tags

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ Bystro consists of 2 main components:
 To install the Bystro Python package, run:
 
 ```sh
-pip install bystro
+pip install --pre bystro
 ```
 
 The Bystro ancestry CLI `score` tool (`bystro-api ancestry score`) parses VCF files to generate dosage matrices. This requires `bystro-vcf`, a Go program which can be installed with:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Bystro Python package also gives the ability to launch workers to process jo
 To install the Bystro Python package, run:
 
 ```sh
-pip install bystro
+pip install --pre bystro
 ```
 
 The Bystro ancestry CLI `score` tool (`bystro-api ancestry score`) parses VCF files to generate dosage matrices. This requires `bystro-vcf`, a Go program which can be installed with:


### PR DESCRIPTION
* We need to use --pre to install pip packages with beta tags. While we will release a production Bystro 2.0 this summer, we are not there yet, so we need to use --pre.