### PR TITLE
[annotation, api] Improve streaming interface

### DIFF
--- a/python/python/bystro/api/streaming.py
+++ b/python/python/bystro/api/streaming.py
@@ -187,25 +187,25 @@ def stream_and_decompress_file(
     stream = stream_file(job_id, output=output, key_path=key_path)
 
     if stream is None:
-        # Yield None if the stream is None
         return None
 
-    for chunk in stream:
-        buffer.write(chunk)
-        buffer.seek(0)  # Reset buffer position to the start
-        while True:
-            try:
-                data = decompressor.read(1024)  # Read decompressed data in chunks
-                if not data:
+    def generator():
+        for chunk in stream:
+            buffer.write(chunk)
+            buffer.seek(0)  # Reset buffer position to the start
+            while True:
+                try:
+                    data = decompressor.read(1024)
+                    if not data:
+                        break
+                    yield data
+                except EOFError:
                     break
-                yield data  # Adjust the decoding if needed
-            except EOFError:
-                break
-        # Clear the buffer after reading
-        buffer.seek(0)
-        buffer.truncate()
 
-    # Close the decompressor
-    decompressor.close()
+            # Clear the buffer after reading
+            buffer.seek(0)
+            buffer.truncate()
 
-    return None
+        decompressor.close()
+
+    return generator()

--- a/python/python/bystro/api/streaming.py
+++ b/python/python/bystro/api/streaming.py
@@ -1,15 +1,24 @@
+import io
+import gzip
 import requests
 import sys
 from pathlib import Path
+from typing import Generator
 
 from bystro.api.auth import authenticate
 
 GET_STREAM_ENDPOINT = "/api/jobs/{job_id}/streamFile"
+MAX_STREAM_TIMEOUT = 60 * 60 * 24 * 7  # 1 week
+
 
 def stream_file(
-        job_id: str, output: bool = False, key_path: str | None = None,
-        out_dir: str | None = None
-    ) -> None:
+    job_id: str,
+    output: bool = False,
+    key_path: str | None = None,
+    out_dir: str | None = None,
+    write_stdout: bool = False,
+    chunk_size: int | None = None,
+) -> None | Generator[bytes, None, None]:
     """
     Fetch the file from the /api/jobs/:id/streamFile endpoint.
 
@@ -25,6 +34,47 @@ def stream_file(
         the first input file is used.
     out_dir : str, optional
         If specified, write the file to this directory. If not specified, the file is written to stdout
+    write_stdout : bool, optional
+        If True, write the file to write_stdout. If False, write the file to the specified directory.
+    chunk_size : int, optional
+        The size of the chunks to read from the response, by default None, which result
+
+    Returns
+    -------
+    None | Generator[bytes, None, None]
+        If `out_dir` is not specified, a generator that yields the file in chunks. Otherwise, None.
+
+    Examples
+    --------
+    >>> from bystro.api import auth, annotation, streaming
+    >>> import gzip
+    >>> import io
+    >>> user = auth.login('email', 'password', 'https://bystro-dev.emory.edu', print_result=False)
+    >>> res = annotation.get_jobs('completed')
+    >>> job_id = res[-2]._id
+    # Create a buffer to hold the streamed data
+    >>> buffer = io.BytesIO()
+
+    # Create a GzipFile object to read the decompressed data
+    >>> decompressor = gzip.GzipFile(fileobj=buffer, mode='rb')
+
+    >>> for chunk in streaming.stream_file(job_id, output=True, key_path='annotation'):
+    >>>     buffer.write(chunk)
+    >>>     buffer.seek(0)  # Reset buffer position to the start
+    >>>     while True:
+    >>>         try:
+    >>>             data = decompressor.read(1024)  # Read decompressed data in chunks
+    >>>             if not data:
+    >>>                 break
+    >>>             print(data.decode('utf-8'))  # Adjust the decoding if needed
+    >>>         except EOFError:
+    >>>             break
+    >>>     # Clear the buffer after reading
+    >>>     buffer.seek(0)
+    >>>     buffer.truncate()
+
+    # Close the decompressor
+    >>> decompressor.close()
     """
     if not job_id:
         raise ValueError("Please specify a job id")
@@ -32,7 +82,7 @@ def stream_file(
     state, auth_header = authenticate()
     url = state.url + GET_STREAM_ENDPOINT.format(job_id=job_id)
 
-    payload : dict[str, bool | str | int]  = {
+    payload: dict[str, bool | str | int] = {
         "output": output,
     }
 
@@ -43,31 +93,119 @@ def stream_file(
     else:
         payload["keyPath"] = key_path if key_path else 0
 
-    response = requests.get(url, headers=auth_header, json=payload, stream=True)
+    response = requests.get(
+        url, headers=auth_header, json=payload, stream=True, timeout=MAX_STREAM_TIMEOUT
+    )
 
     if response.status_code == 200:
         content_disposition = response.headers.get("Content-Disposition")
-        if content_disposition:
-            filename = content_disposition.split("filename=")[-1].strip("\"'")
+        if not content_disposition:
+            raise RuntimeError("No Content-Disposition header found in the response.")
+        
+        filename = content_disposition.split("filename=")[-1].strip("\"'")
 
-            # If the output directory is specified, stream the file to that directory
-            if out_dir:
-                out_dir_path = Path(out_dir)
-                out_dir_path.mkdir(parents=True, exist_ok=True)
-                out_file = out_dir_path / filename
-                with open(out_file, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=1024):
-                        f.write(chunk)
-            else:
-                # Otherwise, stream the file to stdout
-                for chunk in response.iter_content(chunk_size=1024):
+        if out_dir:
+            out_dir_path = Path(out_dir)
+            out_dir_path.mkdir(parents=True, exist_ok=True)
+            out_file = out_dir_path / filename
+            with open(out_file, "wb") as f:
+                for chunk in response.iter_content(chunk_size=chunk_size):
+                    f.write(chunk)
+            return None
+
+        if write_stdout:
+            if hasattr(sys.stdout, "buffer"):
+                for chunk in response.iter_content(chunk_size=chunk_size):
                     sys.stdout.buffer.write(chunk)
                 sys.stdout.buffer.flush()
-        else:
-            raise RuntimeError("No Content-Disposition header found in the response.")
-    elif response.status_code == 400:
+            else:
+                for chunk in response.iter_content(chunk_size=chunk_size):
+                    sys.stdout.write(chunk)
+                sys.stdout.flush()
+
+            return None
+
+        def generator():
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                yield chunk
+
+        return generator()
+    
+    if response.status_code == 400:
         raise RuntimeError(f"Bad Request: {response.text}")
-    elif response.status_code == 404:
+    
+    if response.status_code == 404:
         raise RuntimeError("File not found.")
-    else:
-        raise RuntimeError(f"Failed to fetch file. Error code: {response.status_code}")
+
+    raise RuntimeError(f"Failed to fetch file. Error code: {response.status_code}")
+
+
+def stream_and_decompress_file(
+    job_id: str,
+    output: bool = True,
+    key_path: str | None = "annotation",
+) -> None | Generator[bytes, None, None]:
+    """
+    Fetch the file from the /api/jobs/:id/streamFile endpoint and decompress it.
+
+    Parameters
+    ----------
+    job_id : str
+        The ID of the job being fetched.
+    output : bool, optional
+        Whether to fetch the output file (True) or the input file (False), by default False.
+    key_path : str, optional
+        The path to the desired file, required if `output` is True and it will direct to the output dir.
+        If `output` is False, `key_path` is used as an index into the input file dir. If not provided,
+        the first input file is used.
+
+    Returns
+    -------
+    None | Generator[bytes, None, None]
+        If `out_dir` is not specified, a generator that yields the file in chunks. Otherwise, None.
+
+    Examples
+    --------
+    >>> line = ''
+    >>> lines = []
+    >>> for chunk in streaming.stream_and_decompress_file(job_id, output=True, key_path='annotation'):
+    >>>    line_chunk = chunk.decode('utf-8')
+
+    >>>    if "\n" in line_chunk:
+    >>>        parts = line_chunk.split("\n")
+    >>>        lines.append(line + parts[0])
+    >>>        line = parts[1]
+
+    """
+
+    # Create a buffer to hold the streamed data
+    buffer = io.BytesIO()
+
+    # Create a GzipFile object to read the decompressed data
+    decompressor = gzip.GzipFile(fileobj=buffer, mode="rb")
+
+    stream = stream_file(job_id, output=output, key_path=key_path)
+
+    if stream is None:
+        # Yield None if the stream is None
+        return None
+
+    for chunk in stream:
+        buffer.write(chunk)
+        buffer.seek(0)  # Reset buffer position to the start
+        while True:
+            try:
+                data = decompressor.read(1024)  # Read decompressed data in chunks
+                if not data:
+                    break
+                yield data  # Adjust the decoding if needed
+            except EOFError:
+                break
+        # Clear the buffer after reading
+        buffer.seek(0)
+        buffer.truncate()
+
+    # Close the decompressor
+    decompressor.close()
+
+    return None

--- a/python/python/bystro/api/tests/test_streaming.py
+++ b/python/python/bystro/api/tests/test_streaming.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch, MagicMock
+import io
+import gzip
+from contextlib import redirect_stdout
+
+from bystro.api.streaming import stream_file, stream_and_decompress_file
+
+
+@patch("bystro.api.streaming.authenticate")
+@patch("bystro.api.streaming.requests.get")
+def test_stream_file(mock_get, mock_authenticate):
+    # Setup
+    mock_authenticate.return_value = (
+        MagicMock(url="http://test-url.com"),
+        {"Authorization": "Bearer token"},
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Disposition": 'attachment; filename="testfile.txt"'}
+    mock_response.iter_content.return_value = [b"chunk1", b"chunk2"]
+    mock_get.return_value = mock_response
+
+    # Test streaming to generator
+    stream = stream_file(job_id="1234", chunk_size=5)
+    assert stream is not None
+
+    chunks = list(stream)
+    assert chunks == [b"chunk1", b"chunk2"]
+
+    with io.BytesIO() as buf, redirect_stdout(buf):
+        stream_file(job_id="1234", write_stdout=True, chunk_size=5)
+        buf.seek(0)
+        assert buf.read() == b"chunk1chunk2"
+
+
+@patch("bystro.api.streaming.authenticate")
+@patch("bystro.api.streaming.requests.get")
+def test_stream_and_decompress_file(mock_get, mock_authenticate):
+    # Setup
+    mock_authenticate.return_value = (
+        MagicMock(url="http://test-url.com"),
+        {"Authorization": "Bearer token"},
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Disposition": 'attachment; filename="testfile.txt"'}
+    content = gzip.compress(b"chunk1chunk2")
+    mock_response.iter_content.return_value = [content[:10], content[10:]]
+    mock_get.return_value = mock_response
+
+    # Test decompression
+    stream = stream_and_decompress_file(job_id="1234")
+    decompressed_chunks = list(stream)
+    assert b"".join(decompressed_chunks) == b"chunk1chunk2"


### PR DESCRIPTION
* Adds ability to yield chunks rather than write them to stdout or out_dir
* Creates stream_and_decompress_file which will also decompress the chunks


TL;DR:
```python
line = ''
lines = []
for chunk in streaming.stream_and_decompress_file(job_id, output=True, key_path='annotation'):
    line_chunk = chunk.decode('utf-8')
    
    if "\n" in line_chunk:
      parts = line_chunk.split("\n")
      lines.append(line + parts[0])
      line = parts[1]
```