### PR TITLE
Add adjustable p value thresholds for PRS C+T.

### DIFF
--- a/python/python/bystro/prs/preprocess_for_prs.py
+++ b/python/python/bystro/prs/preprocess_for_prs.py
@@ -173,20 +173,18 @@ def read_feather_in_chunks(file_path, columns=None, chunk_size=1000):
         yield chunk
 
 
-def get_p_value_thresholded_indices(df, p_value_threshold):
+def get_p_value_thresholded_indices(df, p_value_threshold: float):
     """Return indices of rows with P-values less than the specified threshold."""
     return df.index[df["P"] < p_value_threshold].tolist()
 
 
 def generate_thresholded_overlap_scores_dosage(
-    gwas_scores_path: str, dosage_matrix_path: str
+    gwas_scores_path: str, dosage_matrix_path: str, p_value_threshold: float
 ) -> pd.DataFrame:
     """Compare and restrict to overlapping loci between dosage matrix and thresholded scores."""
     scores = _preprocess_scores(gwas_scores_path)
     dosage_loci_nomiss = _extract_nomiss_dosage_loci(dosage_matrix_path)
 
-    # TODO: Add customizable p value threshold and option for multiple thresholds
-    p_value_threshold = 0.05
     thresholded_indices_set = set()
     for chunk in read_feather_in_chunks(gwas_scores_path, columns=["P"], chunk_size=1000):
         thresholded_indices = get_p_value_thresholded_indices(chunk, p_value_threshold)
@@ -281,11 +279,9 @@ def clean_scores_for_analysis(
     scores_overlap_adjusted = max_effect_per_bin.drop(columns=["bin", "abs_effect_weight"])
     scores_overlap_adjusted = scores_overlap_adjusted.set_index("SNPID")
     format_col_index = scores_overlap_adjusted.columns.get_loc(column_to_drop)
-
     # If there is more than 1 column found, our "columns_to_keep" function will not work
     if not isinstance(format_col_index, int):
         raise ValueError(f"Column {column_to_drop} was not found uniquely in the dataframe.")
-
     columns_to_keep = ["allele_comparison"] + list(
         scores_overlap_adjusted.columns[format_col_index + 1 :]
     )
@@ -319,10 +315,12 @@ def extract_clumped_thresholded_genos(
 
 
 def finalize_dosage_scores_after_c_t(
-    gwas_scores_path: str, dosage_matrix_path: str, map_directory_path: str
+    gwas_scores_path: str, dosage_matrix_path: str, map_directory_path: str, p_value_threshold: float
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Finalize dosage matrix and scores for PRS calculation."""
-    scores_overlap = generate_thresholded_overlap_scores_dosage(gwas_scores_path, dosage_matrix_path)
+    scores_overlap = generate_thresholded_overlap_scores_dosage(
+        gwas_scores_path, dosage_matrix_path, p_value_threshold
+    )
     scores_after_c_t, loci_and_allele_comparison = ld_clump(scores_overlap, map_directory_path)
     dosage_overlap = extract_clumped_thresholded_genos(dosage_matrix_path, scores_after_c_t)
     dosage_overlap = dosage_overlap.set_index("locus")
@@ -336,12 +334,15 @@ def finalize_dosage_scores_after_c_t(
 
 
 def generate_c_and_t_prs_scores(
-    gwas_scores_path: str, dosage_matrix_path: str, map_directory_path: str
+    gwas_scores_path: str,
+    dosage_matrix_path: str,
+    map_directory_path: str,
+    p_value_threshold: float = 0.05,
 ) -> pd.Series:
     """Calculate PRS."""
     # TODO: Add covariates to model
     genos_transpose, scores_after_c_t = finalize_dosage_scores_after_c_t(
-        gwas_scores_path, dosage_matrix_path, map_directory_path
+        gwas_scores_path, dosage_matrix_path, map_directory_path, p_value_threshold
     )
     return genos_transpose @ scores_after_c_t["BETA"]
 

--- a/python/python/bystro/prs/preprocess_for_prs.py
+++ b/python/python/bystro/prs/preprocess_for_prs.py
@@ -175,6 +175,8 @@ def read_feather_in_chunks(file_path, columns=None, chunk_size=1000):
 
 def get_p_value_thresholded_indices(df, p_value_threshold: float):
     """Return indices of rows with P-values less than the specified threshold."""
+    if not (0 <= p_value_threshold <= 1):
+        raise ValueError("p_value_threshold must be between 0 and 1")
     return df.index[df["P"] < p_value_threshold].tolist()
 
 

--- a/python/python/bystro/prs/tests/test_preprocess_for_prs.py
+++ b/python/python/bystro/prs/tests/test_preprocess_for_prs.py
@@ -28,7 +28,7 @@ def mock_scores_df() -> pd.DataFrame:
             "POS": [566875, 728951],
             "OTHER_ALLELE": ["C", "G"],
             "EFFECT_ALLELE": ["T", "A"],
-            "P": [0.699009, 0.030673],
+            "P": [0.699009, 0.0030673],
             "BETA": [0.007630, -0.020671],
         }
     )
@@ -41,7 +41,7 @@ def mock_processed_scores_df() -> pd.DataFrame:
         "POS": [566875, 728951],
         "OTHER_ALLELE": ["C", "G"],
         "EFFECT_ALLELE": ["T", "A"],
-        "P": [0.699009, 0.030673],
+        "P": [0.699009, 0.0030673],
         "SNPID": ["1:566875:C:T", "1:728951:A:G"],
         "BETA": [0.007630, -0.020671],
         "ID_effect_as_alt": ["chr1:566875:C:T", "chr1:728951:G:A"],
@@ -172,12 +172,12 @@ def test_preprocess_scores(mock_load_association_scores, mock_scores_df: pd.Data
 
 
 def test_get_p_value_thresholded_indices(mock_processed_scores_df: pd.DataFrame):
-    p_value_threshold = 0.05
+    p_value_threshold = 0.005
     thresholded_indices = get_p_value_thresholded_indices(mock_processed_scores_df, p_value_threshold)
     filtered_scores = mock_processed_scores_df.loc[thresholded_indices]
     assert (
         len(filtered_scores) == 1
-    ), "Filtered scores should only contain 1 row for p_value_threshold=0.05."
+    ), "Filtered scores should only contain 1 row for p_value_threshold=0.005."
     assert all(
         filtered_scores["P"] < p_value_threshold
     ), "All rows should have P-values less than the threshold."


### PR DESCRIPTION
Previously, the p-value threshold was hardcoded for early testing. Now it can take in p-value thresholds as floats between 0 and 1. 