### PR TITLE
pin ubuntu to 22.04, to fix maturin publication action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             target: x86_64
             local_name: x86_64
     steps:
@@ -142,7 +142,7 @@ jobs:
           cd python && pytest
 
   sdist:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build sdist
@@ -158,7 +158,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, macos, sdist]
     steps:


### PR DESCRIPTION
* Address PyO3/maturin-action@v1 issue in ubuntu 24.04 by pinning to ubuntu 22.04. See https://github.com/PyO3/maturin-action/issues/291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to use `ubuntu-22.04` for Linux jobs, enhancing compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->