### PR TITLE
reduce perl docker image size

### DIFF
--- a/Dockerfile.perl
+++ b/Dockerfile.perl
@@ -29,7 +29,7 @@ COPY install-apt.sh /bystro/install-apt.sh
 # Install dependencies
 RUN cd /bystro && ./install-apt.sh \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && bash -c "source ~/.profile && go clean -modcache" && rm -rf ~/.cache/go-build && ~/go/src \
+    && bash -c "source ~/.profile && go clean -modcache" && rm -rf ~/.cache/go-build ~/go/src \
     && rm -rf ~/perl5/perlbrew/build ~/.perl-cpm
 
 WORKDIR /bystro

--- a/Dockerfile.perl
+++ b/Dockerfile.perl
@@ -29,8 +29,8 @@ COPY install-apt.sh /bystro/install-apt.sh
 # Install dependencies
 RUN cd /bystro && ./install-apt.sh \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && . /root/.profile && go clean -modcache && rm -rf /root/.cache/go-build && /root/go/src \
-    && rm -rf /root/perl5/perlbrew/build /root/.perl-cpm
+    && bash -c "source ~/.profile && go clean -modcache" && rm -rf ~/.cache/go-build && ~/go/src \
+    && rm -rf ~/perl5/perlbrew/build ~/.perl-cpm
 
 WORKDIR /bystro
 

--- a/Dockerfile.perl
+++ b/Dockerfile.perl
@@ -15,17 +15,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     perl \
     man-db \
     groff \
-    libperl-dev
+    libperl-dev \
+    && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY perl /bystro/perl
 COPY go /bystro/go
 COPY install /bystro/install
+COPY config /bystro/config
 
 # Copy your install-apt.sh script into the container
 COPY install-apt.sh /bystro/install-apt.sh
 
 # Install dependencies
-RUN cd /bystro && ./install-apt.sh
+RUN cd /bystro && ./install-apt.sh \
+    && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && . /root/.profile && go clean -modcache && rm -rf /root/.cache/go-build && /root/go/src \
+    && rm -rf /root/perl5/perlbrew/build /root/.perl-cpm
+
+WORKDIR /bystro
 
 # Symlink everything in /bystro/perl/bin to /usr/local/bin
 ENTRYPOINT ["/bin/bash", "-c", "source ~/.profile && if [ \"$#\" -eq 0 ]; then bystro-annotate.pl --help; else exec \"$@\"; fi", "--"]


### PR DESCRIPTION
* reduce perl docker image size (2.38GB -> 1.47GB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced cleanup process in the Docker configuration for improved efficiency.
	- Added a new `COPY` command to include a `config` directory.
	- Updated `WORKDIR` and `ENTRYPOINT` commands for better command-line handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->