### PR TITLE
Update .gitattributes to exclude .ipynb from programming language calculations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 *.feather binary
 
 *.zip binary
+
+*.ipynb linguist-vendored


### PR DESCRIPTION
* Update .gitattributes to exclude .ipynb from programming language calculations