### PR TITLE
[api, cli] Allow login/signup with --host that has trailing slash and stream files to disk or stdout

### DIFF
--- a/python/python/bystro/api/annotation.py
+++ b/python/python/bystro/api/annotation.py
@@ -43,7 +43,7 @@ def _generate_uuid():
     return str(uuid.uuid4())
 
 
-def get_jobs(job_type=None, job_id=None, print_result=True) -> list[JobBasicResponse] | dict:
+def get_jobs(job_type=None, job_id=None, print_result=False) -> list[JobBasicResponse] | dict:
     """
     Fetches the jobs for the given job type, or a single job if a job id is specified.
 
@@ -127,7 +127,7 @@ def create_jobs(
     combine=False,
     names: list[str] | None = None,
     no_index=False,
-    print_result=True,
+    print_result=False,
 ) -> list[dict]:
     """
     Creates 1+ annotation jobs

--- a/python/python/bystro/api/auth.py
+++ b/python/python/bystro/api/auth.py
@@ -106,6 +106,9 @@ def _fq_host(host: str, port: int | None = None) -> str:
     str
         The fully qualified host.
     """
+    #strip trailing slashes
+    host = host.rstrip("/")
+
     if port is None:
         # parse the port from the host protocol
         if host.startswith("https"):

--- a/python/python/bystro/api/auth.py
+++ b/python/python/bystro/api/auth.py
@@ -167,7 +167,7 @@ def save_state(data: CachedAuth, print_result=False) -> None:
 
 
 def signup(
-    email: str, password: str, name: str, host: str, port: int | None = None, print_result=True
+    email: str, password: str, name: str, host: str, port: int | None = None, print_result=False
 ) -> CachedAuth:
     """
     Signs up for Bystro with the given email, name, and password. Additionally, logs in and
@@ -230,7 +230,7 @@ def signup(
     return state
 
 
-def login( email: str, password: str, host: str, port: int | None = None, print_result=True,
+def login( email: str, password: str, host: str, port: int | None = None, print_result=False,
     ) -> CachedAuth:
     """
     Logs in to the server with the provided credentials and saves the authentication state to a file.

--- a/python/python/bystro/api/auth.py
+++ b/python/python/bystro/api/auth.py
@@ -142,7 +142,7 @@ def load_state() -> CachedAuth | None:
     return None
 
 
-def save_state(data: CachedAuth, print_result=True) -> None:
+def save_state(data: CachedAuth, print_result=False) -> None:
     """
     Saves the authentication state to a file.
 
@@ -305,7 +305,7 @@ def authenticate() -> tuple[CachedAuth, dict]:
     return state, header
 
 
-def get_user(print_result=True) -> UserProfile:
+def get_user(print_result=False) -> UserProfile:
     """
     Fetches the user profile.
 
@@ -342,7 +342,7 @@ def get_user(print_result=True) -> UserProfile:
     return user_profile
 
 
-def logout(print_result=True) -> None:
+def logout(print_result=False) -> None:
     """
     Logs out of the Bystro server by deleting the authentication state file.
 

--- a/python/python/bystro/api/streaming.py
+++ b/python/python/bystro/api/streaming.py
@@ -46,8 +46,6 @@ def stream_file(
 
     response = requests.get(url, headers=auth_header, json=payload, stream=True)
 
-    response.raise_for_status()
-
     if response.status_code == 200:
         content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:

--- a/python/python/bystro/api/streaming.py
+++ b/python/python/bystro/api/streaming.py
@@ -1,6 +1,5 @@
 import requests
 import sys
-import subprocess
 from pathlib import Path
 
 from bystro.api.auth import authenticate

--- a/python/python/bystro/api/streaming.py
+++ b/python/python/bystro/api/streaming.py
@@ -52,9 +52,9 @@ def stream_file(
 
             # If the output directory is specified, stream the file to that directory
             if out_dir:
-                out_dir = Path(out_dir)
-                out_dir.mkdir(parents=True, exist_ok=True)
-                out_file = out_dir / filename
+                out_dir_path = Path(out_dir)
+                out_dir_path.mkdir(parents=True, exist_ok=True)
+                out_file = out_dir_path / filename
                 with open(out_file, "wb") as f:
                     for chunk in response.iter_content(chunk_size=1024):
                         f.write(chunk)

--- a/python/python/bystro/api/streaming.py
+++ b/python/python/bystro/api/streaming.py
@@ -1,10 +1,15 @@
 import requests
+import sys
+import subprocess
+from pathlib import Path
+
 from bystro.api.auth import authenticate
 
 GET_STREAM_ENDPOINT = "/api/jobs/{job_id}/streamFile"
 
 def stream_file(
-        job_id: str, output: bool = False, key_path: str | None = None, print_result: bool = True
+        job_id: str, output: bool = False, key_path: str | None = None,
+        out_dir: str | None = None
     ) -> None:
     """
     Fetch the file from the /api/jobs/:id/streamFile endpoint.
@@ -19,8 +24,8 @@ def stream_file(
         The path to the desired file, required if `output` is True and it will direct to the output dir.
         If `output` is False, `key_path` is used as an index into the input file dir. If not provided,
         the first input file is used.
-    print_result : bool
-        Whether to print the result of the fetch operation, by default True.
+    out_dir : str, optional
+        If specified, write the file to this directory. If not specified, the file is written to stdout
     """
     if not job_id:
         raise ValueError("Please specify a job id")
@@ -39,16 +44,27 @@ def stream_file(
     else:
         payload["keyPath"] = key_path if key_path else 0
 
-    response = requests.get(url, headers=auth_header, json=payload)
+    response = requests.get(url, headers=auth_header, json=payload, stream=True)
+
+    response.raise_for_status()
 
     if response.status_code == 200:
         content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             filename = content_disposition.split("filename=")[-1].strip("\"'")
-            with open(filename, "wb") as file:
-                file.write(response.content)
-            if print_result:
-                print(f"File was fetched and saved as {filename} successfully.")
+
+            # If the output directory is specified, stream the file to that directory
+            if out_dir:
+                out_dir = Path(out_dir)
+                out_dir.mkdir(parents=True, exist_ok=True)
+                out_file = out_dir / filename
+                with open(out_file, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=1024):
+                        f.write(chunk)
+            else:
+                # Otherwise, stream the file to stdout
+                for chunk in response.iter_content(chunk_size=1024):
+                    sys.stdout.buffer.write(chunk)
         else:
             raise RuntimeError("No Content-Disposition header found in the response.")
     elif response.status_code == 400:

--- a/python/python/bystro/api/streaming.py
+++ b/python/python/bystro/api/streaming.py
@@ -63,6 +63,7 @@ def stream_file(
                 # Otherwise, stream the file to stdout
                 for chunk in response.iter_content(chunk_size=1024):
                     sys.stdout.buffer.write(chunk)
+                sys.stdout.buffer.flush()
         else:
             raise RuntimeError("No Content-Disposition header found in the response.")
     elif response.status_code == 400:

--- a/python/python/bystro/cli/cli.py
+++ b/python/python/bystro/cli/cli.py
@@ -169,8 +169,8 @@ def stream_file_cli(args: argparse.Namespace) -> None:
         Whether to fetch the output file (True) or the input file (False), by default False.
     key_path : str, optional
         The key path for the output file, required if `output` is True.
-    print_result : bool
-        Whether to print the result of the fetch operation, by default True.
+    out_dir : str, optional
+        The directory to write the file to, if not specified, the file is written to stdout.
     """
     stream_file(
         job_id=args.job_id,

--- a/python/python/bystro/cli/cli.py
+++ b/python/python/bystro/cli/cli.py
@@ -176,7 +176,7 @@ def stream_file_cli(args: argparse.Namespace) -> None:
         job_id=args.job_id,
         output=args.output,
         key_path=args.key_path,
-        print_result=True,
+        out_dir=args.out_dir,
     )
 
 
@@ -317,6 +317,9 @@ def main():
     )
     fetch_parser.add_argument(
         "--key_path", help="Key path for the output and input dir, required if --output is used"
+    )
+    fetch_parser.add_argument(
+        "--out_dir", help="Specify --out_dir to write the file to that directory, otherwise stdout"
     )
     fetch_parser.set_defaults(func=stream_file_cli)
 


### PR DESCRIPTION
* Fix logging in with host that has trailing slash; when fetching files
* Stream outputs to stdout or to disk