### PR TITLE
[annotation, proteomics] Refine annotation api interface, proteomic api join interface

### DIFF
--- a/python/python/bystro/examples/ExampleQueryToDataFrame.ipynb
+++ b/python/python/bystro/examples/ExampleQueryToDataFrame.ipynb
@@ -250,7 +250,7 @@
     }
    ],
    "source": [
-    "# Default behavior is to show 1 sample per row, e.g. `melt_by_samples=True`\n",
+    "# Default behavior is to show 1 sample per row, e.g. `melt_samples=True`\n",
     "query_result_df_array_of_structs_select_fields = get_annotation_result_from_query(\n",
     "    query_string=\"*\",\n",
     "    index_name=index,\n",
@@ -379,15 +379,15 @@
     "# so that when the field has an array value, it is flattened\n",
     "# When the primary key of the track isn't found, by default we force that \n",
     "# field to have 1 value per row, and warn you of this behavior.\n",
-    "# To change it, set `force_flatten_melt_by_field=False`\n",
+    "# To change it, set `force_flatten_exploded_field=False`\n",
     "query_result_df = get_annotation_result_from_query(\n",
     "    query_string=\"(type:del && (alt:\\-6 || alt:\\-1)) || (cadd:>40)\",\n",
     "    index_name=index,\n",
     "    bystro_api_auth=user,\n",
-    "    melt_by_samples=True,\n",
-    "    melt_by_field='refSeq.name2',\n",
+    "    melt_samples=True,\n",
+    "    explode_field='refSeq.name2',\n",
     "    fields=['refSeq.name2', 'refSeq.spID', 'refSeq.name'],\n",
-    "    force_flatten_melt_by_field=False\n",
+    "    force_flatten_exploded_field=False\n",
     ")\n",
     "query_result_df[['refSeq.name2', 'refSeq.spID']]"
    ]
@@ -598,14 +598,14 @@
     }
    ],
    "source": [
-    "# You can disabled sample melting by setting `melt_by_samples=False`\n",
+    "# You can disabled sample melting by setting `melt_samples=False`\n",
     "query_result_df = await async_get_annotation_result_from_query(\n",
     "    query_string=\"(type:del && (alt:\\-6 || alt:\\-1)) || (cadd:>40)\",\n",
     "    index_name=index,\n",
     "    bystro_api_auth=user,\n",
     "    fields=['refSeq.name2', 'refSeq.name'],\n",
-    "    melt_by_samples=False,\n",
-    "    melt_by_field='refSeq.name2'\n",
+    "    melt_samples=False,\n",
+    "    explode_field='refSeq.name2'\n",
     ")\n",
     "query_result_df.head(n=10)"
    ]
@@ -990,7 +990,7 @@
    "source": [
     "# You can also represent tracks that have multiple fields by dictionaries, instead of flattening\n",
     "# the dictionaries into separate columns, by setting `structs_of_arrays=False`\n",
-    "# This is currently incompatible with `melt_by_field` and `fields`\n",
+    "# This is currently incompatible with `explode_field` and `fields`\n",
     "query_result_df_array_of_structs_no_melt = get_annotation_result_from_query(\n",
     "    query_string=\"*\",\n",
     "    index_name=index,\n",

--- a/python/python/bystro/proteomics/annotation_interface.py
+++ b/python/python/bystro/proteomics/annotation_interface.py
@@ -999,8 +999,9 @@ async def async_run_annotation_query(
 
         if structs_of_arrays is False:
             raise ValueError(
-                "Cannot yet, melt by field when structs_of_arrays is False, "
-                "as track values are potentially dicts"
+                "structs_of_arrays=False, which means that track values are potentially dicts, "
+                "and we do not currently support exploding these.\n"
+                "Set structs_of_arrays=True to explode fields."
             )
 
         if fields is not None:

--- a/python/python/bystro/proteomics/annotation_interface.py
+++ b/python/python/bystro/proteomics/annotation_interface.py
@@ -16,7 +16,11 @@ from opensearchpy import AsyncOpenSearch
 
 from bystro.api.auth import CachedAuth
 from bystro.api.search import get_async_proxied_opensearch_client
-from bystro.proteomics.fragpipe_tandem_mass_tag import TandemMassTagDataset
+from bystro.proteomics.fragpipe_tandem_mass_tag import (
+    TandemMassTagDataset,
+    FRAGPIPE_SAMPLE_COLUMN,
+    FRAGPIPE_GENE_GENE_NAME_COLUMN_RENAMED,
+)
 from bystro.search.utils.opensearch import gather_opensearch_args
 
 
@@ -131,8 +135,6 @@ DEFAULT_MULTI_VALUED_TRACKS = [
 NOT_SUPPORTED_TRACKS = ["refSeq.clinvar"]
 
 DEFAULT_GENE_NAME_COLUMN = "refSeq.name2"
-
-FRAGPIPE_PROTEIN_ABUNDANCE_COLUMN = "protein_abundance"
 
 
 def _looks_like_float(val: Any) -> bool:
@@ -603,9 +605,9 @@ async def execute_query(
     query: dict,
     fields: list[str] | None = None,
     structs_of_arrays: bool = True,
-    melt_by_samples: bool = False,
-    melt_by_field: str | None = None,
-    force_flatten_melt_by_field: bool = False,
+    melt_samples: bool = False,
+    explode_field: str | None = None,
+    force_flatten_exploded_field: bool = False,
     primary_keys: dict[str, str] | None = None,
 ) -> pd.DataFrame:
     """
@@ -614,13 +616,32 @@ async def execute_query(
     Args:
         client (AsyncOpenSearch): The OpenSearch client.
         query (dict): The OpenSearch query.
-        fields (list[str] | None): A list of fields to include in the DataFrame.
-        structs_of_arrays (bool): Whether to return structs of arrays, defaults to True.
-        melt_by_samples (bool): Whether to melt the DataFrame by samples, defaults to False.
-        melt_by_field (str | None): A field to melt by, defaults to None.
-        force_flatten_melt_by_field (bool):
-            When melting by a field, whether to force flatten array values, defaults to False.
-        primary_keys (dict[str, str] | None): A dictionary of primary keys for tracks, defaults to None.
+        fields (list[str] | None):
+            A list of fields to include in the DataFrame.
+        structs_of_arrays (bool)
+             Whether to return structs of arrays, defaults to True.
+        melt_samples (bool):
+            Whether to unpivot `heterozygotes`, `homozygotes`, and `missingGenos` fields.
+            When `True` the resulting DataFrame will have 2 new columns: `samples` and `dosage`,
+            and `heterozygotes`, `homozygotes`, and `missingGenos` will be removed.
+
+            The `dosage` column will have values of 1, 2, or -1, corresponding to whether the sample was
+            found in the `heterozygotes`, `homozygotes`, and `missingGenos` columns, respectively.
+
+            The `samples` column will have the sample ID for each row, and this will always be a
+            scalar value, even if the original `heterozygotes`, `homozygotes`, or `missingGenos` columns
+            had multiple values.
+
+            Defaults to False.
+        explode_field (str | None):
+            A field to explode, converting rows with list values in this column, into
+            multiple rows with 1 value per column, defaults to None.
+        force_flatten_exploded_field (bool):
+            When exploding a field, whether to force flatten array values in cases where the
+            primary key for the track is not present, or the column's value is a list with respect
+            to the primary key. Defaults to False.
+        primary_keys (dict[str, str] | None):
+            A dictionary of primary keys for tracks, defaults to None.
 
     Returns:
         pd.DataFrame: A DataFrame of query results.
@@ -628,15 +649,15 @@ async def execute_query(
     results: list[dict] = []
     search_after = None  # Initialize search_after for pagination
 
-    if melt_by_field is not None:
-        if fields is not None and melt_by_field not in fields:
+    if explode_field is not None:
+        if fields is not None and explode_field not in fields:
             raise ValueError(
-                f"melt_by_field={melt_by_field} is not in fields={fields}, but must be present."
+                f"explode_field={explode_field} is not in fields={fields}, but must be present."
             )
 
         if structs_of_arrays is False:
             raise ValueError(
-                "Cannot yet, melt by field when structs_of_arrays is False, "
+                "Cannot yet, explode field when structs_of_arrays is False, "
                 "as track values are potentially dicts"
             )
 
@@ -664,9 +685,9 @@ async def execute_query(
         results,
         fields,
         structs_of_arrays=structs_of_arrays,
-        melt_by_samples=melt_by_samples,
-        melt_by_field=melt_by_field,
-        force_flatten_melt_by_field=force_flatten_melt_by_field,
+        melt_samples=melt_samples,
+        explode_field=explode_field,
+        force_flatten_exploded_field=force_flatten_exploded_field,
         primary_keys=primary_keys,
     )
 
@@ -695,9 +716,9 @@ def process_query_response(
     hits: list[dict[str, Any]],
     fields: list[str] | None = None,
     structs_of_arrays: bool = True,
-    melt_by_samples: bool = False,
-    melt_by_field: str | None = None,
-    force_flatten_melt_by_field: bool = True,
+    melt_samples: bool = False,
+    explode_field: str | None = None,
+    force_flatten_exploded_field: bool = False,
     primary_keys: dict[str, str] | None = None,
 ) -> pd.DataFrame:
     """
@@ -707,10 +728,26 @@ def process_query_response(
         hits (list[dict[str, Any]]): A list of hits from an OpenSearch query.
         fields (list[str] | None): A list of fields to include in the DataFrame.
         structs_of_arrays (bool): Whether to return structs of arrays, defaults to True.
-        melt_by_samples (bool): Whether to melt the DataFrame by samples, defaults to False.
-        melt_by_field (str | None): A field to melt by, defaults to None.
-        force_flatten_melt_by_field (bool):
-            When melting by a field, whether to force flatten array values, defaults to True.
+        melt_samples (bool):
+            Whether to unpivot `heterozygotes`, `homozygotes`, and `missingGenos` fields.
+            When `True` the resulting DataFrame will have 2 new columns: `samples` and `dosage`,
+            and `heterozygotes`, `homozygotes`, and `missingGenos` will be removed.
+
+            The `dosage` column will have values of 1, 2, or -1, corresponding to whether the sample was
+            found in the `heterozygotes`, `homozygotes`, and `missingGenos` columns, respectively.
+
+            The `samples` column will have the sample ID for each row, and this will always be a
+            scalar value, even if the original `heterozygotes`, `homozygotes`, or `missingGenos` columns
+            had multiple values.
+
+            Defaults to False.
+        explode_field (str | None):
+            A field to explode, converting rows with list values in this column, into
+            multiple rows with 1 value per column, defaults to None.
+        force_flatten_exploded_field (bool):
+            When exploding a field, whether to force flatten array values in cases where the
+            primary key for the track is not present, or the column's value is a list with respect
+            to the primary key. Defaults to False.
         primary_keys (dict[str, str] | None): A dictionary of primary keys for tracks, defaults to None.
 
     Returns:
@@ -721,15 +758,15 @@ def process_query_response(
     if num_hits == 0:
         return pd.DataFrame()
 
-    if melt_by_field is not None:
-        if fields is not None and melt_by_field not in fields:
+    if explode_field is not None:
+        if fields is not None and explode_field not in fields:
             raise ValueError(
-                f"melt_by_field={melt_by_field} is not in fields={fields}, but must be present."
+                f"explode_field={explode_field} is not in fields={fields}, but must be present."
             )
 
         if structs_of_arrays is False:
             raise ValueError(
-                "Cannot yet, melt by field when structs_of_arrays is False, "
+                "Cannot yet, explode field when structs_of_arrays is False, "
                 "as track values are potentially dicts"
             )
 
@@ -746,7 +783,7 @@ def process_query_response(
     # need to drop duplicates here.
     cols = ALWAYS_INCLUDED_FIELDS + [LINK_GENERATED_COLUMN]
 
-    if melt_by_samples is True:
+    if melt_samples is True:
         melted_rows = []
         for row in rows:
             heterozygotes = _flatten(row.get(HETEROZYGOTES_FIELD, []))
@@ -783,51 +820,51 @@ def process_query_response(
             cols += [SAMPLE_GENERATED_COLUMN, DOSAGE_GENERATED_COLUMN]
             rows = melted_rows
 
-    if melt_by_field is not None:
+    if explode_field is not None:
         melted_rows = []
 
-        track_name = ".".join(melt_by_field.split(".")[0:-1])
+        track_name = ".".join(explode_field.split(".")[0:-1])
 
         for row in rows:
             row_fields = row.keys()
 
-            if melt_by_field not in row_fields:
+            if explode_field not in row_fields:
                 raise ValueError(
                     (
-                        f"You set melt_by_field to `{melt_by_field}`, "
+                        f"You set explode_field to `{explode_field}`, "
                         f"but the only fields we've found are: {list(row_fields)}"
                     )
                 )
 
             # The related fields all share the same arity, and should be split together
-            related_melt_by_fields = [
+            related_explode_fields = [
                 field
                 for field in row_fields
-                if field != melt_by_field and field == f"{track_name}.{field.split('.')[-1]}"
+                if field != explode_field and field == f"{track_name}.{field.split('.')[-1]}"
             ]
 
-            if row[melt_by_field] is None or not isinstance(row[melt_by_field], list):
+            if row[explode_field] is None or not isinstance(row[explode_field], list):
                 melted_rows.append(row)
                 continue
 
-            field_length = len(row[melt_by_field])
+            field_length = len(row[explode_field])
 
             for i in range(field_length):
                 melted_row = {**row}
 
-                for field in related_melt_by_fields:
+                for field in related_explode_fields:
                     melted_row[field] = row[field][i]
 
-                melted_field_value = row[melt_by_field][i]
+                exploded_field_value = row[explode_field][i]
 
-                if isinstance(melted_field_value, list) and force_flatten_melt_by_field:
-                    melted_field_value = _flatten(melted_field_value)
+                if isinstance(exploded_field_value, list) and force_flatten_exploded_field:
+                    exploded_field_value = _flatten(exploded_field_value)
 
-                    for val in melted_field_value:
-                        melted_row[melt_by_field] = val
+                    for val in exploded_field_value:
+                        melted_row[explode_field] = val
                         melted_rows.append({**melted_row})
                 else:
-                    melted_row[melt_by_field] = melted_field_value
+                    melted_row[explode_field] = exploded_field_value
                     melted_rows.append({**melted_row})
 
         if melted_rows:
@@ -840,9 +877,9 @@ def process_query_response(
             if field in df.columns and field not in cols:
                 cols.append(field)
             else:
-                if field in SAMPLE_COLUMNS and melt_by_samples:
+                if field in SAMPLE_COLUMNS and melt_samples:
                     logger.warning(
-                        "Sample column %s not found in results, because melt_by_samples is enabled",
+                        "Sample column %s not found in results, because melt_samples is enabled",
                         field,
                     )
                 else:
@@ -900,9 +937,9 @@ async def async_run_annotation_query(
     bystro_api_auth: CachedAuth | None = None,
     additional_client_args: dict[str, Any] | None = None,
     structs_of_arrays: bool = True,
-    melt_by_samples: bool = False,
-    melt_by_field: str | None = None,
-    force_flatten_melt_by_field: bool = True,
+    melt_samples: bool = False,
+    explode_field: str | None = None,
+    force_flatten_exploded_field: bool = False,
     primary_keys: dict[str, str] | None = None,
 ) -> pd.DataFrame:
     """
@@ -918,10 +955,26 @@ async def async_run_annotation_query(
         additional_client_args (dict[str, Any] | None):
             Additional arguments for the OpenSearch client, defaults to None.
         structs_of_arrays (bool): Whether to return structs of arrays, defaults to True.
-        melt_by_samples (bool): Whether to melt the DataFrame by samples, defaults to False.
-        melt_by_field (str | None): A field to melt by, defaults to None.
-        force_flatten_melt_by_field (bool):
-            When melting by a field, whether to force flatten array values, defaults to True.
+        melt_samples (bool):
+            Whether to unpivot `heterozygotes`, `homozygotes`, and `missingGenos` fields.
+            When `True` the resulting DataFrame will have 2 new columns: `samples` and `dosage`,
+            and `heterozygotes`, `homozygotes`, and `missingGenos` will be removed.
+
+            The `dosage` column will have values of 1, 2, or -1, corresponding to whether the sample was
+            found in the `heterozygotes`, `homozygotes`, and `missingGenos` columns, respectively.
+
+            The `samples` column will have the sample ID for each row, and this will always be a
+            scalar value, even if the original `heterozygotes`, `homozygotes`, or `missingGenos` columns
+            had multiple values.
+
+            Defaults to False.
+        explode_field (str | None):
+            A field to explode, converting rows with list values in this column, into
+            multiple rows with 1 value per column, defaults to None.
+        force_flatten_exploded_field (bool):
+            When exploding a field, whether to force flatten array values in cases where the
+            primary key for the track is not present, or the column's value is a list with respect
+            to the primary key. Defaults to False.
         primary_keys (dict[str, str] | None): A dictionary of primary keys for tracks, defaults to None.
 
     Returns:
@@ -938,10 +991,10 @@ async def async_run_annotation_query(
             "as track values are potentially dicts"
         )
 
-    if melt_by_field is not None:
-        if fields is not None and melt_by_field not in fields:
+    if explode_field is not None:
+        if fields is not None and explode_field not in fields:
             raise ValueError(
-                f"melt_by_field={melt_by_field} is not in fields={fields}, but must be present."
+                f"explode_field={explode_field} is not in fields={fields}, but must be present."
             )
 
         if structs_of_arrays is False:
@@ -951,28 +1004,30 @@ async def async_run_annotation_query(
             )
 
         if fields is not None:
-            melt_by_field_track = ".".join(melt_by_field.split(".")[0:-1])
+            explode_field_track = ".".join(explode_field.split(".")[0:-1])
             primary_keys_to_check = primary_keys or DEFAULT_PRIMARY_KEYS
-            primary_key_for_melt_track = primary_keys_to_check.get(melt_by_field_track)
+            primary_key_for_explode_track = primary_keys_to_check.get(explode_field_track)
 
-            if primary_key_for_melt_track is not None:
-                primary_key_for_melt_track = melt_by_field_track + "." + primary_key_for_melt_track
+            if primary_key_for_explode_track is not None:
+                primary_key_for_explode_track = explode_field_track + "." + primary_key_for_explode_track
 
-                if primary_key_for_melt_track not in fields:
+                if primary_key_for_explode_track not in fields:
                     logger.warning(
                         (
-                            "You are melting by field `%s`, which belongs to track `%s`.\n"
+                            "You are exploding field `%s`, which belongs to track `%s`.\n"
                             "Track `%s`'s primary key is `%s`,\n"
                             "which is not your specified `fields=%s`.\n"
-                            "Consider adding `%s` to `fields` for more precise nested array melting,\n"
-                            "Or disable `force_flatten_melt_by_field` to keep nested arrays intact.\n"
+                            "Consider adding `%s` to `fields` to more precisely "
+                            "explode array values for a given track\n"
+                            "Or disable `force_flatten_exploded_field` to keep nested arrays intact "
+                            "where ambiguity exists.\n"
                         ),
-                        melt_by_field,
-                        melt_by_field_track,
-                        melt_by_field_track,
-                        primary_key_for_melt_track,
+                        explode_field,
+                        explode_field_track,
+                        explode_field_track,
+                        primary_key_for_explode_track,
                         fields,
-                        primary_key_for_melt_track,
+                        primary_key_for_explode_track,
                     )
 
     if bystro_api_auth is not None:
@@ -1007,9 +1062,9 @@ async def async_run_annotation_query(
                 query=slice_query,
                 fields=fields,
                 structs_of_arrays=structs_of_arrays,
-                melt_by_samples=melt_by_samples,
-                melt_by_field=melt_by_field,
-                force_flatten_melt_by_field=force_flatten_melt_by_field,
+                melt_samples=melt_samples,
+                explode_field=explode_field,
+                force_flatten_exploded_field=force_flatten_exploded_field,
                 primary_keys=primary_keys,
             )
             query_results.append(query_result)
@@ -1030,9 +1085,9 @@ async def async_get_annotation_result_from_query(
     bystro_api_auth: CachedAuth | None = None,
     additional_client_args: dict[str, Any] | None = None,
     structs_of_arrays: bool = True,
-    melt_by_samples: bool = True,
-    melt_by_field: str | None = None,
-    force_flatten_melt_by_field: bool = True,
+    melt_samples: bool = True,
+    explode_field: str | None = None,
+    force_flatten_exploded_field: bool = True,
     primary_keys: dict[str, str] | None = None,
 ) -> pd.DataFrame:
     """
@@ -1048,10 +1103,26 @@ async def async_get_annotation_result_from_query(
         additional_client_args (dict[str, Any] | None):
             Additional arguments for the OpenSearch client, defaults to None.
         structs_of_arrays (bool): Whether to return structs of arrays, defaults to True.
-        melt_by_samples (bool): Whether to melt the DataFrame by samples, defaults to True.
-        melt_by_field (str | None): The field to melt by, defaults to None.
-        force_flatten_melt_by_field (bool):
-            Whether to force flatten array values when melting by a field, defaults to True.
+        melt_samples (bool):
+            Whether to unpivot `heterozygotes`, `homozygotes`, and `missingGenos` fields.
+            When `True` the resulting DataFrame will have 2 new columns: `samples` and `dosage`,
+            and `heterozygotes`, `homozygotes`, and `missingGenos` will be removed.
+
+            The `dosage` column will have values of 1, 2, or -1, corresponding to whether the sample was
+            found in the `heterozygotes`, `homozygotes`, and `missingGenos` columns, respectively.
+
+            The `samples` column will have the sample ID for each row, and this will always be a
+            scalar value, even if the original `heterozygotes`, `homozygotes`, or `missingGenos` columns
+            had multiple values.
+
+            Defaults to False.
+        explode_field (str | None):
+            A field to explode, converting rows with list values in this column, into
+            multiple rows with 1 value per column, defaults to None.
+        force_flatten_exploded_field (bool):
+            When exploding a field, whether to force flatten array values in cases where the
+            primary key for the track is not present, or the column's value is a list with respect
+            to the primary key. Defaults to True.
         primary_keys (dict[str, str] | None): The primary keys for tracks, defaults to None.
 
     Returns:
@@ -1064,7 +1135,7 @@ async def async_get_annotation_result_from_query(
         )
 
     query = _build_opensearch_query_from_query_string(
-        query_string, fields=fields, melt_by_samples=melt_by_samples
+        query_string, fields=fields, melt_samples=melt_samples
     )
 
     return await async_run_annotation_query(
@@ -1075,9 +1146,9 @@ async def async_get_annotation_result_from_query(
         bystro_api_auth=bystro_api_auth,
         additional_client_args=additional_client_args,
         structs_of_arrays=structs_of_arrays,
-        melt_by_samples=melt_by_samples,
-        melt_by_field=melt_by_field,
-        force_flatten_melt_by_field=force_flatten_melt_by_field,
+        melt_samples=melt_samples,
+        explode_field=explode_field,
+        force_flatten_exploded_field=force_flatten_exploded_field,
         primary_keys=primary_keys,
     )
 
@@ -1090,9 +1161,9 @@ def get_annotation_result_from_query(
     bystro_api_auth: CachedAuth | None = None,
     additional_client_args: dict[str, Any] | None = None,
     structs_of_arrays: bool = True,
-    melt_by_samples: bool = True,
-    melt_by_field: str | None = None,
-    force_flatten_melt_by_field: bool = True,
+    melt_samples: bool = True,
+    explode_field: str | None = None,
+    force_flatten_exploded_field: bool = True,
     primary_keys: dict[str, str] | None = None,
 ) -> pd.DataFrame:
     """
@@ -1108,10 +1179,26 @@ def get_annotation_result_from_query(
         additional_client_args (dict[str, Any] | None):
             Additional arguments for the OpenSearch client, defaults to None.
         structs_of_arrays (bool): Whether to return structs of arrays, defaults to True.
-        melt_by_samples (bool): Whether to melt the DataFrame by samples, defaults to True.
-        melt_by_field (str | None): The field to melt by, defaults to None.
-        force_flatten_melt_by_field (bool):
-            Whether to force flatten array values when melting by a field, defaults to True.
+        melt_samples (bool):
+            Whether to unpivot `heterozygotes`, `homozygotes`, and `missingGenos` fields.
+            When `True` the resulting DataFrame will have 2 new columns: `samples` and `dosage`,
+            and `heterozygotes`, `homozygotes`, and `missingGenos` will be removed.
+
+            The `dosage` column will have values of 1, 2, or -1, corresponding to whether the sample was
+            found in the `heterozygotes`, `homozygotes`, and `missingGenos` columns, respectively.
+
+            The `samples` column will have the sample ID for each row, and this will always be a
+            scalar value, even if the original `heterozygotes`, `homozygotes`, or `missingGenos` columns
+            had multiple values.
+
+            Defaults to False.
+        explode_field (str | None):
+            A field to explode, converting rows with list values in this column, into
+            multiple rows with 1 value per column, defaults to None.
+        force_flatten_exploded_field (bool):
+            When exploding a field, whether to force flatten array values in cases where the
+            primary key for the track is not present, or the column's value is a list with respect
+            to the primary key. Defaults to True.
         primary_keys (dict[str, str] | None): The primary keys for tracks, defaults to None.
 
     Returns:
@@ -1126,9 +1213,9 @@ def get_annotation_result_from_query(
         bystro_api_auth=bystro_api_auth,
         additional_client_args=additional_client_args,
         structs_of_arrays=structs_of_arrays,
-        melt_by_samples=melt_by_samples,
-        melt_by_field=melt_by_field,
-        force_flatten_melt_by_field=force_flatten_melt_by_field,
+        melt_samples=melt_samples,
+        explode_field=explode_field,
+        force_flatten_exploded_field=force_flatten_exploded_field,
         primary_keys=primary_keys,
     )
 
@@ -1138,7 +1225,7 @@ def get_annotation_result_from_query(
 def _build_opensearch_query_from_query_string(
     query_string: str,
     fields: list[str] | None = None,
-    melt_by_samples: bool = False,
+    melt_samples: bool = False,
 ) -> dict[str, Any]:
     """
     Build an OpenSearch query from a query string.
@@ -1146,7 +1233,11 @@ def _build_opensearch_query_from_query_string(
     Args:
         query_string (str): The query string to use for the search.
         fields (list[str] | None): The fields to include in the query, defaults to None.
-        melt_by_samples (bool): Whether to include sample-related fields, defaults to False.
+        melt_samples (bool):
+            Whether we plan to unpivot `heterozygotes, `homozygotes`, `missingGenos`
+            columns, and add `samples` and `dosage` columns to the resulting DataFrame.
+
+            Defaults to False.
 
     Returns:
         dict[str, Any]: The OpenSearch query.
@@ -1172,7 +1263,7 @@ def _build_opensearch_query_from_query_string(
 
     all_fields = ALWAYS_INCLUDED_FIELDS.copy()
 
-    if melt_by_samples:
+    if melt_samples:
         all_fields += SAMPLE_COLUMNS
 
     for field in fields or []:
@@ -1197,14 +1288,37 @@ def _build_opensearch_query_from_query_string(
     return base_query
 
 
+def explode_rows_with_list(df, column):
+    """
+    For dataframe with column `column`, explode rows with list values in `column` into multiple rows,
+    with each row containing one value from the list.
+
+    Args:
+        df (pd.DataFrame): The DataFrame to expand/explode.
+        column (str): The column whose list values we wish to explode.
+
+    Returns:
+        pd.DataFrame: The DataFrame expanded/exploded on `column` values.
+    """
+    rows = []
+    for _, row in df.iterrows():
+        if isinstance(row[column], list):
+            for item in row[column]:
+                new_row = row.copy()
+                new_row[column] = item
+                rows.append(new_row)
+        else:
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
 def join_annotation_result_to_fragpipe_dataset(
     query_result_df: pd.DataFrame,
     tmt_dataset: TandemMassTagDataset,
     get_tracking_id_from_genomic_sample_id: Callable[[str], str] = (lambda x: x),
     get_tracking_id_from_proteomic_sample_id: Callable[[str], str] = (lambda x: x),
-    gene_name_column: str = DEFAULT_GENE_NAME_COLUMN,
-    fragpipe_sample_id_column: str = "sample_id",
-    fragpipe_gene_name_column: str = "gene_name",
+    genetic_join_column: str = DEFAULT_GENE_NAME_COLUMN,
+    fragpipe_join_column: str = FRAGPIPE_GENE_GENE_NAME_COLUMN_RENAMED,
 ) -> pd.DataFrame:
     """
     Join annotation result to FragPipe dataset.
@@ -1217,13 +1331,10 @@ def join_annotation_result_to_fragpipe_dataset(
             Callable mapping genomic sample IDs to tracking IDs, defaults to identity function.
         get_tracking_id_from_proteomic_sample_id (Callable[[str], str]):
             Callable mapping proteomic sample IDs to tracking IDs, defaults to identity function.
-        gene_name_column (str):
-            The gene name column in the annotation result DataFrame,
-            defaults to DEFAULT_GENE_NAME_COLUMN.
-        fragpipe_sample_id_column (str):
-            The sample ID column in the FragPipe dataset, defaults to "sample_id".
-        fragpipe_gene_name_column (str):
-            The gene name column in the FragPipe dataset, defaults to "gene_name".
+        genetic_join_column (str, optional):
+            The column to join on in the genetic dataset, defaults to "refSeq.name2".
+        fragpipe_join_column (str, optional)
+            The column to join on in the FragPipe dataset, defaults to "gene_name".
 
     Returns:
         pd.DataFrame: The joined DataFrame.
@@ -1234,18 +1345,15 @@ def join_annotation_result_to_fragpipe_dataset(
     query_result_df[SAMPLE_GENERATED_COLUMN] = query_result_df[SAMPLE_GENERATED_COLUMN].apply(
         get_tracking_id_from_genomic_sample_id
     )
-    proteomics_df[fragpipe_sample_id_column] = proteomics_df[fragpipe_sample_id_column].apply(
+
+    proteomics_df[FRAGPIPE_SAMPLE_COLUMN] = proteomics_df[FRAGPIPE_SAMPLE_COLUMN].apply(
         get_tracking_id_from_proteomic_sample_id
     )
 
-    joined_df = (
-        query_result_df.merge(
-            proteomics_df,
-            left_on=[SAMPLE_GENERATED_COLUMN, gene_name_column],
-            right_on=[fragpipe_sample_id_column, fragpipe_gene_name_column],
-        )
-        .drop(columns=[fragpipe_sample_id_column, fragpipe_gene_name_column])
-        .rename(columns={"value": FRAGPIPE_PROTEIN_ABUNDANCE_COLUMN})
-    )
+    joined_df = query_result_df.merge(
+        proteomics_df,
+        left_on=[SAMPLE_GENERATED_COLUMN, genetic_join_column],
+        right_on=[FRAGPIPE_SAMPLE_COLUMN, fragpipe_join_column],
+    ).drop(columns=[fragpipe_join_column])
 
     return joined_df

--- a/python/python/bystro/proteomics/tests/test_fragpipe_tandem_mass_tag.py
+++ b/python/python/bystro/proteomics/tests/test_fragpipe_tandem_mass_tag.py
@@ -70,6 +70,8 @@ expected_abundance_df = pd.DataFrame(
     }
 )
 expected_abundance_df.index.name = "Index"
+expected_abundance_df = expected_abundance_df.reset_index().rename(columns={"Index": "gene_name"})
+
 expected_annotation_df = pd.DataFrame(
     {
         "plex": {"CPT0088900003": 16, "CPT0079270003": 16, "CPT0088920001": 16},
@@ -90,5 +92,6 @@ def test_load_tandem_mass_tag_dataset():
     abundance_handle = StringIO(raw_abundance_df.to_csv(index=False, sep="\t"))
     annotation_handle = StringIO(raw_annotation_df.to_csv(index=False, sep="\t"))
     tandem_mass_tag_dataset = load_tandem_mass_tag_dataset(abundance_handle, annotation_handle)
+
     assert_frame_equal(expected_abundance_df, tandem_mass_tag_dataset.abundance_df)
     assert_frame_equal(expected_annotation_df, tandem_mass_tag_dataset.annotation_df)


### PR DESCRIPTION
* Refines annotation dataset: melt_by_field => explode_field, melt_by_samples => melt_samples, and improve docstring explanations for both. These names more accurately describe what these arguments do
* Refine proteomic join interface, and TandemMassTagDataset: TandemMassTagDataset class is now a msgspec.Struct, and we do not force drop fields. We also now do not force rename fields, besides Index => gene_name; this may be restored in the future as we support additional variations of Frappe datasets
* Enable ability to join on either gene_name or ProteinID columns.
* Improve the example proteomic notebook to better demonstrate melting_samples and explode_field
