### PR TITLE
[api, proteomics] Proxy OpenSearch Requests

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "cvxpy==1.5.0",
     "somadata==1.0.0",
     "statsmodels==0.14.2",
+    "nest-asyncio==1.6.0",
 ]
 
 [tool.maturin]

--- a/python/python/bystro/api/search.py
+++ b/python/python/bystro/api/search.py
@@ -212,7 +212,6 @@ def get_async_proxied_opensearch_client(auth: CachedAuth, job_id: str, client_ar
 
     # Initialize OpenSearch client with custom connection class
 
-    print(client_args)
     client = AsyncOpenSearch(
         hosts=[{"host": host, "port": int(port)}],
         use_ssl=bool(protocol == "https" or int(port) == 443),

--- a/python/python/bystro/api/search.py
+++ b/python/python/bystro/api/search.py
@@ -5,7 +5,7 @@ from opensearchpy import OpenSearch, RequestsHttpConnection, AsyncOpenSearch, As
 
 from bystro.api.auth import CachedAuth
 
-QUERY_ENDPONIT = "/api/jobs/{job_id}/opensearch"
+QUERY_ENDPOINT = "/api/jobs/{job_id}/opensearch"
 
 
 class JWTAuth(AuthBase):
@@ -216,7 +216,7 @@ def get_async_proxied_opensearch_client(auth: CachedAuth, job_id: str, client_ar
         hosts=[{"host": host, "port": int(port)}],
         use_ssl=bool(protocol == "https" or int(port) == 443),
         connection_class=BystroProxyAsyncHttpConnection,
-        path_prefix=QUERY_ENDPONIT.format(job_id=job_id),
+        path_prefix=QUERY_ENDPOINT.format(job_id=job_id),
         http_auth=AsyncConnectorJWTAuth(auth.access_token),
         http_compress=True,
         timeout=client_args.get("timeout", 1200),
@@ -254,7 +254,7 @@ def get_proxied_opensearch_client(auth: CachedAuth, job_id: str, client_args: di
         hosts=[{"host": host, "port": int(port)}],
         use_ssl=bool(protocol == "https" or int(port) == 443),
         connection_class=BystroProxyHttpConnection,
-        path_prefix=QUERY_ENDPONIT.format(job_id=job_id),
+        path_prefix=QUERY_ENDPOINT.format(job_id=job_id),
         http_auth=JWTAuth(auth.access_token),
         http_compress=True,
         timeout=client_args.get("timeout", 1200),

--- a/python/python/bystro/api/search.py
+++ b/python/python/bystro/api/search.py
@@ -1,0 +1,265 @@
+from typing import Optional, Mapping, Any, Union, Collection
+from requests.auth import AuthBase
+
+from opensearchpy import OpenSearch, RequestsHttpConnection, AsyncOpenSearch, AsyncHttpConnection
+
+from bystro.api.auth import CachedAuth
+
+QUERY_ENDPONIT = "/api/jobs/{job_id}/opensearch"
+
+
+class JWTAuth(AuthBase):
+    """
+    A class that provides the JWT authentication for the OpenSearch connection.
+
+    Parameters
+    ----------
+    token : str
+        The JWT token.
+
+    Attributes
+    ----------
+    token : str
+        The JWT token.
+
+    Methods
+    -------
+    __call__(r, *args, **kwargs)
+        Add the Authorization header to the request.
+    """
+
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r, *_args, **_kwargs):
+        r.headers["Authorization"] = f"Bearer {self.token}"
+        return r
+
+
+class BystroProxyHttpConnection(RequestsHttpConnection):
+    """
+    A class that provides the HTTP connection to the OpenSearch server.
+
+    Parameters
+    ----------
+    path_prefix : str
+        The path prefix to use when connecting to the OpenSearch server.
+
+    Attributes
+    ----------
+    path_prefix : str
+        The path prefix to use when connecting to the OpenSearch server.
+
+    Methods
+    -------
+    perform_request(method, path, params=None, body=None,
+                    headers=None, timeout=None, ignore=(), **kwargs)
+        Perform a request to the OpenSearch server.
+    """
+
+    def __init__(self, *args, path_prefix="", **kwargs):
+        self.path_prefix = path_prefix
+        super().__init__(*args, **kwargs)
+        self.auth = JWTAuth(kwargs.get("http_auth"))
+
+    def perform_request(
+        self, method, url, params=None, body=None, headers=None, timeout=None, ignore=(), **kwargs
+    ):
+        """
+        Perform a request to the OpenSearch server.
+
+        Parameters
+        ----------
+        method : str
+            The HTTP method to use.
+        url : str
+            The URL to connect to.
+        params : Optional[Mapping[str, Any]]
+            The parameters to include in the request.
+        body : Optional[bytes]
+            The body of the request.
+        headers : Optional[Mapping[str, str]]
+            The headers to include in the request.
+        timeout : Optional[Union[int, float]]
+            The timeout for the request.
+        ignore : Collection[int]
+            The status codes to ignore.
+        """
+        # Ensure path_prefix is included in the URL
+        if not url.startswith(self.path_prefix):
+            url = self.path_prefix + url
+
+        return super().perform_request(
+            method,
+            url,
+            params=params,
+            body=body,
+            headers=headers,
+            timeout=timeout,
+            ignore=ignore,
+            **kwargs,
+        )
+
+
+class AsyncConnectorJWTAuth:
+    """
+    A class that provides the JWT authentication for the OpenSearch connection.
+
+    Parameters
+    ----------
+    token : str
+        The JWT token.
+    """
+
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, _method, _url, _query_string: str, _body=None):
+        return {"Authorization": f"Bearer {self.token}"}
+
+
+class BystroProxyAsyncHttpConnection(AsyncHttpConnection):
+    """
+    An OpenSearch connection class that uses a proxy to connect to the OpenSearch server.
+
+    Parameters
+    ----------
+    path_prefix : str
+        The path prefix to use when connecting to the OpenSearch server.
+
+    Attributes
+    ----------
+    path_prefix : str
+        The path prefix to use when connecting to the OpenSearch server.
+
+    Methods
+    -------
+    perform_request(method, url, params=None, body=None, timeout=None, ignore=(), headers=None)
+        Perform a request to the OpenSearch server.
+    """
+
+    def __init__(self, *args, path_prefix: str = "", **kwargs):
+        self.path_prefix = path_prefix
+        super().__init__(*args, **kwargs)
+        self.auth = kwargs.get("http_auth")
+
+    async def perform_request(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Mapping[str, Any]] = None,
+        body: Optional[bytes] = None,
+        timeout: Optional[Union[int, float]] = None,
+        ignore: Collection[int] = (),
+        headers: Optional[Mapping[str, str]] = None,
+    ):
+        """
+        Perform a request to the OpenSearch server.
+
+        Parameters
+        ----------
+        method : str
+            The HTTP method to use.
+        url : str
+            The URL to connect to.
+        params : Optional[Mapping[str, Any]]
+            The parameters to include in the request.
+        body : Optional[bytes]
+            The body of the request.
+        timeout : Optional[Union[int, float]]
+            The timeout for the request.
+        ignore : Collection[int]
+            The status codes to ignore.
+        headers : Optional[Mapping[str, str]]
+            The headers to include in the request.
+        """
+        if not url.startswith(self.path_prefix):
+            path = self.path_prefix + url
+
+        return await super().perform_request(
+            method=method,
+            url=path,
+            params=params,
+            body=body,
+            headers=headers,
+            timeout=timeout,
+            ignore=ignore,
+        )
+
+
+def get_async_proxied_opensearch_client(auth: CachedAuth, job_id: str, client_args: dict | None = None):
+    """
+    Create an OpenSearch client that uses a proxy to connect to the OpenSearch server.
+
+    Parameters
+    ----------
+    auth : CachedAuth
+        The authentication information.
+    job_id : str
+        The ID of the job to connect to.
+
+    Returns
+    -------
+    AsyncOpenSearch
+        The AsyncOpenSearch client.
+    """
+    [protocol, host] = auth.url.split("://")
+
+    [host, port] = host.split(":")
+
+    if client_args is None:
+        client_args = {}
+
+    # Initialize OpenSearch client with custom connection class
+
+    print(client_args)
+    client = AsyncOpenSearch(
+        hosts=[{"host": host, "port": int(port)}],
+        use_ssl=bool(protocol == "https" or int(port) == 443),
+        connection_class=BystroProxyAsyncHttpConnection,
+        path_prefix=QUERY_ENDPONIT.format(job_id=job_id),
+        http_auth=AsyncConnectorJWTAuth(auth.access_token),
+        http_compress=True,
+        timeout=client_args.get("timeout", 1200),
+        pool_maxsize=client_args.get("pool_maxsize", 16),
+    )
+
+    return client
+
+
+def get_proxied_opensearch_client(auth: CachedAuth, job_id: str, client_args: dict | None = None):
+    """
+    Create an OpenSearch client that uses a proxy to connect to the OpenSearch server.
+
+    Parameters
+    ----------
+    auth : CachedAuth
+        The authentication information.
+    job_id : str
+        The ID of the job to connect to.
+
+    Returns
+    -------
+    OpenSearch
+        The OpenSearch client.
+    """
+    [protocol, host] = auth.url.split("://")
+
+    [host, port] = host.split(":")
+
+    if client_args is None:
+        client_args = {}
+
+    # Initialize OpenSearch client with custom connection class
+    client = OpenSearch(
+        hosts=[{"host": host, "port": int(port)}],
+        use_ssl=bool(protocol == "https" or int(port) == 443),
+        connection_class=BystroProxyHttpConnection,
+        path_prefix=QUERY_ENDPONIT.format(job_id=job_id),
+        http_auth=JWTAuth(auth.access_token),
+        http_compress=True,
+        timeout=client_args.get("timeout", 1200),
+        pool_maxsize=client_args.get("pool_maxsize", 16),
+    )
+
+    return client

--- a/python/python/bystro/api/tests/test_search.py
+++ b/python/python/bystro/api/tests/test_search.py
@@ -62,7 +62,10 @@ def test_get_async_proxied_opensearch_client(cached_auth, job_id):
             use_ssl=True,
             connection_class=BystroProxyAsyncHttpConnection,
             path_prefix=f"/api/jobs/{job_id}/opensearch",
-            http_auth=mock_auth.return_value,  # Ensure the mock instance is used
+            http_auth=mock_auth.return_value,
+            http_compress=True,
+            pool_maxsize=16,
+            timeout=1200,
         )
 
 
@@ -149,4 +152,30 @@ def test_get_proxied_opensearch_client(cached_auth, job_id):
             connection_class=BystroProxyHttpConnection,
             path_prefix=f"/api/jobs/{job_id}/opensearch",
             http_auth=mock_auth.return_value,  # Ensure the mock instance is used
+            http_compress=True,
+            pool_maxsize=16,
+            timeout=1200,
         )
+
+def test_get_proxied_opensearch_client_nondefault_params(cached_auth, job_id):
+    with (
+        patch("bystro.api.search.OpenSearch", new_callable=Mock) as mock_client,
+        patch("bystro.api.search.JWTAuth", new_callable=Mock) as mock_auth,
+    ):
+        client = get_proxied_opensearch_client(cached_auth, job_id, {
+            "timeout": 600,
+            "pool_maxsize": 8
+        })
+
+        assert isinstance(client, Mock)
+        mock_client.assert_called_once_with(
+            hosts=[{"host": "testhost", "port": 9200}],
+            use_ssl=True,
+            connection_class=BystroProxyHttpConnection,
+            path_prefix=f"/api/jobs/{job_id}/opensearch",
+            http_auth=mock_auth.return_value,  # Ensure the mock instance is used
+            http_compress=True,
+            pool_maxsize=8,
+            timeout=600,
+        )
+

--- a/python/python/bystro/api/tests/test_search.py
+++ b/python/python/bystro/api/tests/test_search.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+from opensearchpy import AsyncHttpConnection
+
+
+from bystro.api.auth import CachedAuth
+from bystro.api.search import (
+    AsyncConnectorJWTAuth,
+    BystroProxyAsyncHttpConnection,
+    get_async_proxied_opensearch_client,
+)
+
+
+@pytest.fixture
+def auth_token():
+    return "test_token"
+
+
+@pytest.fixture
+def job_id():
+    return "1234"
+
+
+@pytest.fixture
+def cached_auth(auth_token):
+    return CachedAuth(email="email", access_token=auth_token, url="https://testhost:9200")
+
+
+@pytest.mark.asyncio
+async def test_async_connector_jwt_auth(auth_token):
+    auth = AsyncConnectorJWTAuth(auth_token)
+    headers = auth("GET", "http://testhost:9200", "")
+
+    assert headers["Authorization"] == f"Bearer {auth_token}"
+
+
+@pytest.mark.asyncio
+async def test_bystro_proxy_async_http_connection(auth_token):
+    connection = BystroProxyAsyncHttpConnection(
+        http_auth=AsyncConnectorJWTAuth(auth_token), path_prefix="/testprefix"
+    )
+
+    assert connection.path_prefix == "/testprefix"
+    assert isinstance(connection.auth, AsyncConnectorJWTAuth)
+
+
+def test_get_async_proxied_opensearch_client(cached_auth, job_id):
+    with (
+        patch("bystro.api.search.AsyncOpenSearch", new_callable=Mock) as mock_client,
+        patch("bystro.api.search.AsyncConnectorJWTAuth", new_callable=Mock) as mock_auth,
+    ):
+        client = get_async_proxied_opensearch_client(cached_auth, job_id)
+
+        assert isinstance(client, Mock)
+        mock_client.assert_called_once_with(
+            hosts=[{"host": "testhost", "port": "9200"}],
+            use_ssl=True,
+            connection_class=BystroProxyAsyncHttpConnection,
+            path_prefix=f"/api/jobs/{job_id}/opensearch",
+            http_auth=mock_auth.return_value,  # Ensure the mock instance is used
+        )
+
+
+
+@pytest.mark.asyncio
+async def test_bystro_proxy_async_http_connection_perform_request(auth_token):
+    with patch.object(
+        AsyncHttpConnection, "perform_request", new_callable=AsyncMock
+    ) as mock_super_perform_request:
+        connection = BystroProxyAsyncHttpConnection(
+            http_auth=AsyncConnectorJWTAuth(auth_token), path_prefix="/testprefix"
+        )
+
+        await connection.perform_request("GET", "/testurl")
+
+        mock_super_perform_request.assert_awaited_once_with(
+            method="GET",
+            url="/testprefix/testurl",
+            params=None,
+            body=None,
+            headers=None,
+            timeout=None,
+            ignore=(),
+        )

--- a/python/python/bystro/covariance/tests/test_base_covariance.py
+++ b/python/python/bystro/covariance/tests/test_base_covariance.py
@@ -203,7 +203,7 @@ def test_marginal_score():
     score = model.marginal_score(X[:, idxs == 1], idxs)
     mvn = st.multivariate_normal(mean=np.zeros(8), cov=model.covariance[:8, :8])
     logpdf = mvn.logpdf(X[:, :8])
-    assert np.mean(logpdf) == score
+    assert np.abs(np.mean(logpdf) - score) < 1e-8
 
 
 def test_marginal_score_sherman_woodbury():

--- a/python/python/bystro/covariance/tests/test_base_covariance.py
+++ b/python/python/bystro/covariance/tests/test_base_covariance.py
@@ -238,7 +238,7 @@ def test_score():
     score = model.score(X, weights=1.0 * np.ones(1000))
     mvn = st.multivariate_normal(mean=np.zeros(10), cov=model.covariance)
     logpdf = mvn.logpdf(X)
-    assert np.mean(logpdf) == score
+    assert np.abs(np.mean(logpdf) - score) < 1e-8
 
 
 def test_score_sherman_woodbury():

--- a/python/python/bystro/proteomics/annotation_interface.py
+++ b/python/python/bystro/proteomics/annotation_interface.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 
 import asyncio
 from msgspec import Struct
-import nest_asyncio
+import nest_asyncio # type: ignore
 import numpy as np
 
 import pandas as pd

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -5,6 +5,7 @@ pandas-stubs==2.2.1.240316
 pytest==7.3.1
 pytest-cov==4.1.0
 pytest-mock==3.11.1
+pytest-asyncio==0.23.7
 pyright==1.1.349
 ruff==0.0.270
 types-tqdm==4.65.0.1


### PR DESCRIPTION
* Proxy OpenSearch requests, allowing users to directly query the OpenSearch cluster, even outside the cluster, by way of the Bystro API server

This will enable useful telemetry, while still ensuring adequate security. Not all requests are handled, but all the requests we need for fetching annotation data in bulk, and joining on proteomic data, without needing to go through the queue.

This makes our proteomic filtering functionality directly useful, and opens the door to enable users to programmatically do other things that require the search engine, like filtering annotations, without requiring batch job submissions through the queue. This will probably be popular for cases where the data is small enough, or the user wants to manually distribute execution (say they want to use some other batch scheduler)

In a future PR we will move the `get_annotation_result_from_query` and `get_annotation_result_from_query_async` functions out of proteomics.py, and into api/search.py

Example Notebooks:
[ProteomicsProxiedQuery(1).zip](https://github.com/bystrogenomics/bystro/files/15384205/ProteomicsProxiedQuery.1.zip)
[BasicProxyQuery.zip](https://github.com/bystrogenomics/bystro/files/15384206/BasicProxyQuery.zip)

Corresponds to: https://github.com/bystrogenomics/bystro-web/pull/448
