### PR TITLE
Improve Think SDK progress and run workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,38 +117,35 @@ The Python package can submit durable agentic workloads to the same Bystro
 Think account used at [bystro.cloud](https://bystro.cloud):
 
 ```python
-from bystro.api import auth
-from bystro.think import NeedsInput, RunOptions, ThinkClient
+from bystro.think import RunOptions, ThinkClient, show_progress
 
-auth.login("you@example.com", "your-password")
 
-with ThinkClient() as client:
-    run = client.submit(
+# Complete the one-time getpass-based login in python/THINK_API.md first.
+with ThinkClient.from_cached_login(on_event=show_progress) as client:
+    run = client.submit_with_progress(
         "Compare the case and control cohorts in these files.",
         files=["cases.vcf.gz", "controls.vcf.gz"],
         options=RunOptions(mode="plus", advanced_planning=True),
     )
-
-    outcome = run.wait()
-    while isinstance(outcome, NeedsInput):
-        print(outcome.prompt)
-        outcome = run.respond(input("> ")).wait()
-
-    print(outcome.output)
+    outcome = run.interact(timeout=3600)
+    print(outcome)
 ```
 
-On deployments with Bystro's shared site-access gate, pass
-`site_access_code=os.environ["BYSTRO_SITE_ACCESS_CODE"]` to `auth.login` or
-`ThinkClient.login`; the gate code is used for that login session and is not
-cached.
+The one-time login uses `getpass` and can include Bystro's shared site-access
+code. Neither the password nor gate code needs to appear in normal scripts;
+only the dashboard JWT is cached with owner-only filesystem permissions.
 
 ```python
-import os
+from getpass import getpass
 
+from bystro.api import auth
+
+
+site_access_code = getpass("Site access code (leave blank if not required): ")
 auth.login(
-    "you@example.com",
-    "your-password",
-    site_access_code=os.environ["BYSTRO_SITE_ACCESS_CODE"],
+    input("Bystro email: ").strip(),
+    getpass("Bystro password: "),
+    site_access_code=site_access_code or None,
 )
 ```
 
@@ -166,8 +163,9 @@ from bystro.think import (
 message = add_genetic_context("annotation-job-id", "Investigate this phenotype")
 message = add_previous_conversation_context("earlier-thread-id", message)
 message = add_artifact_context("existing-artifact-id", message)
-run = client.submit(message)
+run = client.submit_with_progress(message)
 ```
 
-See the [Think Python API guide](python/THINK_API.md) for progress events,
-large uploads, reconnecting to runs, typed errors, and context composition.
+See the [Think Python API guide](python/THINK_API.md) for structured phases and
+heartbeats, chunked uploads, interactive callbacks, cancellation versus detach,
+async iteration, conversation history, and protected result downloads.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bystro"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "pyo3",
 ]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bystro"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 build = "build.rs"
 

--- a/python/THINK_API.md
+++ b/python/THINK_API.md
@@ -1,316 +1,236 @@
 # Bystro Think Python API
 
-The Think SDK is a synchronous, typed client for durable Bystro agent
-workloads. It intentionally exposes a small surface: authenticate, upload
-artifacts, compose context, submit work, observe progress, answer pauses, and
-resume by run ID.
+The Think SDK submits durable agent workloads, streams visible output and
+structured progress, handles human-input pauses, uploads large files in chunks,
+reuses Bystro datasets and conversations as context, and downloads protected
+results.
 
 ## Install
 
-Bystro 2.1.1 supports CPython 3.11 and 3.12. Activate the environment you want
-to use, confirm it with `python --version`, and install from PyPI:
+Bystro 2.1.2 supports CPython 3.11 and 3.12:
 
 ```sh
-python -m pip install "bystro>=2.1.1,<2.2"
+python --version
+python -m pip install "bystro>=2.1.2,<2.2"
 ```
 
-Production endpoints use publicly trusted HTTPS certificates, so no custom CA
-bundle or TLS override is required. A private CA bundle is only needed for a
-local development deployment that uses its own certificate authority.
+Production uses publicly trusted HTTPS certificates. Customers do not need a
+custom CA bundle or TLS override; those are only for local development servers
+using a private certificate authority.
 
-## Authenticate
+## Authenticate once, then use the cached login
 
-`auth.login` uses the same `bystro.cloud` dashboard account as the browser and
-caches its JWT in `~/.bystro/bystro_authentication_token.json`. The directory
-is mode `0700`, the file is atomically replaced at mode `0600`, and tokens are
-never printed.
+Use `getpass` for the one-time interactive login so secrets do not appear in
+source code, notebook output, shell history, or environment listings:
 
 ```python
+from getpass import getpass
+
 from bystro.api import auth
+
+
+email = input("Bystro email: ").strip()
+site_access_code = getpass("Site access code (leave blank if not required): ")
+auth.login(
+    email,
+    getpass("Bystro password: "),
+    site_access_code=site_access_code or None,
+)
+```
+
+The login JWT is stored in `~/.bystro/bystro_authentication_token.json`; the
+directory is mode `0700` and the atomically replaced file is mode `0600`. The
+site-access code is used only for that login session and is not cached.
+
+Normal scripts then use the cached login without handling a password:
+
+```python
 from bystro.think import ThinkClient
 
-auth.login("you@example.com", "your-password")
 client = ThinkClient.from_cached_login()
 ```
 
-For short scripts, login and construction can be one call:
+New accounts must accept the current legal assertions once. Use
+`LegalConsent.accepted(name)` with `auth.signup(...)`, or complete signup in the
+dashboard before running the login snippet above.
+
+## Canonical interactive workflow
+
+This is the recommended customer experience. It prints lifecycle changes,
+backend-owned phases such as web search and source verification, visible answer
+chunks, and an elapsed heartbeat if no server frame arrives for 30 seconds.
+`interact()` prompts for any number of clarification or plan-review pauses.
 
 ```python
-client = ThinkClient.login("you@example.com", "your-password")
-```
-
-If the deployment keeps Bystro's shared site-access gate enabled, present its
-code during the same login. The SDK establishes the gate cookie and performs
-dashboard login in one private session; the code is never written to the auth
-cache:
-
-```python
-import os
-
-client = ThinkClient.login(
-    "you@example.com",
-    "your-password",
-    site_access_code=os.environ["BYSTRO_SITE_ACCESS_CODE"],
-)
-```
-
-New accounts must explicitly provide the dashboard's signed legal assertions:
-
-```python
-from bystro.api.auth import LegalConsent, signup
-
-signup(
-    "you@example.com",
-    "your-password",
-    "Your Name",
-    legal_consent=LegalConsent.accepted("Your Name"),
-    site_access_code=os.environ["BYSTRO_SITE_ACCESS_CODE"],
-)
-```
-
-`site_access_code` is the Bystro application gate, not a Cloudflare credential.
-Cloudflare must still allow non-browser traffic to the dashboard authentication
-and Think API routes while retaining its challenge on browser pages.
-
-The SDK exchanges that dashboard session through Think's existing cookie-auth
-admission endpoint. The application credential created by Think remains on the
-server; it is not copied into local code or exposed as a second API key.
-
-## Customer quickstart: complete examples
-
-Start with this shared setup. Credentials come from environment variables, and
-the `wait_for_result` loop handles any number of durable clarification or plan
-review pauses while progress continues to stream. A billing pause must be
-resolved in the dashboard before refreshing the run.
-
-```python
-import os
-
-from bystro.think import (
-    InputKind,
-    NeedsInput,
-    Run,
-    RunResult,
-    ThinkClient,
-    show_progress,
-)
+from bystro.think import NeedsInput, RunResult, ThinkClient, show_progress
 
 
-def login() -> ThinkClient:
-    return ThinkClient.login(
-        os.environ["BYSTRO_EMAIL"],
-        os.environ["BYSTRO_PASSWORD"],
-        site_access_code=os.environ.get("BYSTRO_SITE_ACCESS_CODE"),
-        on_event=show_progress,
-    )
-
-
-def wait_for_result(run: Run) -> RunResult:
-    while True:
-        outcome = run.wait(timeout=3600)
-        if not isinstance(outcome, NeedsInput):
-            return outcome
-
-        print(f"\n{outcome.prompt}")
-        if outcome.kind is InputKind.BILLING:
-            input("Resolve billing in the dashboard, then press Enter: ")
-            run.refresh()
-            continue
-
-        run.respond(input("> "))
-```
-
-Set credentials before running an example:
-
-```sh
-export BYSTRO_EMAIL="you@example.com"
-export BYSTRO_PASSWORD="your-password"
-export BYSTRO_SITE_ACCESS_CODE="your-site-code"  # omit when not required
-```
-
-### 1. Submit a question with live progress
-
-`submit_with_progress` installs the concise progress renderer automatically.
-Passing `show_progress` at login also reports connection and reconnect events.
-The final answer remains available as the typed `RunResult.output` value.
-
-```python
-with login() as client:
+with ThinkClient.from_cached_login(on_event=show_progress) as client:
     run = client.submit_with_progress(
         "Research the latest CAR-T therapies and cite primary sources."
     )
-    result = wait_for_result(run)
+    outcome = run.interact(timeout=3600)
 
-    print("\n--- Final response ---\n")
-    print(result.output)
+    if isinstance(outcome, NeedsInput):
+        # interact() handles clarification and plan-review pauses itself.
+        # A returned NeedsInput is a billing pause that must be resolved in
+        # the dashboard, followed by run.refresh(). Unlimited accounts should
+        # not enter this branch.
+        print(outcome)
+    else:
+        assert isinstance(outcome, RunResult)
+        print("\nFinal Markdown is also available as outcome.output")
 ```
 
-Progress is based on durable server lifecycle and status events; it is not a
-token-by-token stream of the final prose.
+`submit_with_progress()` installs a progress renderer automatically. Supplying
+`show_progress` on the client also includes connection and reconnect events.
+Do not pass the same callback again to `run.wait(on_event=...)`.
 
-### 2. Submit a question with files
+Think uses authenticated Socket.IO transport. It normally upgrades to WebSocket
+and retains HTTP polling as a compatibility fallback. Output frames are
+cumulative short snapshots, not necessarily one event per tokenizer token; the
+SDK turns them into exact append/replace/retract updates and never exposes
+internal reasoning text.
 
-Paths passed through `files` are uploaded first and then attached to the same
-question. Large files automatically use the resumable, chunked upload path.
+To require native WebSocket and fail rather than fall back to polling:
 
 ```python
-from bystro.think import UploadProgress
+with ThinkClient.from_cached_login(
+    on_event=show_progress,
+    transports=("websocket",),
+) as client:
+    result = client.submit_with_progress("Draw a duck.").interact(timeout=3600)
+```
+
+## Non-interactive input callbacks
+
+Applications can answer pauses without calling `input()`. Manual `wait()` and
+`respond()` remain available when the application needs complete control.
+
+```python
+from bystro.think import NeedsInput, ThinkClient
 
 
-def report_upload(progress: UploadProgress) -> None:
+def answer_clarification(request: NeedsInput) -> str:
+    print("Clarification:", request.prompt)
+    return "Cover all disease areas and the last 24 months."
+
+
+def review_plan(request: NeedsInput) -> str:
+    print("Proposed plan:", request.prompt)
+    return "accept"
+
+
+with ThinkClient.from_cached_login() as client:
+    run = client.submit_with_progress("Research recent CAR-T therapies.")
+    result = run.interact(
+        timeout=3600,
+        on_clarification=answer_clarification,
+        on_plan_review=review_plan,
+    )
+```
+
+For manual control:
+
+```python
+from bystro.think import InputKind, NeedsInput
+
+
+outcome = run.wait(timeout=3600)
+if isinstance(outcome, NeedsInput):
+    if outcome.kind is InputKind.PLAN_REVIEW:
+        run.respond("accept")
+    elif outcome.kind is InputKind.CLARIFICATION:
+        run.respond("Use case_control as the phenotype column")
+```
+
+The first live pause can precede its durable checkpoint commit. `respond()`
+waits for the checkpoint replay before uploading attachments or dispatching the
+answer, and ignores stale replayed checkpoints after reconnect.
+
+## Choose a mode
+
+The default mode is `base`. Pass `RunOptions` per submitted conversation:
+
+```python
+from bystro.think import RunOptions
+
+
+run = client.submit_with_progress(
+    "Research the latest CAR-T therapies and cite primary sources.",
+    options=RunOptions(mode="plus2"),
+)
+```
+
+| Value | Dashboard name | Intended use |
+| --- | --- | --- |
+| `base` | Base | Faster, token-efficient work with lighter research. |
+| `plus` | Plus v1 | Verified analysis with deep research. |
+| `plus2` | Plus v2 | Stronger experimental research workflow. |
+| `phd` | PhD | Deepest reasoning for demanding analyses. |
+
+Other controls are typed fields on `RunOptions`: `advanced_planning`,
+`auto_compact`, `fast`, `verify`, `verify_sources`, and
+`zero_data_retention`. Availability and billing follow the authenticated
+account and deployment configuration.
+
+## Submit files with the question
+
+A path passed in `files` is uploaded to the authenticated user's personal
+artifacts and attached to the same message. Large inputs use resumable bounded
+10 MiB chunks, SHA-256 checksums, idempotent retries, and asynchronous
+finalization polling.
+
+```python
+from bystro.think import ThinkClient, UploadProgress
+
+
+def upload_progress(progress: UploadProgress) -> None:
     print(
         f"[upload:{progress.phase.value}] {progress.fraction:.0%}",
         flush=True,
     )
 
 
-with login() as client:
+with ThinkClient.from_cached_login() as client:
     run = client.submit_with_progress(
         "Analyze the cohort using the attached phenotype table.",
         files=["cohort.vcf.gz", "phenotypes.tsv"],
-        on_upload_progress=report_upload,
+        on_upload_progress=upload_progress,
     )
-    result = wait_for_result(run)
-    print(result.output)
+    result = run.interact(timeout=3600)
 ```
 
-### 3. Submit with genetic, conversation, and artifact context
-
-The `add_*_context` helpers accept a string or an existing
-`MessageWithContext`, so context can be built one layer at a time. Existing
-references are resolved under the authenticated user's ownership.
+A single path can be passed directly:
 
 ```python
-import os
-
-from bystro.think import (
-    add_artifact_context,
-    add_genetic_context,
-    add_previous_conversation_context,
-)
-
-
-with login() as client:
-    artifact = client.upload_artifact("study-notes.pdf")
-
-    message = "Re-evaluate the strongest phenotype associations."
-    message = add_genetic_context(
-        os.environ["BYSTRO_JOB_ID"],
-        message,
-        name="Case cohort",
-        assembly="hg38",
-    )
-    message = add_previous_conversation_context(
-        os.environ["BYSTRO_PRIOR_THREAD_ID"],
-        message,
-        name="Previous analysis",
-    )
-    message = add_artifact_context(artifact, message)
-
-    run = client.submit_with_progress(message)
-    result = wait_for_result(run)
-    print(result.output)
-```
-
-For a reusable higher-order context pipeline:
-
-```python
-from bystro.think import (
-    artifact_context,
-    compose_context,
-    genetic_context,
-    previous_conversation_context,
-)
-
-add_study_context = compose_context(
-    genetic_context("annotation-job-id", assembly="hg38"),
-    previous_conversation_context("prior-thread-id"),
-    artifact_context("existing-artifact-id"),
-)
-
-message = add_study_context("Compare the strongest signals.")
-```
-
-### 4. List conversations, browse results, and download files
-
-`list_conversations` returns the authenticated user's conversations newest
-first and transparently follows every cursor page. Pass `search` to filter by
-conversation name. Resume a returned ID to browse or download its protected
-output files through the same authenticated session.
-
-```python
-from pathlib import Path
-
-
-with login() as client:
-    conversations = client.list_conversations(search="CAR-T")
-    for conversation in conversations:
-        print(conversation.id, conversation.name)
-
-    if not conversations:
-        raise RuntimeError("No matching conversations")
-
-    previous_run = client.resume(conversations[0].id)
-    files = previous_run.output_files()
-    for output_file in files:
-        print(output_file.path, output_file.size)
-
-    if files:
-        downloaded = previous_run.download_file(
-            files[0],
-            Path("downloads") / files[0].path,
-        )
-        print("Downloaded:", downloaded)
-
-    archive = previous_run.download_all(
-        Path("downloads") / f"{previous_run.id}.tar"
-    )
-    print("Archive:", archive)
-```
-
-`download_file` and `download_all` stream to a temporary file and only publish
-the destination after the authenticated download completes. Existing targets
-are not overwritten unless `overwrite=True` is passed explicitly.
-
-## Upload files and submit them with a question
-
-Passing paths to `submit` uploads each file to personal input artifacts first,
-then attaches the resulting artifact records to the same user message:
-
-```python
-run = client.submit(
-    "Find variants associated with the case phenotype.",
-    files=["cohort.vcf.gz", "phenotypes.tsv"],
+run = client.submit_with_progress(
+    "Summarize this study protocol.",
+    files="protocol.pdf",
 )
 ```
 
-Uploads use the production resumable protocol: bounded 10 MiB chunks,
-per-chunk SHA-256 checksums, idempotent retries with exponential backoff, and
-polling for asynchronous server finalization. The chunk size and retry policy
-can be configured on `ThinkClient`. An `artifact_path` is relative, has at most
-64 components, and must end in the local file's exact name; invalid paths fail
-locally before authentication or upload begins.
-
-Use `upload_artifact` when the artifact should be created before the question:
+Create a reusable artifact before submission with `upload_artifact()` (or its
+short alias `upload()`):
 
 ```python
-def report_upload(progress):
-    print(progress.phase.value, f"{progress.fraction:.0%}")
-
 artifact = client.upload_artifact(
     "cohort.vcf.gz",
     artifact_path="study/cohort.vcf.gz",
-    on_progress=report_upload,
+    on_progress=upload_progress,
 )
-run = client.submit("Run QC on this cohort", files=[artifact])
+run = client.submit_with_progress("Run QC on this cohort.", files=[artifact])
 ```
 
-`upload` is an equivalent shorter alias.
+Artifact paths are relative, have at most 64 components, and must end with the
+local file's exact name. Invalid paths fail locally before upload.
 
 ## Compose genetic, conversation, and artifact context
 
-Context helpers accept either a plain string or an immutable
-`MessageWithContext`, so calls compose naturally:
+The context helpers accept either a string or an immutable
+`MessageWithContext`, so they compose without constructing XML manually. The
+SDK serializes an escaped XML preview with `message.to_xml()`, while the live
+request keeps ownership-bearing references in structured metadata.
 
 ```python
 from bystro.think import (
@@ -319,7 +239,8 @@ from bystro.think import (
     add_previous_conversation_context,
 )
 
-message = "Compare the strongest signals"
+
+message = "Re-evaluate the strongest phenotype associations."
 message = add_genetic_context(
     "annotation-job-id",
     message,
@@ -333,10 +254,10 @@ message = add_previous_conversation_context(
 )
 message = add_artifact_context(artifact, message)
 
-run = client.submit(message)
+run = client.submit_with_progress(message)
 ```
 
-Reusable higher-order transforms are also available:
+Reusable higher-order transforms are available:
 
 ```python
 from bystro.think import (
@@ -346,107 +267,235 @@ from bystro.think import (
     previous_conversation_context,
 )
 
+
 study_context = compose_context(
-    genetic_context("annotation-job-id", name="Case cohort", assembly="hg38"),
+    genetic_context("annotation-job-id", assembly="hg38"),
     previous_conversation_context("prior-thread-id"),
     artifact_context("existing-artifact-id"),
 )
 
-run = client.submit(study_context("Re-evaluate the phenotype association"))
+run = client.submit_with_progress(
+    study_context("Compare the strongest signals.")
+)
 ```
 
-`message.to_xml()` returns a safely escaped preview of the semantic context.
-On the wire, references remain structured metadata. Think resolves artifacts
-against the authenticated user before creating canonical input-file context;
-dataset and conversation retrieval tools independently enforce ownership
-before returning referenced data. Raw user-authored XML is never treated as an
-ownership boundary.
+Think resolves every dataset, conversation, and artifact under the
+authenticated user's ownership. User-authored XML is never an authorization
+boundary.
 
-## Handle `needs_input`
+## Structured progress and custom presentation
 
-`wait()` returns exactly one of two values: `RunResult` or `NeedsInput`.
-Clarifications and plan review are durable checkpoint states, not transient
-socket prompts.
+`ThinkEvent.progress` contains the server's current phase snapshot. Typical
+phase kinds are `search`, `verify`, `compute`, `query`, and `think`.
+`ThinkEvent.stream_update` contains safe visible-output deltas.
 
 ```python
-from bystro.think import InputKind, NeedsInput
+from bystro.think import EventKind, ThinkEvent
 
-outcome = run.wait(timeout=3600)
-if isinstance(outcome, NeedsInput):
-    if outcome.kind is InputKind.PLAN_REVIEW:
-        run.respond("accept")
-    else:
-        run.respond("Use case_control as the phenotype column")
-    outcome = run.wait(timeout=3600)
+
+def on_event(event: ThinkEvent) -> None:
+    if event.progress is not None:
+        phase = event.progress.active_phase
+        if phase is not None:
+            print(phase.kind, phase.label, phase.completed, phase.total)
+        return
+
+    update = event.stream_update
+    if event.kind is EventKind.STREAM and update is not None:
+        if update.operation == "append":
+            print(update.delta, end="", flush=True)
+        elif update.operation == "replace":
+            print("\n[corrected output]\n", update.delta)
+        elif update.operation == "retract":
+            print(f"\n[removed message {update.message_id}]")
 ```
 
-The first live pause notification can arrive just before its checkpoint is
-committed, so `checkpoint_id` may initially be `None`. `run.respond()` requests
-the durable replay automatically and will not upload attachments or dispatch
-the response until the checkpoint is present. Once answered, replays of that
-same or an older checkpoint are ignored, preventing reconnect races from
-reopening a stale question. If synchronization fails, the pause remains intact
-and `RunProtocolError` asks you to call `run.refresh()` and retry. A billing
-pause is also represented as `NeedsInput`, but must be resolved through the
-billing action in the dashboard; then call `run.refresh()`.
+`ProgressRenderer(heartbeat_interval=30)` provides the canonical terminal
+presentation. Generic `Thinking...` and `Processing...` states print at most
+once per turn; meaningful phase/count changes print immediately; and the renderer emits
+`Still working... (… elapsed)` during complete transport silence. Heartbeat
+workers stop on input, completion, failure, cancellation, or local detach.
 
-## Progress and reconnects
+## Results, conversations, and downloads
 
-`submit_with_progress` uses `show_progress`; use `submit` for silent workloads:
+Generated files are available directly on a successful `RunResult`. The
+listing is authenticated and loaded once, on first access, so access it while
+the client context is open:
 
 ```python
-from bystro.think import ThinkClient, show_progress
+from pathlib import Path
 
-with ThinkClient.login(
-    "you@example.com", "your-password", on_event=show_progress
-) as client:
-    run = client.submit_with_progress("Perform a GWAS", files=["cohort.vcf.gz"])
-    result = run.wait()
+from bystro.think import RunResult, ThinkClient
+
+
+with ThinkClient.from_cached_login() as client:
+    run = client.submit_with_progress("Draw and save a cartoon duck.")
+    result = run.interact(timeout=3600)
+    if not isinstance(result, RunResult):
+        raise RuntimeError("The run paused for billing")
+
+    for output_file in result.files:  # result.artifacts is the same tuple
+        print(output_file.path, output_file.size)
+
+    if result.files:
+        first = run.download_file(
+            result.files[0],
+            Path("downloads") / result.files[0].path,
+        )
+        print("Downloaded:", first)
+
+    archive = run.download_all(Path("downloads") / f"{run.id}.tar")
+    print("Archive:", archive)
 ```
 
-## Browse and download generated results
+`download_file()` and `download_all()` stream to a temporary file and publish
+the destination only after the authenticated download completes. Existing
+targets are never replaced unless `overwrite=True` is explicit.
+
+List and resume past conversations:
 
 ```python
-conversations = client.list_conversations(search="CAR-T")
+conversations = client.list_conversations(search="CAR-T", limit=20)
 for conversation in conversations:
-    print(conversation.id, conversation.name)
+    print(conversation.id, conversation.name, conversation.created_at)
 
-files = run.output_files()
-print([(output_file.path, output_file.size) for output_file in files])
-image = run.download_file(files[0], "downloads/duck.png")
-archive = run.download_all("downloads/all-results.tar")
+previous = client.resume(conversations[0].id)
+print(previous.messages)
+print(previous.output_files())
 ```
 
-The durable run ID is available immediately after admission:
+Omit `limit` to traverse all cursor pages. `run.messages` excludes internal
+reasoning and progress-card messages; `run.history` is bounded SDK event
+history. A resumed run restores its submitted mode and other `RunOptions`, so
+`run.follow_up(...)` continues with the original settings.
+
+In Jupyter, `RunResult` and `NeedsInput` implement `_repr_markdown_()`, so
+placing either object at the end of a cell renders its Markdown naturally.
+
+## Cancellation, detach, and reconnect
+
+Cancellation is distinct from closing a local client:
 
 ```python
-print(run.id)
+from bystro.think import RunCancelledError
+
+
+run.cancel(timeout=60)  # waits for durable server cleanup to be released
+try:
+    run.wait()
+except RunCancelledError:
+    print("Cancelled")
 ```
 
-Another process can attach to it later:
+`cancel()` sends the active task ID when available, ignores delayed lifecycle
+events from older tasks, and reissues an interrupted stop after reconnect until
+the server emits its durable release event.
+
+Use `run.detach()` (or close the `ThinkClient`) to disconnect locally while the
+server keeps working. Reattach from another process later:
 
 ```python
-client = ThinkClient()
-run = client.resume("run-or-thread-id")
-outcome = run.wait()
+run_id = run.id
+run.detach()
+
+with ThinkClient.from_cached_login() as client:
+    resumed = client.resume(run_id)
+    outcome = resumed.wait(timeout=3600)
 ```
 
-`run.messages` provides the hydrated transcript and `run.history` provides
-bounded SDK progress history. Socket reconnects automatically replay the
-current overlay state. When a replayed `needs_input` overlay arrives before its
-transcript, `wait()` holds the outcome until transcript hydration restores the
-clarification or plan-review prompt.
+A `ThinkClient` owns one foreground conversation at a time. Use separate
+clients for concurrently controlled conversations.
 
-## Follow-up turns and errors
+## Async applications
 
-After a successful result, start another turn in the same conversation:
+The submission API is synchronous; the live event iterator and terminal wait
+also have event-loop-friendly async forms:
 
 ```python
-run.follow_up("Now stratify the result by ancestry")
-next_result = run.wait()
+import asyncio
+
+from bystro.think import ThinkClient
+
+
+async def main() -> None:
+    with ThinkClient.from_cached_login() as client:
+        run = client.submit("Research recent CAR-T approvals.")
+        async for event in run.aevents(timeout=3600):
+            print(event.kind.value)
+        result = await run.await_result(timeout=30)
+        print(result)
+
+
+asyncio.run(main())
 ```
 
-Transport, HTTP, billing, admission, timeout, and protocol failures have typed
-exceptions under `bystro.think`. A `ThinkClient` owns one foreground run at a
-time; use separate clients for concurrently controlled conversations. Closing
-a client disconnects local transports but does not cancel durable server work.
+`aevents()` never blocks the event loop while waiting for Socket.IO events;
+durable refreshes run outside the loop.
+
+## Cloudflare configuration
+
+No Cloudflare change is needed when the installed SDK connects, uploads, and
+downloads successfully. If browser-only challenges intercept Python traffic,
+create a **zone-level custom rule** with action **Skip** and match only the API
+hosts/routes used by the SDK. Select only:
+
+- All Super Bot Fight Mode rules
+- Browser Integrity Check
+- Security Level
+
+Keep **Log matching requests** enabled. Do not select all remaining custom
+rules, rate limiting rules, or managed WAF rules unless a specific logged false
+positive proves one of those components is responsible. Cloudflare documents
+that Skip can target these products independently, leaving other security
+layers active: [Skip action](https://developers.cloudflare.com/waf/custom-rules/skip/)
+and [available skip options](https://developers.cloudflare.com/waf/custom-rules/skip/options/).
+
+For `ai.bystro.cloud`, the complete SDK transport surface is:
+
+```text
+/auth/cookie
+/set-session-cookie
+/ws/socket.io
+/project/threads
+/user/files/*
+/api/user-output/*
+```
+
+For `bystro.cloud`, one-time programmatic login uses:
+
+```text
+/api/site-gate/authenticate
+/api/user/auth/local
+```
+
+If customers also need to discover existing genetic-analysis jobs with
+`bystro.api.annotation.get_jobs`, include the narrow `/api/jobs*` path prefix
+on `bystro.cloud`. This route is optional when the caller already knows the
+genetic job ID. It remains protected by Bystro authentication and authorization;
+the Cloudflare rule skips only the selected browser-oriented checks.
+
+Keep the route expression narrow rather than bypassing by user agent or a
+shared customer token. Application authentication and ownership checks still
+run at the origin, while Cloudflare DDoS protection, managed WAF, and rate
+limits remain available.
+
+An easy verification is to install the wheel in a clean environment, unset
+`REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE`, require
+`transports=("websocket",)`, submit a small run, list conversations, upload a
+file larger than 10 MiB, and download one result plus the tar archive. A
+Cloudflare HTML challenge or `cf-ray` 403 indicates the route rule still does
+not match; a typed JSON/application error means the request reached Bystro.
+
+## Errors
+
+Transport, HTTP, authentication, billing, admission, cancellation, timeout, and
+protocol failures have typed exceptions under `bystro.think`. In particular:
+
+- `ThinkAuthenticationError`: cached dashboard login is missing or expired.
+- `ThinkBillingRequiredError`: initial admission requires plan/credit action.
+- `RunRejectedError`: submission was rejected before dispatch.
+- `RunTimeoutError`: a local wait deadline elapsed; the durable run may continue.
+- `RunCancelledError`: server-side cancellation completed.
+- `RunProtocolError`: the server returned contradictory or incomplete state.
+
+Closing a client never implies cancellation.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
     "requests>=2.31.0,<3",
     "python-socketio[client]>=5.11.0,<6",

--- a/python/python/bystro/think/__init__.py
+++ b/python/python/bystro/think/__init__.py
@@ -2,23 +2,20 @@
 
 Typical usage::
 
-    from bystro.api import auth
-    from bystro.think import NeedsInput, ThinkClient
+    from bystro.think import ThinkClient, show_progress
 
-    auth.login("you@example.com", "password")
-    with ThinkClient() as client:
-        run = client.submit("Summarize this cohort", files=["cohort.vcf"])
-        outcome = run.wait()
-        if isinstance(outcome, NeedsInput):
-            outcome = run.respond("Use the case_control column").wait()
-        print(outcome.output)
+    with ThinkClient.from_cached_login(on_event=show_progress) as client:
+        run = client.submit_with_progress(
+            "Summarize this cohort",
+            files=["cohort.vcf"],
+        )
+        outcome = run.interact()
+        print(outcome)
 """
 
 from bystro.think.client import (
     DEFAULT_THINK_URL,
-    ProgressCallback,
     Run,
-    show_progress,
     ThinkClient,
     UploadProgressCallback,
 )
@@ -39,6 +36,7 @@ from bystro.think.context import (
 )
 from bystro.think.errors import (
     InputResponseError,
+    RunCancelledError,
     RunProtocolError,
     RunRejectedError,
     RunTimeoutError,
@@ -56,16 +54,21 @@ from bystro.think.models import (
     InputKind,
     NeedsInput,
     OutputFile,
+    ProgressPhase,
+    ProgressUpdate,
     RunOptions,
     RunOutcome,
     RunResult,
     RunStatus,
+    StreamOperation,
+    StreamUpdate,
     ThinkEvent,
     ThinkMessage,
     UploadedFile,
     UploadPhase,
     UploadProgress,
 )
+from bystro.think.progress import ProgressCallback, ProgressRenderer, show_progress
 
 __all__ = [
     "ArtifactReference",
@@ -82,15 +85,21 @@ __all__ = [
     "MessageWithContext",
     "NeedsInput",
     "OutputFile",
+    "ProgressPhase",
+    "ProgressUpdate",
     "ProgressCallback",
     "PreviousConversation",
+    "ProgressRenderer",
     "Run",
+    "RunCancelledError",
     "RunOptions",
     "RunOutcome",
     "RunProtocolError",
     "RunRejectedError",
     "RunResult",
     "RunStatus",
+    "StreamOperation",
+    "StreamUpdate",
     "RunTimeoutError",
     "show_progress",
     "ThinkAuthenticationError",

--- a/python/python/bystro/think/client.py
+++ b/python/python/bystro/think/client.py
@@ -2,11 +2,13 @@
 
 # ``Run`` is intentionally a friend handle over ``ThinkClient`` internals.
 # pyright: reportPrivateUsage=false
+# ruff: noqa: SLF001
 
 from __future__ import annotations
 
+import asyncio
 from collections import deque
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
@@ -35,6 +37,7 @@ from bystro.think.context import (
 )
 from bystro.think.errors import (
     InputResponseError,
+    RunCancelledError,
     RunProtocolError,
     RunRejectedError,
     RunTimeoutError,
@@ -45,21 +48,32 @@ from bystro.think.errors import (
     ThinkHTTPError,
 )
 from bystro.think.models import (
+    ConversationMode,
     Dataset,
     EventKind,
     FileInput,
     InputKind,
     NeedsInput,
     OutputFile,
+    ProgressPhase,
+    ProgressUpdate,
     RunOptions,
     RunOutcome,
     RunResult,
     RunStatus,
+    StreamOperation,
+    StreamUpdate,
     ThinkEvent,
     ThinkMessage,
     UploadedFile,
     UploadPhase,
     UploadProgress,
+)
+from bystro.think.progress import (
+    ProgressCallback,
+    ProgressRenderer,
+    close_progress_callback,
+    show_progress as show_progress,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,31 +87,12 @@ _CHECKPOINT_REPLAY_INTERVAL = 0.25
 _ARTIFACT_PATH_MAX_LENGTH = 2_048
 _ARTIFACT_PATH_MAX_DEPTH = 64
 _MAX_EVENT_HISTORY = 2_000
+_ALLOWED_TRANSPORTS = frozenset({"polling", "websocket"})
 
-ProgressCallback: TypeAlias = Callable[[ThinkEvent], None]
 UploadProgressCallback: TypeAlias = Callable[[UploadProgress], None]
-
-_PROGRESS_MESSAGES: dict[EventKind, str] = {
-    EventKind.SUBMITTED: "Workload submitted",
-    EventKind.STARTED: "Analysis started",
-    EventKind.NEEDS_INPUT: "Input required",
-    EventKind.COMPLETED: "Analysis complete",
-}
-
-
-def show_progress(event: ThinkEvent) -> None:
-    """Print concise live progress without echoing prompts or final results."""
-
-    if event.kind is EventKind.MESSAGE or event.message == "progress":
-        return
-    if (
-        event.kind is EventKind.DISCONNECTED
-        and event.message
-        and ("client disconnect" in event.message.casefold())
-    ):
-        return
-    message = _PROGRESS_MESSAGES.get(event.kind, event.message)
-    print(f"[{event.kind.value}] {message or event.kind.value}", flush=True)
+FileInputs: TypeAlias = FileInput | Iterable[FileInput]
+TransportInputs: TypeAlias = str | Iterable[str]
+InputCallback: TypeAlias = Callable[[NeedsInput], MessageInput]
 
 
 class _Response(Protocol):
@@ -173,10 +168,38 @@ def _boolean(value: object) -> bool:
     return value is True
 
 
+def _nonnegative_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _nonnegative_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        return None
+    normalized = float(value)
+    return normalized if math.isfinite(normalized) else None
+
+
 def _normalize_base_url(url: str) -> str:
     normalized = dashboard_auth.normalize_url(url)
     parsed = urlsplit(normalized)
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def _normalize_transports(transports: TransportInputs | None) -> tuple[str, ...] | None:
+    if transports is None:
+        return None
+    candidates = (transports,) if isinstance(transports, str) else tuple(transports)
+    if not candidates:
+        raise ValueError("Think transports cannot be empty")
+    if any(
+        not isinstance(candidate, str) or candidate not in _ALLOWED_TRANSPORTS
+        for candidate in candidates
+    ):
+        allowed = ", ".join(sorted(_ALLOWED_TRANSPORTS))
+        raise ValueError(f"unsupported Think transport; expected one of: {allowed}")
+    return tuple(dict.fromkeys(candidates))
 
 
 def _normalize_artifact_path(
@@ -208,9 +231,25 @@ def _normalize_output_path(output_path: str) -> str:
     if not normalized or normalized.startswith(("/", "\\")) or "\\" in normalized:
         raise ValueError("output file path must be a non-empty relative path")
     parts = normalized.split("/")
-    if ".." in normalized or any(not part or part == "." for part in parts):
+    if any(not part or part in {".", ".."} for part in parts):
         raise ValueError("output file path contains invalid components")
     return normalized
+
+
+def _optional_utc_datetime(value: object, *, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    raw_value = _text(value)
+    if raw_value is None:
+        raise RunProtocolError(f"Think returned an invalid {field_name}")
+    normalized = raw_value[:-1] + "+00:00" if raw_value.endswith("Z") else raw_value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise RunProtocolError(f"Think returned an invalid {field_name}") from exc
+    if parsed.tzinfo is None:
+        raise RunProtocolError(f"Think returned an invalid {field_name}")
+    return parsed.astimezone(timezone.utc)
 
 
 def _json_payload(response: _Response) -> dict[str, object]:
@@ -298,6 +337,97 @@ def _message_from_payload(payload: Mapping[str, object], run_id: str) -> ThinkMe
     )
 
 
+def _stream_traits(message: ThinkMessage) -> tuple[str | None, bool]:
+    stream_type = _text(message.metadata.get("stream_type"))
+    is_reasoning = message.metadata.get("is_reasoning") is True or stream_type in {
+        "reasoning",
+        "thinking",
+    }
+    return stream_type, is_reasoning
+
+
+def _progress_update(message: ThinkMessage) -> ProgressUpdate | None:
+    """Parse the backend progress card without trusting its metadata shape."""
+
+    if _text(message.metadata.get("section")) != "progress":
+        return None
+    raw_progress = _mapping(message.metadata.get("progress"))
+    raw_phases = raw_progress.get("phases")
+    if not isinstance(raw_phases, list):
+        return ProgressUpdate(done=_boolean(raw_progress.get("done")), phases=())
+    phases: list[ProgressPhase] = []
+    for raw_phase in cast(list[object], raw_phases):
+        phase = _mapping(raw_phase)
+        phase_id = _text(phase.get("id"))
+        kind = _text(phase.get("kind"))
+        state = _text(phase.get("state"))
+        label = _text(phase.get("label"))
+        if None in {phase_id, kind, state, label}:
+            continue
+        count = _mapping(phase.get("count"))
+        started_at: datetime | None = None
+        started_at_ms = _nonnegative_float(phase.get("started_at"))
+        if started_at_ms is not None:
+            try:
+                started_at = datetime.fromtimestamp(
+                    started_at_ms / 1000,
+                    timezone.utc,
+                )
+            except (OverflowError, OSError, ValueError):
+                started_at = None
+        phases.append(
+            ProgressPhase(
+                id=cast(str, phase_id),
+                kind=cast(str, kind),
+                state=cast(str, state),
+                label=cast(str, label),
+                detail=_text(phase.get("detail")),
+                completed=_nonnegative_int(count.get("done")),
+                total=_nonnegative_int(count.get("total")),
+                started_at=started_at,
+                duration_seconds=_nonnegative_float(phase.get("duration_s")),
+            )
+        )
+    return ProgressUpdate(
+        done=_boolean(raw_progress.get("done")),
+        phases=tuple(phases),
+    )
+
+
+def _run_options_from_metadata(
+    metadata: Mapping[str, object],
+    current: RunOptions,
+) -> RunOptions:
+    raw_mode = _text(metadata.get("mode"))
+    mode = current.mode
+    if raw_mode in {"base", "plus", "plus2", "phd"}:
+        mode = cast(ConversationMode, raw_mode)
+
+    def boolean(key: str, default: bool) -> bool:
+        value = metadata.get(key)
+        return value if isinstance(value, bool) else default
+
+    raw_zdr = metadata.get("zdrEnabled")
+    zero_data_retention = (
+        raw_zdr if isinstance(raw_zdr, bool) else current.zero_data_retention
+    )
+    return RunOptions(
+        mode=mode,
+        advanced_planning=boolean(
+            "advancedPlanningEnabled",
+            current.advanced_planning,
+        ),
+        auto_compact=boolean("autoCompactEnabled", current.auto_compact),
+        fast=boolean("fastEnabled", current.fast),
+        verify=boolean("verificationEnabled", current.verify),
+        verify_sources=boolean(
+            "searchVerificationEnabled",
+            current.verify_sources,
+        ),
+        zero_data_retention=zero_data_retention,
+    )
+
+
 def _uploaded_file(payload: Mapping[str, object]) -> UploadedFile:
     file_id = _text(payload.get("id"))
     name = _text(payload.get("name"))
@@ -348,6 +478,7 @@ class _RunTracker:
     events: list[ThinkEvent] = field(default_factory=list)
     messages: dict[str, ThinkMessage] = field(default_factory=dict)
     message_order: list[str] = field(default_factory=list)
+    streamed_message_ids: set[str] = field(default_factory=set)
     needs_input: NeedsInput | None = None
     final_output: str | None = None
     failure: Exception | None = None
@@ -356,7 +487,12 @@ class _RunTracker:
     answered_checkpoint_id: str | None = None
     final_message_id: str | None = None
     completed_message_id: str | None = None
+    final_result: RunResult | None = None
     task_ended_at: float | None = None
+    task_id: str | None = None
+    cancel_requested: bool = False
+    cancelling_event_emitted: bool = False
+    stop_released: bool = False
     refresh_requested: bool = False
     awaiting_transcript: bool = False
     progress_callback: ProgressCallback | None = None
@@ -382,7 +518,7 @@ class ThinkClient:
         socket_timeout: float = _DEFAULT_SOCKET_TIMEOUT,
         http_timeout: tuple[float, float] = _DEFAULT_HTTP_TIMEOUT,
         finalization_timeout: float = _DEFAULT_FINALIZATION_TIMEOUT,
-        transports: Iterable[str] | None = None,
+        transports: TransportInputs | None = None,
         _session: _HTTPSession | None = None,
         _socket_factory: SocketFactory | None = None,
         _sleep: Callable[[float], None] = time.sleep,
@@ -414,7 +550,7 @@ class ThinkClient:
         self._socket_timeout = socket_timeout
         self._http_timeout = http_timeout
         self._finalization_timeout = finalization_timeout
-        self._transports = tuple(transports) if transports is not None else None
+        self._transports = _normalize_transports(transports)
         self._sleep = _sleep
         self._clock = _clock
         self._session = (
@@ -455,7 +591,7 @@ class ThinkClient:
         socket_timeout: float = _DEFAULT_SOCKET_TIMEOUT,
         http_timeout: tuple[float, float] = _DEFAULT_HTTP_TIMEOUT,
         finalization_timeout: float = _DEFAULT_FINALIZATION_TIMEOUT,
-        transports: Iterable[str] | None = None,
+        transports: TransportInputs | None = None,
     ) -> Self:
         """Log in through the dashboard and construct a Think client."""
 
@@ -492,7 +628,7 @@ class ThinkClient:
         socket_timeout: float = _DEFAULT_SOCKET_TIMEOUT,
         http_timeout: tuple[float, float] = _DEFAULT_HTTP_TIMEOUT,
         finalization_timeout: float = _DEFAULT_FINALIZATION_TIMEOUT,
-        transports: Iterable[str] | None = None,
+        transports: TransportInputs | None = None,
     ) -> Self:
         """Construct a client from ``~/.bystro`` authentication state."""
 
@@ -533,9 +669,12 @@ class ThinkClient:
             "disconnect": self._handle_disconnect,
             "task_start": self._handle_task_start,
             "task_end": self._handle_task_end,
+            "task_stopping": self._handle_task_stopping,
+            "thread_stop_released": self._handle_thread_stop_released,
             "new_message": self._handle_message,
-            "update_message": self._handle_message,
-            "stream_start": self._handle_message,
+            "update_message": self._handle_update_message,
+            "delete_message": self._handle_delete_message,
+            "stream_start": self._handle_stream_start,
             "stream_token": self._handle_stream_token,
             "status_overlay_update": self._handle_overlay,
             "resume_thread": self._handle_resume_thread,
@@ -635,6 +774,10 @@ class ThinkClient:
                 run_id = tracker.run_id
             if run_id:
                 self._emit_status_ready(run_id)
+            with tracker.condition:
+                cancel_requested = tracker.cancel_requested and not tracker.stop_released
+            if cancel_requested:
+                self._emit_stop_request(tracker)
 
     def _handle_connect_error(self, error: object) -> None:
         tracker = self._active_tracker_snapshot()
@@ -679,6 +822,8 @@ class ThinkClient:
         *,
         message: str | None = None,
         data: Mapping[str, object] | None = None,
+        stream_update: StreamUpdate | None = None,
+        progress: ProgressUpdate | None = None,
     ) -> ThinkEvent:
         with tracker.condition:
             tracker.sequence += 1
@@ -689,6 +834,8 @@ class ThinkClient:
                 created_at=datetime.now(timezone.utc),
                 message=message,
                 data=dict(data or {}),
+                stream_update=stream_update,
+                progress=progress,
             )
             tracker.events.append(event)
             if len(tracker.events) > _MAX_EVENT_HISTORY:
@@ -720,11 +867,25 @@ class ThinkClient:
         if tracker is None:
             return
         with tracker.condition:
-            tracker.status = RunStatus.RUNNING
+            if tracker.status in {
+                RunStatus.SUCCEEDED,
+                RunStatus.FAILED,
+                RunStatus.CANCELLED,
+            }:
+                return
+            tracker.task_id = _text(payload.get("taskId")) or tracker.task_id
             tracker.task_ended_at = None
             tracker.refresh_requested = False
+            cancel_requested = tracker.cancel_requested
+            tracker.status = (
+                RunStatus.CANCELLING
+                if cancel_requested
+                else RunStatus.RUNNING
+            )
             tracker.condition.notify_all()
         self._record_event(tracker, EventKind.STARTED, data=payload)
+        if cancel_requested:
+            self._emit_stop_request(tracker)
 
     def _handle_task_end(self, raw_payload: object) -> None:
         payload = _mapping(raw_payload)
@@ -734,15 +895,94 @@ class ThinkClient:
         completed = False
         final_output: str | None = None
         with tracker.condition:
+            if tracker.status is RunStatus.CANCELLED:
+                return
+            incoming_task_id = _text(payload.get("taskId"))
+            if (
+                incoming_task_id is not None
+                and tracker.task_id is not None
+                and incoming_task_id != tracker.task_id
+            ):
+                return
             tracker.task_ended_at = self._clock()
-            completed = self._mark_succeeded_locked(tracker, require_task_end=True)
+            tracker.task_id = incoming_task_id or tracker.task_id
+            if tracker.cancel_requested:
+                tracker.status = RunStatus.CANCELLING
+            else:
+                completed = self._mark_succeeded_locked(
+                    tracker,
+                    require_task_end=True,
+                )
             final_output = tracker.final_output
             tracker.condition.notify_all()
         if completed:
             self._record_event(tracker, EventKind.COMPLETED, message=final_output)
 
+    def _handle_task_stopping(self, raw_payload: object) -> None:
+        payload = _mapping(raw_payload)
+        tracker = self._tracker_for_payload(payload)
+        if tracker is None:
+            return
+        with tracker.condition:
+            if tracker.stop_released or tracker.status not in {
+                RunStatus.SUBMITTING,
+                RunStatus.QUEUED,
+                RunStatus.RUNNING,
+                RunStatus.CANCELLING,
+            }:
+                return
+            incoming_task_id = _text(payload.get("taskId"))
+            if (
+                incoming_task_id is not None
+                and tracker.task_id is not None
+                and incoming_task_id != tracker.task_id
+            ):
+                return
+            tracker.cancel_requested = True
+            tracker.task_id = incoming_task_id or tracker.task_id
+            tracker.status = RunStatus.CANCELLING
+            should_emit = not tracker.cancelling_event_emitted
+            tracker.cancelling_event_emitted = True
+            tracker.condition.notify_all()
+        if should_emit:
+            self._record_event(
+                tracker,
+                EventKind.CANCELLING,
+                message="Cancelling analysis",
+                data=payload,
+            )
+
+    def _handle_thread_stop_released(self, raw_payload: object) -> None:
+        payload = _mapping(raw_payload)
+        tracker = self._tracker_for_payload(payload)
+        if tracker is None:
+            return
+        with tracker.condition:
+            incoming_task_id = _text(payload.get("taskId"))
+            if tracker.stop_released or not tracker.cancel_requested or (
+                incoming_task_id is not None
+                and tracker.task_id is not None
+                and incoming_task_id != tracker.task_id
+            ):
+                return
+            tracker.stop_released = True
+            tracker.task_id = incoming_task_id or tracker.task_id
+            tracker.status = RunStatus.CANCELLED
+            tracker.failure = RunCancelledError(
+                f"Think run {tracker.run_id or ''} was cancelled"
+            )
+            tracker.needs_input = None
+        self._record_event(
+            tracker,
+            EventKind.CANCELLED,
+            message="Analysis cancelled",
+            data=payload,
+        )
+
     @staticmethod
     def _recompute_final_locked(tracker: _RunTracker) -> None:
+        previous_final_message_id = tracker.final_message_id
+        previous_final_output = tracker.final_output
         latest_final: ThinkMessage | None = None
         for message_id in tracker.message_order:
             message = tracker.messages[message_id]
@@ -752,6 +992,11 @@ class ThinkClient:
                 latest_final = message
         tracker.final_message_id = latest_final.id if latest_final is not None else None
         tracker.final_output = latest_final.output if latest_final is not None else None
+        if (
+            tracker.final_message_id != previous_final_message_id
+            or tracker.final_output != previous_final_output
+        ):
+            tracker.final_result = None
 
     @staticmethod
     def _mark_succeeded_locked(
@@ -759,6 +1004,8 @@ class ThinkClient:
         *,
         require_task_end: bool,
     ) -> bool:
+        if tracker.cancel_requested:
+            return False
         final_message_id = tracker.final_message_id
         if final_message_id is None or tracker.final_output is None:
             return False
@@ -796,7 +1043,72 @@ class ThinkClient:
             details=input_state.details,
         )
 
-    def _handle_message(self, raw_payload: object) -> None:
+    @staticmethod
+    def _stream_update(
+        message: ThinkMessage,
+        previous_output: str | None,
+    ) -> StreamUpdate | None:
+        """Convert cumulative Socket.IO snapshots into bounded incremental updates."""
+
+        if message.type != "assistant_message":
+            return None
+        stream_type, is_reasoning = _stream_traits(message)
+        if is_reasoning:
+            if previous_output is not None:
+                return None
+            return StreamUpdate(
+                message_id=message.id,
+                delta="",
+                operation="append",
+                content_length=len(message.output),
+                message_type=message.type,
+                name=message.name,
+                stream_type=stream_type,
+                is_reasoning=True,
+            )
+        if previous_output is None or message.output.startswith(previous_output):
+            delta = message.output[len(previous_output or "") :]
+            operation: StreamOperation = "append"
+        else:
+            delta = message.output
+            operation = "replace"
+        if not delta:
+            return None
+        return StreamUpdate(
+            message_id=message.id,
+            delta=delta,
+            operation=operation,
+            content_length=len(message.output),
+            message_type=message.type,
+            name=message.name,
+            stream_type=stream_type,
+            is_reasoning=False,
+        )
+
+    def _record_stream_update(
+        self,
+        tracker: _RunTracker,
+        message: ThinkMessage,
+        *,
+        previous_output: str | None,
+    ) -> None:
+        with tracker.condition:
+            tracker.streamed_message_ids.add(message.id)
+        update = self._stream_update(message, previous_output)
+        if update is not None:
+            self._record_event(
+                tracker,
+                EventKind.STREAM,
+                stream_update=update,
+            )
+
+    def _handle_message_payload(
+        self,
+        raw_payload: object,
+        *,
+        stream_start: bool,
+        continue_stream: bool,
+    ) -> None:
         payload = _mapping(raw_payload)
         tracker = self._tracker_for_payload(payload)
         if tracker is None:
@@ -808,17 +1120,102 @@ class ThinkClient:
         message = _message_from_payload(payload, run_id)
         if message is None:
             return
+        with tracker.condition:
+            previous = tracker.messages.get(message.id)
+            was_streamed = message.id in tracker.streamed_message_ids
         completed = self._store_message(tracker, message)
-        self._record_event(
-            tracker,
-            EventKind.MESSAGE,
-            message=message.output,
-            data={"message_id": message.id, "message_type": message.type},
-        )
+        stream_type, is_reasoning = _stream_traits(message)
+        progress = _progress_update(message)
+        event_data: dict[str, object] = {
+            "message_id": message.id,
+            "message_type": message.type,
+            "is_reasoning": is_reasoning,
+        }
+        if stream_type is not None:
+            event_data["stream_type"] = stream_type
+        if progress is not None:
+            self._record_event(
+                tracker,
+                EventKind.PROGRESS,
+                message=message.output,
+                data=event_data,
+                progress=progress,
+            )
+        else:
+            self._record_event(
+                tracker,
+                EventKind.MESSAGE,
+                message=None if is_reasoning else message.output,
+                data=event_data,
+            )
+        if progress is None and (stream_start or (continue_stream and was_streamed)):
+            previous_output = (
+                previous.output if was_streamed and previous is not None else None
+            )
+            self._record_stream_update(
+                tracker,
+                message,
+                previous_output=previous_output,
+            )
         if completed:
             with tracker.condition:
                 final_output = tracker.final_output
             self._record_event(tracker, EventKind.COMPLETED, message=final_output)
+
+    def _handle_message(self, raw_payload: object) -> None:
+        self._handle_message_payload(
+            raw_payload,
+            stream_start=False,
+            continue_stream=False,
+        )
+
+    def _handle_update_message(self, raw_payload: object) -> None:
+        self._handle_message_payload(
+            raw_payload,
+            stream_start=False,
+            continue_stream=True,
+        )
+
+    def _handle_stream_start(self, raw_payload: object) -> None:
+        self._handle_message_payload(
+            raw_payload,
+            stream_start=True,
+            continue_stream=False,
+        )
+
+    def _handle_delete_message(self, raw_payload: object) -> None:
+        payload = _mapping(raw_payload)
+        tracker = self._tracker_for_payload(payload)
+        if tracker is None:
+            return
+        message_id = _text(payload.get("id"))
+        if message_id is None:
+            return
+        with tracker.condition:
+            removed = tracker.messages.pop(message_id, None)
+            if message_id in tracker.message_order:
+                tracker.message_order.remove(message_id)
+            was_streamed = message_id in tracker.streamed_message_ids
+            tracker.streamed_message_ids.discard(message_id)
+            self._recompute_final_locked(tracker)
+            self._refresh_needs_input_prompt_locked(tracker)
+            tracker.condition.notify_all()
+        if was_streamed and removed is not None:
+            stream_type, is_reasoning = _stream_traits(removed)
+            self._record_event(
+                tracker,
+                EventKind.STREAM,
+                stream_update=StreamUpdate(
+                    message_id=removed.id,
+                    delta="",
+                    operation="retract",
+                    content_length=0,
+                    message_type=removed.type,
+                    name=removed.name,
+                    stream_type=stream_type,
+                    is_reasoning=is_reasoning,
+                ),
+            )
 
     def _handle_stream_token(self, raw_payload: object) -> None:
         payload = _mapping(raw_payload)
@@ -836,8 +1233,10 @@ class ThinkClient:
             existing = tracker.messages.get(message_id)
             if existing is None or tracker.run_id is None:
                 return
+            was_streamed = message_id in tracker.streamed_message_ids
+            previous_output = existing.output if was_streamed else None
             output = token if payload.get("isSequence") is True else f"{existing.output}{token}"
-            tracker.messages[message_id] = ThinkMessage(
+            updated_message = ThinkMessage(
                 id=existing.id,
                 run_id=existing.run_id,
                 type=existing.type,
@@ -845,11 +1244,17 @@ class ThinkClient:
                 name=existing.name,
                 metadata=existing.metadata,
             )
+            tracker.messages[message_id] = updated_message
             self._recompute_final_locked(tracker)
             self._refresh_needs_input_prompt_locked(tracker)
             completed = self._mark_succeeded_locked(tracker, require_task_end=True)
             final_output = tracker.final_output
             tracker.condition.notify_all()
+        self._record_stream_update(
+            tracker,
+            updated_message,
+            previous_output=previous_output,
+        )
         if completed:
             self._record_event(tracker, EventKind.COMPLETED, message=final_output)
 
@@ -860,7 +1265,12 @@ class ThinkClient:
             if message.type == "user_message":
                 prompt = None
                 continue
-            if message.type == "assistant_message" and message.output.strip():
+            if (
+                message.type == "assistant_message"
+                and not _stream_traits(message)[1]
+                and _progress_update(message) is None
+                and message.output.strip()
+            ):
                 prompt = message.output
         return prompt
 
@@ -912,7 +1322,9 @@ class ThinkClient:
                     or tracker.status is RunStatus.NEEDS_INPUT
                 )
                 tracker.needs_input = None
-                if tracker.final_output is not None and tracker.task_ended_at is not None:
+                if tracker.cancel_requested:
+                    tracker.status = RunStatus.CANCELLING
+                elif tracker.final_output is not None and tracker.task_ended_at is not None:
                     tracker.status = RunStatus.SUCCEEDED
                 elif payload.get("visible") is True or was_waiting:
                     tracker.status = RunStatus.RUNNING
@@ -947,12 +1359,20 @@ class ThinkClient:
                 message = _message_from_payload(step, run_id)
                 if message is not None:
                     self._store_message(tracker, message)
+                    if message.type == "user_message":
+                        with tracker.condition:
+                            tracker.options = _run_options_from_metadata(
+                                message.metadata,
+                                tracker.options,
+                            )
         completed = False
         final_output: str | None = None
         with tracker.condition:
             tracker.awaiting_transcript = False
             self._refresh_needs_input_prompt_locked(tracker)
-            if tracker.final_output is not None:
+            if tracker.cancel_requested:
+                tracker.status = RunStatus.CANCELLING
+            elif tracker.final_output is not None:
                 completed = self._mark_succeeded_locked(tracker, require_task_end=False)
             elif tracker.status in {RunStatus.SUBMITTING, RunStatus.SUCCEEDED}:
                 tracker.status = RunStatus.QUEUED
@@ -996,6 +1416,48 @@ class ThinkClient:
         message = _text(payload.get("message"))
         if message:
             self._record_event(tracker, EventKind.PROGRESS, message=message, data=payload)
+
+    def _emit_stop_request(
+        self,
+        tracker: _RunTracker,
+        *,
+        raise_on_error: bool = False,
+    ) -> None:
+        with tracker.condition:
+            run_id = tracker.run_id
+            task_id = tracker.task_id
+            client_observed_active = tracker.status in {
+                RunStatus.SUBMITTING,
+                RunStatus.QUEUED,
+                RunStatus.RUNNING,
+                RunStatus.CANCELLING,
+            }
+        if run_id is None:
+            raise RunProtocolError("Cannot cancel a run without an id")
+        payload: dict[str, object] = {
+            "threadId": run_id,
+            "clientObservedActive": client_observed_active,
+        }
+        if task_id is not None:
+            payload["taskId"] = task_id
+        try:
+            self._socket.emit("stop", payload)
+        except (SocketIOError, OSError) as exc:
+            if raise_on_error:
+                raise ThinkConnectionError(
+                    "Could not request Think cancellation"
+                ) from exc
+            logger.warning(
+                "Think cancellation request failed; reconnect will retry",
+                exc_info=True,
+            )
+        except Exception:
+            logger.warning(
+                "Unexpected Think cancellation request failure; reconnect will retry",
+                exc_info=True,
+            )
+            if raise_on_error:
+                raise
 
     def _emit_status_ready(self, run_id: str) -> None:
         self._socket.emit(
@@ -1163,11 +1625,16 @@ class ThinkClient:
 
     def _resolve_files(
         self,
-        files: Iterable[FileInput],
+        files: FileInputs,
         on_upload_progress: UploadProgressCallback | None,
     ) -> list[UploadedFile]:
         resolved: list[UploadedFile] = []
-        for item in files:
+        items = (
+            (files,)
+            if isinstance(files, (UploadedFile, str, Path))
+            else files
+        )
+        for item in items:
             if isinstance(item, UploadedFile):
                 resolved.append(item)
             else:
@@ -1204,7 +1671,7 @@ class ThinkClient:
         self,
         prompt: MessageInput,
         *,
-        files: Iterable[FileInput] = (),
+        files: FileInputs = (),
         datasets: Iterable[Dataset] = (),
         options: RunOptions | None = None,
         on_upload_progress: UploadProgressCallback | None = None,
@@ -1224,13 +1691,13 @@ class ThinkClient:
         self,
         prompt: MessageInput,
         *,
-        files: Iterable[FileInput] = (),
+        files: FileInputs = (),
         datasets: Iterable[Dataset] = (),
         options: RunOptions | None = None,
         on_upload_progress: UploadProgressCallback | None = None,
         on_event: ProgressCallback | None = None,
     ) -> "Run":
-        """Submit a workload and render live progress by default."""
+        """Submit and render lifecycle plus browser-visible streamed output."""
 
         return self._submit(
             prompt,
@@ -1238,14 +1705,14 @@ class ThinkClient:
             datasets=datasets,
             options=options,
             on_upload_progress=on_upload_progress,
-            progress_callback=on_event or self._on_event or show_progress,
+            progress_callback=on_event or self._on_event or ProgressRenderer(),
         )
 
     def _submit(
         self,
         prompt: MessageInput,
         *,
-        files: Iterable[FileInput],
+        files: FileInputs,
         datasets: Iterable[Dataset],
         options: RunOptions | None,
         on_upload_progress: UploadProgressCallback | None,
@@ -1333,12 +1800,21 @@ class ThinkClient:
         tracker.awaiting_transcript = True
         with self._state_lock:
             self._active_tracker = tracker
-        was_connected = self._socket.connected
-        self.connect()
-        if was_connected:
-            self._room_sync(normalized_id)
-            self._socket.emit("connection_successful")
-            self._emit_status_ready(normalized_id)
+        try:
+            was_connected = self._socket.connected
+            self.connect()
+            if was_connected:
+                self._room_sync(normalized_id)
+                self._socket.emit("connection_successful")
+                self._emit_status_ready(normalized_id)
+        except Exception as exc:
+            logger.debug("Think resume failed before transcript hydration", exc_info=True)
+            with tracker.condition:
+                tracker.failure = exc
+                tracker.status = RunStatus.FAILED
+                tracker.awaiting_transcript = False
+                tracker.condition.notify_all()
+            raise
         return Run(self, tracker)
 
     def _synchronize_pause_checkpoint(self, tracker: _RunTracker) -> None:
@@ -1403,7 +1879,7 @@ class ThinkClient:
         tracker: _RunTracker,
         prompt: MessageInput,
         *,
-        files: Iterable[FileInput],
+        files: FileInputs,
         datasets: Iterable[Dataset],
         planning_response: bool,
         on_upload_progress: UploadProgressCallback | None,
@@ -1421,8 +1897,13 @@ class ThinkClient:
             prior_input = tracker.needs_input
             prior_final_output = tracker.final_output
             prior_final_message_id = tracker.final_message_id
+            prior_final_result = tracker.final_result
             prior_failure = tracker.failure
             prior_task_ended_at = tracker.task_ended_at
+            prior_task_id = tracker.task_id
+            prior_cancel_requested = tracker.cancel_requested
+            prior_cancelling_event_emitted = tracker.cancelling_event_emitted
+            prior_stop_released = tracker.stop_released
             prior_refresh_requested = tracker.refresh_requested
             prior_answered_checkpoint_id = tracker.answered_checkpoint_id
             if run_id is None:
@@ -1441,8 +1922,13 @@ class ThinkClient:
             tracker.needs_input = None
             tracker.final_output = None
             tracker.final_message_id = None
+            tracker.final_result = None
             tracker.failure = None
             tracker.task_ended_at = None
+            tracker.task_id = None
+            tracker.cancel_requested = False
+            tracker.cancelling_event_emitted = False
+            tracker.stop_released = False
             tracker.refresh_requested = False
             tracker.status = RunStatus.SUBMITTING
             tracker.condition.notify_all()
@@ -1478,8 +1964,13 @@ class ThinkClient:
                     tracker.needs_input = prior_input
                     tracker.final_output = prior_final_output
                     tracker.final_message_id = prior_final_message_id
+                    tracker.final_result = prior_final_result
                     tracker.failure = prior_failure
                     tracker.task_ended_at = prior_task_ended_at
+                    tracker.task_id = prior_task_id
+                    tracker.cancel_requested = prior_cancel_requested
+                    tracker.cancelling_event_emitted = prior_cancelling_event_emitted
+                    tracker.stop_released = prior_stop_released
                     tracker.refresh_requested = prior_refresh_requested
                     tracker.answered_checkpoint_id = prior_answered_checkpoint_id
                 tracker.condition.notify_all()
@@ -1505,6 +1996,9 @@ class ThinkClient:
         self._emit_status_ready(run_id)
 
     def _refresh(self, tracker: _RunTracker) -> None:
+        with self._state_lock:
+            if tracker is not self._active_tracker:
+                raise InputResponseError("This run is no longer active on its client")
         with tracker.condition:
             run_id = tracker.run_id
         if run_id is None:
@@ -1626,21 +2120,29 @@ class ThinkClient:
         *,
         search: str | None = None,
         page_size: int = 50,
+        limit: int | None = None,
     ) -> tuple[PreviousConversation, ...]:
         """List the authenticated user's conversations, newest first."""
 
         if not 1 <= page_size <= 1_000:
             raise ValueError("page_size must be between 1 and 1000")
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be positive")
         self.connect()
         conversations: list[PreviousConversation] = []
         cursor: str | None = None
         normalized_search = _text(search)
         while True:
+            request_size = (
+                page_size
+                if limit is None
+                else min(page_size, limit - len(conversations))
+            )
             try:
                 response = self._session.post(
                     f"{self.think_url}/project/threads",
                     json={
-                        "pagination": {"first": page_size, "cursor": cursor},
+                        "pagination": {"first": request_size, "cursor": cursor},
                         "filter": {"search": normalized_search},
                     },
                     timeout=self._http_timeout,
@@ -1666,8 +2168,17 @@ class ThinkClient:
                 if conversation_id is None:
                     raise RunProtocolError("Think conversation listing omitted an id")
                 conversations.append(
-                    PreviousConversation(conversation_id, _text(conversation.get("name")))
+                    PreviousConversation(
+                        conversation_id,
+                        _text(conversation.get("name")),
+                        _optional_utc_datetime(
+                            conversation.get("createdAt"),
+                            field_name="conversation creation timestamp",
+                        ),
+                    )
                 )
+                if limit is not None and len(conversations) >= limit:
+                    return tuple(conversations)
             if not has_next_page:
                 return tuple(conversations)
             next_cursor = _text(page_info.get("endCursor"))
@@ -1876,6 +2387,15 @@ class ThinkClient:
             if self._closed:
                 return
             self._closed = True
+            with self._state_lock:
+                tracker = self._active_tracker
+            if tracker is None:
+                tracker_callback = None
+                run_id = None
+            else:
+                with tracker.condition:
+                    tracker_callback = tracker.progress_callback
+                    run_id = tracker.run_id
             if self._socket.connected:
                 try:
                     self._socket.disconnect()
@@ -1883,6 +2403,9 @@ class ThinkClient:
                     logger.debug("Think socket disconnect failed", exc_info=True)
                 except Exception:
                     logger.warning("Unexpected Think socket disconnect failure", exc_info=True)
+            close_progress_callback(tracker_callback, run_id)
+            if self._on_event is not tracker_callback:
+                close_progress_callback(self._on_event, run_id)
             if self._owns_session:
                 self._session.close()
 
@@ -1917,6 +2440,8 @@ class Run:
             return tuple(
                 self._tracker.messages[message_id]
                 for message_id in self._tracker.message_order
+                if not _stream_traits(self._tracker.messages[message_id])[1]
+                and _progress_update(self._tracker.messages[message_id]) is None
             )
 
     @property
@@ -1934,7 +2459,13 @@ class Run:
         if self._tracker.status is RunStatus.SUCCEEDED:
             if self._tracker.final_output is None:
                 raise RunProtocolError("Run succeeded without a final response")
-            return RunResult(run_id=self.id, output=self._tracker.final_output)
+            if self._tracker.final_result is None:
+                self._tracker.final_result = RunResult(
+                    run_id=self.id,
+                    output=self._tracker.final_output,
+                    _file_loader=self.output_files,
+                )
+            return self._tracker.final_result
         return None
 
     def _terminal_state_locked(
@@ -1946,6 +2477,7 @@ class Run:
         if (
             failure is None
             and outcome is None
+            and not self._tracker.cancel_requested
             and self._tracker.task_ended_at is not None
         ):
             elapsed = self._client._clock() - self._tracker.task_ended_at
@@ -2033,6 +2565,7 @@ class Run:
             outcome: RunOutcome | None = None
             failure: Exception | None = None
             should_refresh = False
+            remaining: float | None = None
             with self._tracker.condition:
                 if not pending_events:
                     pending_events.extend(self._events_after_locked(cursor))
@@ -2069,11 +2602,113 @@ class Run:
             if should_refresh:
                 self.refresh()
 
+    async def aevents(
+        self,
+        timeout: float | None = None,
+        *,
+        poll_interval: float = 0.1,
+    ) -> AsyncIterator[ThinkEvent]:
+        """Asynchronously yield ordered events without blocking the event loop."""
+
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be positive")
+        if poll_interval <= 0:
+            raise ValueError("poll_interval must be positive")
+        deadline = None if timeout is None else self._client._clock() + timeout
+        cursor = 0
+        pending_events: deque[ThinkEvent] = deque()
+        while True:
+            event: ThinkEvent | None = None
+            outcome: RunOutcome | None = None
+            failure: Exception | None = None
+            should_refresh = False
+            remaining: float | None = None
+            with self._tracker.condition:
+                if not pending_events:
+                    pending_events.extend(self._events_after_locked(cursor))
+                if pending_events:
+                    event = pending_events.popleft()
+                    cursor = event.sequence
+                else:
+                    outcome, failure, should_refresh = self._terminal_state_locked()
+                    remaining = (
+                        None
+                        if deadline is None
+                        else deadline - self._client._clock()
+                    )
+            if failure is not None:
+                raise failure
+            if event is not None:
+                yield event
+                continue
+            if outcome is not None:
+                return
+            if should_refresh:
+                await asyncio.to_thread(self.refresh)
+                continue
+            if remaining is not None and remaining <= 0:
+                raise RunTimeoutError(f"Timed out streaming Think run {self.id}")
+            await asyncio.sleep(
+                poll_interval
+                if remaining is None
+                else min(poll_interval, remaining)
+            )
+
+    async def await_result(self, timeout: float | None = None) -> RunOutcome:
+        """Await the current turn while keeping an asyncio loop responsive."""
+
+        async for _event in self.aevents(timeout=timeout):
+            pass
+        with self._tracker.condition:
+            outcome, failure, _should_refresh = self._terminal_state_locked()
+        if failure is not None:
+            raise failure
+        if outcome is None:
+            raise RunProtocolError("Think event stream ended without an outcome")
+        return outcome
+
+    def interact(
+        self,
+        timeout: float | None = None,
+        *,
+        on_clarification: InputCallback | None = None,
+        on_plan_review: InputCallback | None = None,
+    ) -> RunOutcome:
+        """Drive clarification and plan-review pauses until the turn completes.
+
+        Missing callbacks use a terminal/notebook input prompt. Billing pauses
+        remain explicit and are returned unchanged for dashboard resolution.
+        """
+
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be positive")
+        deadline = None if timeout is None else self._client._clock() + timeout
+        while True:
+            remaining = (
+                None if deadline is None else deadline - self._client._clock()
+            )
+            if remaining is not None and remaining <= 0:
+                raise RunTimeoutError(f"Timed out interacting with Think run {self.id}")
+            outcome = self.wait(timeout=remaining)
+            if isinstance(outcome, RunResult) or outcome.kind is InputKind.BILLING:
+                return outcome
+            callback = (
+                on_plan_review
+                if outcome.kind is InputKind.PLAN_REVIEW
+                else on_clarification
+            )
+            if callback is None:
+                prompt = outcome.prompt or f"Input required ({outcome.kind.value})"
+                response: MessageInput = input(f"{prompt}\n> ")
+            else:
+                response = callback(outcome)
+            self.respond(response)
+
     def respond(
         self,
         response: MessageInput,
         *,
-        files: Iterable[FileInput] = (),
+        files: FileInputs = (),
         datasets: Iterable[Dataset] = (),
         on_upload_progress: UploadProgressCallback | None = None,
     ) -> Self:
@@ -2093,7 +2728,7 @@ class Run:
         self,
         prompt: MessageInput,
         *,
-        files: Iterable[FileInput] = (),
+        files: FileInputs = (),
         datasets: Iterable[Dataset] = (),
         on_upload_progress: UploadProgressCallback | None = None,
     ) -> Self:
@@ -2108,6 +2743,57 @@ class Run:
             on_upload_progress=on_upload_progress,
         )
         return self
+
+    def cancel(self, timeout: float = 60.0) -> Self:
+        """Cancel durable server work and wait for stop cleanup to be released."""
+
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+        with self._tracker.condition:
+            status = self._tracker.status
+            if status is RunStatus.CANCELLED:
+                return self
+            if status in {RunStatus.SUCCEEDED, RunStatus.FAILED}:
+                raise InputResponseError("A terminal run cannot be cancelled")
+            if status is RunStatus.NEEDS_INPUT:
+                raise InputResponseError(
+                    "A paused run has no active work to cancel; respond or detach instead"
+                )
+            self._tracker.cancel_requested = True
+            self._tracker.status = RunStatus.CANCELLING
+            should_emit = not self._tracker.cancelling_event_emitted
+            self._tracker.cancelling_event_emitted = True
+            self._tracker.condition.notify_all()
+        if should_emit:
+            self._client._record_event(
+                self._tracker,
+                EventKind.CANCELLING,
+                message="Cancelling analysis",
+            )
+        self._client.connect()
+        self._client._emit_stop_request(self._tracker, raise_on_error=True)
+        deadline = self._client._clock() + timeout
+        with self._tracker.condition:
+            while self._tracker.status is not RunStatus.CANCELLED:
+                failure = self._tracker.failure
+                if failure is not None and not isinstance(
+                    failure,
+                    RunCancelledError,
+                ):
+                    raise failure
+                remaining = deadline - self._client._clock()
+                if remaining <= 0:
+                    raise RunTimeoutError(
+                        f"Timed out cancelling Think run {self.id}; "
+                        "the request will be retried after reconnect"
+                    )
+                self._tracker.condition.wait(timeout=remaining)
+        return self
+
+    def detach(self) -> None:
+        """Disconnect locally while leaving durable server work running."""
+
+        self._client.close()
 
     def refresh(self) -> Self:
         """Rehydrate durable transcript and pause state after reconnecting."""

--- a/python/python/bystro/think/context.py
+++ b/python/python/bystro/think/context.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, replace
+from datetime import datetime
 import html
 from typing import TypeAlias, TypeVar
 
@@ -22,6 +23,7 @@ class PreviousConversation:
 
     id: str  # noqa: A003 - mirrors the conversation API field
     name: str | None = None
+    created_at: datetime | None = None
 
     def __post_init__(self) -> None:
         if not self.id.strip():

--- a/python/python/bystro/think/errors.py
+++ b/python/python/bystro/think/errors.py
@@ -59,6 +59,10 @@ class RunTimeoutError(ThinkError, TimeoutError):
     """Waiting for a run outcome exceeded the requested timeout."""
 
 
+class RunCancelledError(ThinkError):
+    """The run was durably cancelled rather than merely detached."""
+
+
 class RunProtocolError(ThinkError):
     """The live server sent an incomplete or contradictory run state."""
 
@@ -69,6 +73,7 @@ class InputResponseError(ThinkError):
 
 __all__ = [
     "InputResponseError",
+    "RunCancelledError",
     "RunProtocolError",
     "RunRejectedError",
     "RunTimeoutError",

--- a/python/python/bystro/think/models.py
+++ b/python/python/bystro/think/models.py
@@ -6,9 +6,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Literal, Mapping, TypeAlias
+import threading
+from typing import Callable, Literal, Mapping, TypeAlias
 
 ConversationMode: TypeAlias = Literal["base", "plus", "plus2", "phd"]
+StreamOperation: TypeAlias = Literal["append", "replace", "retract"]
 
 
 class RunStatus(str, Enum):
@@ -18,6 +20,7 @@ class RunStatus(str, Enum):
     QUEUED = "queued"
     RUNNING = "running"
     NEEDS_INPUT = "needs_input"
+    CANCELLING = "cancelling"
     SUCCEEDED = "succeeded"
     FAILED = "failed"
     CANCELLED = "cancelled"
@@ -39,8 +42,11 @@ class EventKind(str, Enum):
     SUBMITTED = "submitted"
     STARTED = "started"
     PROGRESS = "progress"
+    STREAM = "stream"
     MESSAGE = "message"
     NEEDS_INPUT = "needs_input"
+    CANCELLING = "cancelling"
+    CANCELLED = "cancelled"
     COMPLETED = "completed"
     FAILED = "failed"
 
@@ -150,6 +156,53 @@ class ThinkMessage:
 
 
 @dataclass(frozen=True, slots=True)
+class StreamUpdate:
+    """A typed update derived from a live Socket.IO output frame."""
+
+    message_id: str
+    delta: str
+    operation: StreamOperation
+    content_length: int
+    message_type: str
+    name: str | None = None
+    stream_type: str | None = None
+    is_reasoning: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressPhase:
+    """One backend-owned unit of work in a structured progress update."""
+
+    id: str  # noqa: A003 - mirrors the progress protocol field
+    kind: str
+    state: str
+    label: str
+    detail: str | None = None
+    completed: int | None = None
+    total: int | None = None
+    started_at: datetime | None = None
+    duration_seconds: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressUpdate:
+    """A complete snapshot of the server's current workload phases."""
+
+    done: bool
+    phases: tuple[ProgressPhase, ...]
+
+    @property
+    def active_phase(self) -> ProgressPhase | None:
+        """Return the most relevant current phase, if the snapshot has one."""
+
+        for state in ("active", "pending"):
+            for phase in reversed(self.phases):
+                if phase.state == state:
+                    return phase
+        return self.phases[-1] if self.phases else None
+
+
+@dataclass(frozen=True, slots=True)
 class ThinkEvent:
     """An ordered, SDK-level progress event."""
 
@@ -159,6 +212,8 @@ class ThinkEvent:
     created_at: datetime
     message: str | None = None
     data: Mapping[str, object] = field(default_factory=dict)
+    stream_update: StreamUpdate | None = None
+    progress: ProgressUpdate | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,13 +226,62 @@ class NeedsInput:
     checkpoint_id: str | None
     details: Mapping[str, object] = field(default_factory=dict)
 
+    def _repr_markdown_(self) -> str:
+        """Render the durable input request naturally in notebooks."""
+
+        return self.prompt or f"Input required: {self.kind.value}"
+
+
+OutputFileLoader: TypeAlias = Callable[[], tuple[OutputFile, ...]]
+
 
 @dataclass(frozen=True, slots=True)
 class RunResult:
-    """Successful Think run result."""
+    """Successful Think output with lazily discovered generated files."""
 
     run_id: str
     output: str
+    _file_loader: OutputFileLoader | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _files: tuple[OutputFile, ...] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _files_lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    @property
+    def files(self) -> tuple[OutputFile, ...]:
+        """Return generated files, loading the protected listing once on demand."""
+
+        with self._files_lock:
+            cached = self._files
+            if cached is None:
+                loader = self._file_loader
+                cached = () if loader is None else tuple(loader())
+                object.__setattr__(self, "_files", cached)
+                object.__setattr__(self, "_file_loader", None)
+            return cached
+
+    @property
+    def artifacts(self) -> tuple[OutputFile, ...]:
+        """Alias for :attr:`files`, matching agent-artifact terminology."""
+
+        return self.files
+
+    def _repr_markdown_(self) -> str:
+        """Render the final Markdown response naturally in notebooks."""
+
+        return self.output
 
 
 RunOutcome: TypeAlias = NeedsInput | RunResult
@@ -191,10 +295,14 @@ __all__ = [
     "InputKind",
     "NeedsInput",
     "OutputFile",
+    "ProgressPhase",
+    "ProgressUpdate",
     "RunOptions",
     "RunOutcome",
     "RunResult",
     "RunStatus",
+    "StreamOperation",
+    "StreamUpdate",
     "ThinkEvent",
     "ThinkMessage",
     "UploadedFile",

--- a/python/python/bystro/think/progress.py
+++ b/python/python/bystro/think/progress.py
@@ -1,0 +1,423 @@
+"""Terminal rendering for Bystro Think live events."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import sys
+import threading
+import time
+from typing import TextIO, TypeAlias
+
+from bystro.think.models import EventKind, ProgressUpdate, StreamUpdate, ThinkEvent
+
+_MAX_RENDER_STATES = 128
+_GENERIC_PROGRESS_MESSAGES = frozenset({"Processing...", "Thinking..."})
+
+ProgressCallback: TypeAlias = Callable[[ThinkEvent], None]
+
+_PROGRESS_MESSAGES: dict[EventKind, str] = {
+    EventKind.SUBMITTED: "Workload submitted",
+    EventKind.STARTED: "Analysis started",
+    EventKind.NEEDS_INPUT: "Input required",
+    EventKind.CANCELLING: "Cancelling analysis",
+    EventKind.CANCELLED: "Analysis cancelled",
+    EventKind.COMPLETED: "Analysis complete",
+}
+
+
+def _terminal_text(value: str) -> str:
+    """Remove terminal control bytes while preserving readable layout."""
+
+    return "".join(
+        character
+        for character in value
+        if character in {"\n", "\t"}
+        or (ord(character) >= 32 and not 127 <= ord(character) <= 159)
+    )
+
+
+def _common_prefix_length(left: str, right: str) -> int:
+    for index, (left_character, right_character) in enumerate(zip(left, right)):
+        if left_character != right_character:
+            return index
+    return min(len(left), len(right))
+
+
+@dataclass(slots=True)
+class _ProgressRenderState:
+    last_progress: str | None = None
+    last_progress_at: datetime | None = None
+    turn_started_at: datetime | None = None
+    needs_input_rendered: bool = False
+    stream_message_id: str | None = None
+    visible_message_id: str | None = None
+    visible_content: str = ""
+    stream_line_open: bool = False
+    turn: int = 0
+    started_turn: int = -1
+    pending_started: bool = False
+    waiting_for_submission: bool = True
+    turn_started_monotonic: float | None = None
+    last_activity_monotonic: float | None = None
+    generic_progress_seen: set[str] = field(default_factory=set)
+    heartbeat_stop: threading.Event | None = None
+    heartbeat_thread: threading.Thread | None = None
+
+
+class ProgressRenderer:
+    """Render coalesced lifecycle updates and live visible output."""
+
+    def __init__(
+        self,
+        *,
+        stream_output: bool = True,
+        file: TextIO | None = None,
+        heartbeat_interval: float = 30.0,
+    ) -> None:
+        if heartbeat_interval <= 0:
+            raise ValueError("heartbeat_interval must be positive")
+        self._stream_output = stream_output
+        self._file = file
+        self._heartbeat_interval = heartbeat_interval
+        self._states: dict[str, _ProgressRenderState] = {}
+        self._lock = threading.RLock()
+
+    def _output(self) -> TextIO:
+        return self._file or sys.stdout
+
+    def _state(self, run_id: str) -> _ProgressRenderState:
+        state = self._states.get(run_id)
+        if state is None:
+            state = _ProgressRenderState()
+            self._states[run_id] = state
+            if len(self._states) > _MAX_RENDER_STATES:
+                for oldest_run_id in tuple(self._states):
+                    if oldest_run_id != run_id:
+                        self._stop_heartbeat(self._states[oldest_run_id])
+                        del self._states[oldest_run_id]
+                        break
+        return state
+
+    def _close_stream_line(self, state: _ProgressRenderState) -> None:
+        if state.stream_line_open:
+            print(file=self._output(), flush=True)
+            state.stream_line_open = False
+
+    @staticmethod
+    def _stop_heartbeat(state: _ProgressRenderState) -> None:
+        stop = state.heartbeat_stop
+        if stop is not None:
+            stop.set()
+        state.heartbeat_stop = None
+        state.heartbeat_thread = None
+
+    def _heartbeat_loop(
+        self,
+        run_id: str,
+        turn: int,
+        stop: threading.Event,
+    ) -> None:
+        while not stop.wait(self._heartbeat_interval):
+            with self._lock:
+                state = self._states.get(run_id)
+                if (
+                    state is None
+                    or state.turn != turn
+                    or state.heartbeat_stop is not stop
+                    or state.waiting_for_submission
+                ):
+                    return
+                now = time.monotonic()
+                last_activity = state.last_activity_monotonic
+                if (
+                    last_activity is not None
+                    and now - last_activity < self._heartbeat_interval
+                ):
+                    continue
+                started_at = state.turn_started_monotonic or now
+                elapsed = max(0, int(now - started_at))
+                minutes, seconds = divmod(elapsed, 60)
+                elapsed_text = f"{minutes}m {seconds}s" if minutes else f"{seconds}s"
+                self._write_status(
+                    state,
+                    EventKind.PROGRESS,
+                    f"Still working... ({elapsed_text} elapsed)",
+                )
+                state.last_progress_at = datetime.now(timezone.utc)
+                state.last_activity_monotonic = now
+
+    def _start_heartbeat(self, run_id: str, state: _ProgressRenderState) -> None:
+        self._stop_heartbeat(state)
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=self._heartbeat_loop,
+            args=(run_id, state.turn, stop),
+            name=f"bystro-think-progress-{run_id[:8]}",
+            daemon=True,
+        )
+        state.heartbeat_stop = stop
+        state.heartbeat_thread = thread
+        thread.start()
+
+    def _write_status(
+        self,
+        state: _ProgressRenderState,
+        kind: EventKind,
+        message: str,
+    ) -> None:
+        self._close_stream_line(state)
+        state.stream_message_id = None
+        print(
+            f"[{kind.value}] {_terminal_text(message)}",
+            file=self._output(),
+            flush=True,
+        )
+
+    def _render_stream(
+        self,
+        state: _ProgressRenderState,
+        update: StreamUpdate,
+        created_at: datetime,
+    ) -> None:
+        state.last_activity_monotonic = time.monotonic()
+        if update.is_reasoning:
+            message = "Thinking..."
+            if message in state.generic_progress_seen:
+                return
+            state.generic_progress_seen.add(message)
+            self._write_status(state, EventKind.PROGRESS, message)
+            state.last_progress = message
+            state.last_progress_at = created_at
+            return
+        if not self._stream_output:
+            return
+        if update.operation == "retract":
+            self._close_stream_line(state)
+            print("[stream restarted]", file=self._output(), flush=True)
+            state.stream_message_id = None
+            if state.visible_message_id == update.message_id:
+                state.visible_message_id = None
+                state.visible_content = ""
+            return
+        same_visible_message = state.visible_message_id == update.message_id
+        visible_delta = update.delta
+        if update.operation == "replace" and same_visible_message:
+            unchanged_prefix = _common_prefix_length(
+                state.visible_content,
+                update.delta,
+            )
+            self._close_stream_line(state)
+            print(
+                f"[stream updated from character {unchanged_prefix}]",
+                file=self._output(),
+                flush=True,
+            )
+            state.stream_message_id = update.message_id
+            visible_delta = update.delta[unchanged_prefix:]
+        elif state.stream_message_id != update.message_id:
+            self._close_stream_line(state)
+            print("[stream]", file=self._output(), flush=True)
+            state.stream_message_id = update.message_id
+
+        if update.operation == "replace":
+            state.visible_content = update.delta
+        elif same_visible_message:
+            state.visible_content += update.delta
+        else:
+            state.visible_content = update.delta
+        state.visible_message_id = update.message_id
+
+        if visible_delta:
+            terminal_delta = _terminal_text(visible_delta)
+            output = self._output()
+            output.write(terminal_delta)
+            output.flush()
+            state.stream_line_open = bool(terminal_delta) and not terminal_delta.endswith("\n")
+
+    @staticmethod
+    def _structured_progress_message(update: ProgressUpdate) -> str | None:
+        phase = update.active_phase
+        if phase is None:
+            return None
+        message = phase.label
+        if phase.detail and phase.detail not in message:
+            message = f"{message} — {phase.detail}"
+        if (
+            phase.completed is not None
+            and phase.total is not None
+            and phase.total > 0
+        ):
+            message = f"{message} ({phase.completed}/{phase.total})"
+        return message
+
+    def __call__(self, event: ThinkEvent) -> None:
+        with self._lock:
+            state = self._state(event.run_id)
+            if event.kind is EventKind.STREAM:
+                if event.stream_update is not None:
+                    self._render_stream(state, event.stream_update, event.created_at)
+                return
+            if event.kind is EventKind.MESSAGE:
+                return
+            if event.kind is EventKind.NEEDS_INPUT:
+                # The live overlay is first emitted before checkpoint commit and
+                # replayed with its durable id. A response submission is the only
+                # writer that can advance this run to another input pause.
+                if state.needs_input_rendered:
+                    return
+                state.needs_input_rendered = True
+            if (
+                event.kind is EventKind.DISCONNECTED
+                and event.message
+                and "client disconnect" in event.message.casefold()
+            ):
+                return
+            if event.kind is EventKind.SUBMITTED:
+                self._stop_heartbeat(state)
+                state.turn += 1
+                state.started_turn = -1
+                state.waiting_for_submission = False
+                state.needs_input_rendered = False
+                state.last_progress = None
+                state.last_progress_at = None
+                state.generic_progress_seen.clear()
+                state.turn_started_at = event.created_at
+                state.turn_started_monotonic = time.monotonic()
+                state.last_activity_monotonic = state.turn_started_monotonic
+                state.visible_message_id = None
+                state.visible_content = ""
+                self._write_status(state, event.kind, _PROGRESS_MESSAGES[event.kind])
+                if state.pending_started:
+                    self._write_status(
+                        state,
+                        EventKind.STARTED,
+                        _PROGRESS_MESSAGES[EventKind.STARTED],
+                    )
+                    state.started_turn = state.turn
+                    state.pending_started = False
+                self._start_heartbeat(event.run_id, state)
+                return
+            if event.kind is EventKind.STARTED:
+                if state.waiting_for_submission or state.turn == 0:
+                    state.pending_started = True
+                    return
+                if state.started_turn == state.turn:
+                    return
+                state.started_turn = state.turn
+                self._write_status(state, event.kind, _PROGRESS_MESSAGES[event.kind])
+                return
+            if event.kind is EventKind.PROGRESS:
+                progress_message = (
+                    self._structured_progress_message(event.progress)
+                    if event.progress is not None
+                    else None
+                )
+                if progress_message is None:
+                    detail = event.data.get("detail")
+                    progress_message = (
+                        detail.strip()
+                        if isinstance(detail, str) and detail.strip()
+                        else event.message
+                    )
+                if progress_message is None or progress_message == "progress":
+                    return
+                generic_progress = (
+                    event.progress is None
+                    and progress_message in _GENERIC_PROGRESS_MESSAGES
+                )
+                repeated_generic = (
+                    generic_progress
+                    and progress_message in state.generic_progress_seen
+                )
+                if generic_progress:
+                    state.generic_progress_seen.add(progress_message)
+                if progress_message == state.last_progress or repeated_generic:
+                    if state.last_progress_at is None:
+                        state.last_progress_at = event.created_at
+                        return
+                    since_last = (
+                        event.created_at - state.last_progress_at
+                    ).total_seconds()
+                    if since_last < self._heartbeat_interval:
+                        return
+                    state.last_progress_at = event.created_at
+                    started_at = state.turn_started_at or event.created_at
+                    elapsed = max(
+                        0,
+                        int((event.created_at - started_at).total_seconds()),
+                    )
+                    minutes, seconds = divmod(elapsed, 60)
+                    elapsed_text = (
+                        f"{minutes}m {seconds}s" if minutes else f"{seconds}s"
+                    )
+                    message = f"Still working... ({elapsed_text} elapsed)"
+                else:
+                    state.last_progress = progress_message
+                    state.last_progress_at = event.created_at
+                    state.last_activity_monotonic = time.monotonic()
+                    if state.turn_started_at is None:
+                        state.turn_started_at = event.created_at
+                    message = progress_message
+            else:
+                message = (
+                    _PROGRESS_MESSAGES.get(event.kind, event.message)
+                    or event.kind.value
+                )
+                state.last_activity_monotonic = time.monotonic()
+            if event.kind in {
+                EventKind.NEEDS_INPUT,
+                EventKind.CANCELLED,
+                EventKind.COMPLETED,
+                EventKind.FAILED,
+            }:
+                state.waiting_for_submission = True
+                self._stop_heartbeat(state)
+            self._write_status(state, event.kind, message)
+            if event.kind in {
+                EventKind.CANCELLED,
+                EventKind.COMPLETED,
+                EventKind.FAILED,
+            }:
+                state.visible_message_id = None
+                state.visible_content = ""
+
+    def close(self, run_id: str | None = None) -> None:
+        """Stop owned heartbeat workers, optionally for one run only."""
+
+        with self._lock:
+            if run_id is not None:
+                state = self._states.pop(run_id, None)
+                if state is not None:
+                    self._stop_heartbeat(state)
+                return
+            for state in self._states.values():
+                self._stop_heartbeat(state)
+            self._states.clear()
+
+
+_DEFAULT_PROGRESS_RENDERER = ProgressRenderer()
+
+
+def show_progress(event: ThinkEvent) -> None:
+    """Render coalesced progress and browser-visible streamed output."""
+
+    _DEFAULT_PROGRESS_RENDERER(event)
+
+
+def close_progress_callback(
+    callback: ProgressCallback | None,
+    run_id: str | None,
+) -> None:
+    """Release renderer state owned by a public progress callback."""
+
+    if run_id is None:
+        return
+    if isinstance(callback, ProgressRenderer):
+        callback.close(run_id)
+    elif callback is show_progress:
+        _DEFAULT_PROGRESS_RENDERER.close(run_id)
+
+
+__all__ = ["ProgressCallback", "ProgressRenderer", "show_progress"]

--- a/python/python/bystro/think/progress.py
+++ b/python/python/bystro/think/progress.py
@@ -362,7 +362,8 @@ class ProgressRenderer:
                     message = progress_message
             else:
                 message = (
-                    _PROGRESS_MESSAGES.get(event.kind, event.message)
+                    _PROGRESS_MESSAGES.get(event.kind)
+                    or event.message
                     or event.kind.value
                 )
                 state.last_activity_monotonic = time.monotonic()

--- a/python/python/bystro/think/tests/test_client.py
+++ b/python/python/bystro/think/tests/test_client.py
@@ -2544,7 +2544,7 @@ def test_run_result_lazily_exposes_structured_files_and_notebook_markdown(
     )
     assert result.artifacts is result.files
     assert len(session.gets) == 1
-    assert result._repr_markdown_() == result.output
+    assert result._repr_markdown_() == result.output  # noqa: SLF001 - notebook display protocol
     assert hash(result) == hash(RunResult(result.run_id, result.output))
 
 

--- a/python/python/bystro/think/tests/test_client.py
+++ b/python/python/bystro/think/tests/test_client.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Iterator
+from datetime import datetime, timedelta, timezone
+from io import StringIO
 from pathlib import Path
 import time
 from typing import cast
@@ -23,15 +26,21 @@ from bystro.think import (
     NeedsInput,
     OutputFile,
     PreviousConversation,
+    ProgressPhase,
+    ProgressUpdate,
+    ProgressRenderer,
+    RunCancelledError,
     RunOptions,
     RunProtocolError,
     RunRejectedError,
     RunResult,
     RunStatus,
     RunTimeoutError,
+    StreamUpdate,
     ThinkClient,
     ThinkAuthenticationError,
     ThinkEvent,
+    ThinkConnectionError,
     ThinkHTTPError,
     UploadedFile,
     UploadPhase,
@@ -119,6 +128,7 @@ class FakeSocket:
         self.emits: list[tuple[str, object]] = []
         self.connect_args: tuple[str, dict[str, object]] | None = None
         self.connected = False
+        self.connect_failure: Exception | None = None
         self.next_message_ack: dict[str, object] = {
             "success": True,
             "threadId": "thread-1",
@@ -145,6 +155,8 @@ class FakeSocket:
         return register
 
     def connect(self, url: str, **kwargs: object) -> None:
+        if self.connect_failure is not None:
+            raise self.connect_failure
         self.connect_args = (url, kwargs)
         self.connected = True
         callback = self.handlers.get("connect")
@@ -208,6 +220,7 @@ def make_client(
     upload_chunk_size: int = 10 * 1024 * 1024,
     sleep: Callable[[float], None] = time.sleep,
     finalization_timeout: float = 10.0,
+    transports: tuple[str, ...] | None = None,
 ) -> ThinkClient:
     session, socket = transport
     return ThinkClient(
@@ -218,6 +231,7 @@ def make_client(
         _socket_factory=lambda **_kwargs: socket,
         upload_chunk_size=upload_chunk_size,
         finalization_timeout=finalization_timeout,
+        transports=transports,
         _sleep=sleep,
     )
 
@@ -300,6 +314,55 @@ def test_connect_bootstraps_existing_browser_auth_contract(
     assert ("connection_successful", None) in socket.emits
 
 
+def test_connect_can_require_websocket_transport(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport, transports=("websocket",))
+
+    client.connect()
+
+    assert socket.connect_args is not None
+    _socket_url, socket_kwargs = socket.connect_args
+    assert socket_kwargs["transports"] == ["websocket"]
+
+
+def test_connect_accepts_a_single_transport_string(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    session, socket = transport
+    client = ThinkClient(
+        auth=auth_state,
+        think_url="https://ai.bystro.cloud",
+        _session=session,
+        _socket_factory=lambda **_kwargs: socket,
+        transports="websocket",
+    )
+
+    client.connect()
+
+    assert socket.connect_args is not None
+    _socket_url, socket_kwargs = socket.connect_args
+    assert socket_kwargs["transports"] == ["websocket"]
+
+
+def test_connect_rejects_unknown_or_empty_transports(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    session, socket = transport
+    for transports in ((), ("websocket", "invalid")):
+        with pytest.raises(ValueError, match="transport"):
+            ThinkClient(
+                auth=auth_state,
+                _session=session,
+                _socket_factory=lambda **_kwargs: socket,
+                transports=transports,
+            )
+
+
 def test_submit_reports_connected_before_submitted(
     auth_state: CachedAuth,
     transport: tuple[FakeSession, FakeSocket],
@@ -340,6 +403,671 @@ def test_submit_with_progress_is_the_canonical_concise_renderer(
         "[started] Analysis started",
         "[progress] Processing...",
     ]
+
+
+def test_progress_renderer_coalesces_repeated_overlay_snapshots(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+
+    run = client.submit_with_progress("Analyze")
+    for _ in range(4):
+        socket.trigger(
+            "status_overlay_update",
+            {
+                "threadId": run.id,
+                "visible": True,
+                "display": "Processing...",
+            },
+        )
+
+    output = capsys.readouterr().out
+    assert output.count("[progress] Processing...") == 1
+
+
+def test_progress_renderer_coalesces_alternating_generic_states() -> None:
+    output = StringIO()
+    renderer = ProgressRenderer(file=output, heartbeat_interval=30.0)
+    started_at = datetime(2026, 8, 15, tzinfo=timezone.utc)
+
+    renderer(ThinkEvent(1, EventKind.SUBMITTED, "thread-1", started_at))
+    for sequence in (2, 4):
+        renderer(
+            ThinkEvent(
+                sequence,
+                EventKind.STREAM,
+                "thread-1",
+                started_at + timedelta(seconds=sequence),
+                stream_update=StreamUpdate(
+                    message_id=f"reasoning-{sequence}",
+                    delta="",
+                    operation="append",
+                    content_length=10,
+                    message_type="assistant_message",
+                    is_reasoning=True,
+                ),
+            )
+        )
+        renderer(
+            ThinkEvent(
+                sequence + 1,
+                EventKind.PROGRESS,
+                "thread-1",
+                started_at + timedelta(seconds=sequence + 1),
+                message="Processing...",
+            )
+        )
+
+    rendered = output.getvalue()
+    assert rendered.count("[progress] Thinking...") == 1
+    assert rendered.count("[progress] Processing...") == 1
+
+
+def test_progress_renderer_turns_repeated_processing_into_elapsed_heartbeats() -> None:
+    output = StringIO()
+    renderer = ProgressRenderer(file=output, heartbeat_interval=30.0)
+    started_at = datetime(2026, 8, 15, tzinfo=timezone.utc)
+
+    renderer(
+        ThinkEvent(
+            1,
+            EventKind.SUBMITTED,
+            "thread-1",
+            started_at,
+        )
+    )
+    for sequence, seconds in ((2, 1), (3, 15), (4, 31), (5, 45), (6, 61)):
+        renderer(
+            ThinkEvent(
+                sequence,
+                EventKind.PROGRESS,
+                "thread-1",
+                started_at + timedelta(seconds=seconds),
+                message="Processing...",
+            )
+        )
+
+    assert output.getvalue().splitlines() == [
+        "[submitted] Workload submitted",
+        "[progress] Processing...",
+        "[progress] Still working... (31s elapsed)",
+        "[progress] Still working... (1m 1s elapsed)",
+    ]
+
+
+def test_structured_backend_progress_is_typed_rendered_and_not_transcript(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    output = StringIO()
+    renderer = ProgressRenderer(file=output)
+    events: list[ThinkEvent] = []
+    _session, socket = transport
+
+    def capture_and_render(event: ThinkEvent) -> None:
+        events.append(event)
+        renderer(event)
+
+    client = make_client(
+        auth_state,
+        transport,
+        on_event=capture_and_render,
+    )
+    run = client.submit("Research")
+
+    socket.trigger(
+        "new_message",
+        {
+            "id": "progress-card",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "🔍 Gathering the evidence…",
+            "metadata": {
+                "section": "progress",
+                "progress": {
+                    "done": False,
+                    "phases": [
+                        {
+                            "id": "search-123",
+                            "kind": "search",
+                            "state": "active",
+                            "label": "Gathering the evidence…",
+                            "detail": "PubMed and FDA",
+                            "count": {"done": 3, "total": 8},
+                            "started_at": 1_786_752_000_000,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    progress_events = [event for event in events if event.progress is not None]
+    assert len(progress_events) == 1
+    update = progress_events[0].progress
+    assert isinstance(update, ProgressUpdate)
+    assert update.done is False
+    assert update.active_phase == ProgressPhase(
+        id="search-123",
+        kind="search",
+        state="active",
+        label="Gathering the evidence…",
+        detail="PubMed and FDA",
+        completed=3,
+        total=8,
+        started_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+        duration_seconds=None,
+    )
+    assert run.messages == ()
+    assert "Gathering the evidence… — PubMed and FDA (3/8)" in output.getvalue()
+
+
+def test_progress_renderer_emits_elapsed_heartbeat_without_server_frames() -> None:
+    output = StringIO()
+    renderer = ProgressRenderer(file=output, heartbeat_interval=0.02)
+    now = datetime.now(timezone.utc)
+
+    renderer(ThinkEvent(1, EventKind.SUBMITTED, "thread-1", now))
+    deadline = time.monotonic() + 0.5
+    while "Still working" not in output.getvalue() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    renderer(
+        ThinkEvent(2, EventKind.COMPLETED, "thread-1", datetime.now(timezone.utc))
+    )
+    rendered_after_completion = output.getvalue()
+    time.sleep(0.05)
+
+    assert "Still working" in rendered_after_completion
+    assert output.getvalue() == rendered_after_completion
+
+
+def test_detach_stops_the_run_progress_renderer(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    output = StringIO()
+    renderer = ProgressRenderer(file=output, heartbeat_interval=0.02)
+    client = make_client(auth_state, transport)
+    run = client.submit_with_progress("Analyze", on_event=renderer)
+
+    run.detach()
+    rendered_after_detach = output.getvalue()
+    time.sleep(0.05)
+
+    assert output.getvalue() == rendered_after_detach
+
+
+def test_detach_stops_the_canonical_show_progress_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    output = StringIO()
+    renderer = ProgressRenderer(file=output, heartbeat_interval=0.02)
+    monkeypatch.setattr(
+        "bystro.think.progress._DEFAULT_PROGRESS_RENDERER",
+        renderer,
+    )
+    client = make_client(
+        auth_state,
+        transport,
+        on_event=think_client_module.show_progress,
+    )
+    run = client.submit("Analyze")
+
+    run.detach()
+    rendered_after_detach = output.getvalue()
+    time.sleep(0.05)
+
+    assert output.getvalue() == rendered_after_detach
+
+
+def test_progress_renderer_does_not_reprint_the_unchanged_prefix_on_correction() -> None:
+    output = StringIO()
+    renderer = ProgressRenderer(file=output)
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    prefix = "stable-prefix-" * 20
+    renderer(ThinkEvent(1, EventKind.SUBMITTED, "thread-1", now))
+    renderer(
+        ThinkEvent(
+            2,
+            EventKind.STREAM,
+            "thread-1",
+            now,
+            stream_update=StreamUpdate(
+                "answer",
+                prefix + "old ending",
+                "append",
+                len(prefix) + len("old ending"),
+                "assistant_message",
+            ),
+        )
+    )
+    renderer(
+        ThinkEvent(
+            3,
+            EventKind.STREAM,
+            "thread-1",
+            now,
+            stream_update=StreamUpdate(
+                "answer",
+                prefix + "new ending",
+                "replace",
+                len(prefix) + len("new ending"),
+                "assistant_message",
+            ),
+        )
+    )
+
+    rendered = output.getvalue()
+    assert rendered.count(prefix) == 1
+    assert f"[stream updated from character {len(prefix)}]" in rendered
+    assert rendered.endswith("new ending")
+
+
+def test_progress_renderer_coalesces_replayed_needs_input_checkpoint(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit_with_progress("Analyze")
+    before_commit = {
+        "threadId": run.id,
+        "visible": True,
+        "waitingForInput": True,
+        "humanApprovalStage": "clarifying_questions",
+    }
+    after_commit = {
+        **before_commit,
+        "checkpointId": "1f13d2a1-9893-603b-8000-000000000001",
+    }
+
+    socket.trigger("status_overlay_update", before_commit)
+    socket.trigger("status_overlay_update", after_commit)
+
+    run.respond("skip")
+    socket.trigger(
+        "status_overlay_update",
+        {
+            **before_commit,
+            "checkpointId": "1f13d2a1-9893-603b-8000-000000000002",
+        },
+    )
+
+    output = capsys.readouterr().out
+    assert output.count("[needs_input] Input required") == 2
+
+
+def test_progress_renderer_coalesces_started_replay_around_input_response(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit_with_progress("Analyze")
+    socket.trigger("task_start", {"threadId": run.id})
+    socket.trigger(
+        "new_message",
+        {
+            "id": "question",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Which cohort?",
+            "metadata": {},
+        },
+    )
+    socket.trigger(
+        "status_overlay_update",
+        {
+            "threadId": run.id,
+            "visible": True,
+            "waitingForInput": True,
+            "humanApprovalStage": "clarifying_questions",
+            "checkpointId": "1f13d2a1-9893-603b-8000-000000000001",
+        },
+    )
+
+    def start_before_response_ack(
+        event: str,
+        data: object,
+        timeout: float | None,
+    ) -> None:
+        del data, timeout
+        if event == "client_message":
+            socket.trigger("task_start", {"threadId": run.id})
+
+    socket.call_hook = start_before_response_ack
+    run.respond("Use all cohorts")
+    socket.trigger("task_start", {"threadId": run.id})
+
+    lines = capsys.readouterr().out.splitlines()
+    assert lines.count("[submitted] Workload submitted") == 2
+    assert lines.count("[started] Analysis started") == 2
+    second_submission = lines.index("[submitted] Workload submitted", 2)
+    assert lines[second_submission + 1] == "[started] Analysis started"
+
+
+def test_websocket_stream_snapshots_become_incremental_typed_events(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    events: list[ThinkEvent] = []
+    _session, socket = transport
+    client = make_client(auth_state, transport, on_event=events.append)
+    run = client.submit("Analyze")
+
+    socket.trigger(
+        "new_message",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Hel",
+            "metadata": {"stream_type": "text"},
+        },
+    )
+    socket.trigger(
+        "stream_start",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Hel",
+            "metadata": {"stream_type": "text"},
+        },
+    )
+    socket.trigger(
+        "stream_token",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "token": "Hello",
+            "isSequence": True,
+        },
+    )
+    socket.trigger(
+        "stream_token",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "token": "Hello",
+            "isSequence": True,
+        },
+    )
+    socket.trigger(
+        "stream_token",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "token": "!",
+            "isSequence": False,
+        },
+    )
+    socket.trigger(
+        "update_message",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Hello! Done.",
+            "metadata": {"stream_type": "text", "is_final_response": True},
+        },
+    )
+
+    stream_updates = [
+        event.stream_update
+        for event in events
+        if event.kind is EventKind.STREAM and event.stream_update is not None
+    ]
+    assert [update.delta for update in stream_updates] == [
+        "Hel",
+        "lo",
+        "!",
+        " Done.",
+    ]
+    assert [update.operation for update in stream_updates] == [
+        "append",
+        "append",
+        "append",
+        "append",
+    ]
+    assert [update.content_length for update in stream_updates] == [
+        3,
+        5,
+        6,
+        12,
+    ]
+    assert all(update.message_id == "answer" for update in stream_updates)
+
+
+def test_streaming_progress_hides_reasoning_and_prints_visible_deltas(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit_with_progress("Analyze")
+
+    socket.trigger(
+        "stream_start",
+        {
+            "id": "reasoning",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "private reasoning text",
+            "metadata": {"stream_type": "reasoning", "is_reasoning": True},
+        },
+    )
+    socket.trigger(
+        "stream_start",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Visible",
+            "metadata": {"stream_type": "text", "is_reasoning": False},
+        },
+    )
+    socket.trigger(
+        "stream_token",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "token": "Visible answer",
+            "isSequence": True,
+        },
+    )
+
+    output = capsys.readouterr().out
+    assert "private reasoning text" not in output
+    assert output.count("[progress] Thinking...") == 1
+    assert "[stream]\nVisible answer" in output
+
+
+def test_streaming_progress_strips_terminal_control_sequences(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit_with_progress("Analyze")
+
+    socket.trigger(
+        "stream_start",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "safe\x1b[31m answer\x1b[0m",
+            "metadata": {"stream_type": "text"},
+        },
+    )
+
+    output = capsys.readouterr().out
+    assert "\x1b" not in output
+    assert "safe[31m answer[0m" in output
+
+
+def test_websocket_stream_events_redact_reasoning_content(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    events: list[ThinkEvent] = []
+    _session, socket = transport
+    client = make_client(auth_state, transport, on_event=events.append)
+    run = client.submit("Analyze")
+
+    socket.trigger(
+        "stream_start",
+        {
+            "id": "reasoning",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "private reasoning text",
+            "metadata": {"stream_type": "reasoning", "is_reasoning": True},
+        },
+    )
+    socket.trigger(
+        "stream_token",
+        {
+            "id": "reasoning",
+            "threadId": run.id,
+            "token": "private reasoning text continued",
+            "isSequence": True,
+        },
+    )
+    socket.trigger(
+        "status_overlay_update",
+        {
+            "threadId": run.id,
+            "visible": True,
+            "waitingForInput": True,
+            "humanApprovalStage": "clarifying_questions",
+        },
+    )
+
+    stream_updates = [
+        event.stream_update
+        for event in events
+        if event.kind is EventKind.STREAM and event.stream_update is not None
+    ]
+    assert len(stream_updates) == 1
+    assert stream_updates[0].delta == ""
+    assert stream_updates[0].is_reasoning is True
+    assert stream_updates[0].content_length == len("private reasoning text")
+    message_events = [event for event in events if event.kind is EventKind.MESSAGE]
+    assert len(message_events) == 1
+    assert message_events[0].message is None
+    assert message_events[0].data["is_reasoning"] is True
+    assert run.messages == ()
+    assert run.needs_input is not None
+    assert run.needs_input.prompt is None
+    assert all("private reasoning text" not in repr(event) for event in events)
+
+
+def test_websocket_stream_reports_replacements_and_retractions(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    events: list[ThinkEvent] = []
+    _session, socket = transport
+    client = make_client(auth_state, transport, on_event=events.append)
+    run = client.submit("Analyze")
+
+    socket.trigger(
+        "stream_start",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Draft",
+            "metadata": {"stream_type": "text"},
+        },
+    )
+    socket.trigger(
+        "stream_token",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "token": "Corrected",
+            "isSequence": True,
+        },
+    )
+    socket.trigger("delete_message", {"id": "answer", "threadId": run.id})
+
+    stream_updates = [
+        event.stream_update
+        for event in events
+        if event.kind is EventKind.STREAM and event.stream_update is not None
+    ]
+    assert [(update.operation, update.delta) for update in stream_updates] == [
+        ("append", "Draft"),
+        ("replace", "Corrected"),
+        ("retract", ""),
+    ]
+
+
+@settings(max_examples=30, deadline=None, database=None)
+@given(
+    fragments=st.lists(
+        st.text(alphabet=" abcdefghijklmnopqrstuvwxyz", min_size=0, max_size=12),
+        min_size=1,
+        max_size=20,
+    )
+)
+def test_websocket_cumulative_snapshots_have_linear_incremental_payloads(
+    fragments: list[str],
+) -> None:
+    auth_state = CachedAuth(
+        email="scientist@example.com",
+        access_token="dashboard-jwt",
+        url="https://bystro.cloud",
+    )
+    transport = (FakeSession(), FakeSocket())
+    _session, socket = transport
+    events: list[ThinkEvent] = []
+    client = make_client(auth_state, transport, on_event=events.append)
+    run = client.submit("Analyze")
+    cumulative = fragments[0]
+
+    socket.trigger(
+        "stream_start",
+        {
+            "id": "answer",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": cumulative,
+            "metadata": {"stream_type": "text"},
+        },
+    )
+    for fragment in fragments[1:]:
+        cumulative += fragment
+        socket.trigger(
+            "stream_token",
+            {
+                "id": "answer",
+                "threadId": run.id,
+                "token": cumulative,
+                "isSequence": True,
+            },
+        )
+
+    stream_updates = [
+        event.stream_update
+        for event in events
+        if event.kind is EventKind.STREAM and event.stream_update is not None
+    ]
+    assert all(update.operation == "append" for update in stream_updates)
+    assert "".join(update.delta for update in stream_updates) == cumulative
+    assert sum(len(update.delta) for update in stream_updates) == len(cumulative)
 
 
 def test_output_files_and_downloads_use_authenticated_streaming_routes(
@@ -389,6 +1117,27 @@ def test_output_files_and_downloads_use_authenticated_streaming_routes(
     assert len(session.gets) == gets_before
 
 
+def test_output_download_allows_doubled_dots_inside_a_file_name(
+    tmp_path: Path,
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    session, _socket = transport
+    session.output_responses.append(FakeResponse(200, None, chunks=(b"RESULT",)))
+    client = make_client(auth_state, transport)
+    run = client.submit("Create a report")
+
+    downloaded = run.download_file(
+        "reports/report..final.txt",
+        tmp_path / "report..final.txt",
+    )
+
+    assert downloaded.read_bytes() == b"RESULT"
+    assert session.gets[-1][0].endswith(
+        "/api/user-output/download/reports/report..final.txt"
+    )
+
+
 def test_list_conversations_searches_and_paginates(
     auth_state: CachedAuth,
     transport: tuple[FakeSession, FakeSocket],
@@ -399,7 +1148,13 @@ def test_list_conversations_searches_and_paginates(
             FakeResponse(
                 200,
                 {
-                    "data": [{"id": "thread-2", "name": "CAR-T update"}],
+                    "data": [
+                        {
+                            "id": "thread-2",
+                            "name": "CAR-T update",
+                            "createdAt": "2026-08-15T18:24:30.123Z",
+                        }
+                    ],
                     "pageInfo": {"hasNextPage": True, "endCursor": "thread-2"},
                 },
             ),
@@ -415,7 +1170,11 @@ def test_list_conversations_searches_and_paginates(
     client = make_client(auth_state, transport)
 
     conversations = client.list_conversations(search=" CAR-T ", page_size=1)
-    assert conversations[0] == PreviousConversation("thread-2", "CAR-T update")
+    assert conversations[0] == PreviousConversation(
+        "thread-2",
+        "CAR-T update",
+        datetime(2026, 8, 15, 18, 24, 30, 123000, tzinfo=timezone.utc),
+    )
     assert conversations[1] == PreviousConversation("thread-1")
     requests = [options for url, options in session.posts if url.endswith("/project/threads")]
     assert requests[0]["json"] == {
@@ -426,6 +1185,52 @@ def test_list_conversations_searches_and_paginates(
         "pagination": {"first": 1, "cursor": "thread-2"},
         "filter": {"search": "CAR-T"},
     }
+
+
+def test_list_conversations_can_bound_history_without_fetching_every_page(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    session, _socket = transport
+    session.conversation_responses.extend(
+        [
+            FakeResponse(
+                200,
+                {
+                    "data": [{"id": "thread-new", "name": "Newest"}],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "thread-new"},
+                },
+            ),
+            FakeResponse(
+                200,
+                {
+                    "data": [{"id": "thread-old", "name": "Older"}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": "thread-old"},
+                },
+            ),
+        ]
+    )
+    client = make_client(auth_state, transport)
+
+    conversations = client.list_conversations(page_size=50, limit=1)
+
+    assert conversations == (PreviousConversation("thread-new", "Newest"),)
+    requests = [options for url, options in session.posts if url.endswith("/project/threads")]
+    assert len(requests) == 1
+    assert requests[0]["json"] == {
+        "pagination": {"first": 1, "cursor": None},
+        "filter": {"search": None},
+    }
+
+
+def test_list_conversations_rejects_nonpositive_limit(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    client = make_client(auth_state, transport)
+
+    with pytest.raises(ValueError, match="limit"):
+        client.list_conversations(limit=0)
 
 
 def test_non_json_unauthorized_response_still_has_typed_auth_error(
@@ -696,6 +1501,44 @@ def test_submit_uploads_multiple_files_and_attaches_them_to_same_question(
     attachments = metadata["attached_input_artifacts"]
     assert isinstance(attachments, list)
     assert [attachment["id"] for attachment in attachments] == ["file-vcf", "file-tsv"]
+
+
+def test_submit_accepts_one_file_path_without_wrapping_it_in_a_list(
+    tmp_path: Path,
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    session, socket = transport
+    source = tmp_path / "cohort.csv"
+    source.write_bytes(b"sample,value\nA,1\n")
+    session.upload_responses.append(
+        FakeResponse(
+            200,
+            {
+                "completed": True,
+                "file": {
+                    "id": "file-csv",
+                    "name": "cohort.csv",
+                    "displayName": "cohort.csv",
+                    "size": source.stat().st_size,
+                    "mime": "text/csv",
+                },
+            },
+        )
+    )
+    client = make_client(auth_state, transport)
+
+    client.submit("Analyze this file", files=str(source))
+
+    sent = [data for event, data, _timeout in socket.calls if event == "client_message"][-1]
+    assert isinstance(sent, dict)
+    message = sent["message"]
+    assert isinstance(message, dict)
+    metadata = message["metadata"]
+    assert isinstance(metadata, dict)
+    attachments = metadata["attached_input_artifacts"]
+    assert isinstance(attachments, list)
+    assert [attachment["id"] for attachment in attachments] == ["file-csv"]
 
 
 def test_submit_needs_input_respond_and_finish(
@@ -1252,6 +2095,113 @@ def test_resume_hydrates_a_completed_run(
     )
 
 
+def test_resume_restores_run_options_for_follow_up_turns(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.resume("thread-mode")
+    socket.trigger(
+        "resume_thread",
+        {
+            "id": "thread-mode",
+            "steps": [
+                {
+                    "id": "user-existing",
+                    "threadId": "thread-mode",
+                    "type": "user_message",
+                    "output": "Deep analysis",
+                    "metadata": {
+                        "mode": "plus2",
+                        "advancedPlanningEnabled": True,
+                        "autoCompactEnabled": True,
+                        "fastEnabled": True,
+                        "verificationEnabled": False,
+                        "searchVerificationEnabled": False,
+                        "zdrEnabled": True,
+                    },
+                },
+                {
+                    "id": "final-existing",
+                    "threadId": "thread-mode",
+                    "type": "assistant_message",
+                    "output": "Persisted answer",
+                    "metadata": {"is_final_response": True},
+                },
+            ],
+            "elements": [],
+        },
+    )
+    assert isinstance(run.wait(timeout=0.1), RunResult)
+    socket.next_message_ack = {
+        "success": True,
+        "threadId": "thread-mode",
+        "created": True,
+        "dispatched": True,
+    }
+
+    run.follow_up("Continue in the same mode")
+
+    sent = [data for event, data, _timeout in socket.calls if event == "client_message"][-1]
+    assert isinstance(sent, dict)
+    message = sent["message"]
+    assert isinstance(message, dict)
+    metadata = message["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["mode"] == "plus2"
+    assert metadata["advancedPlanningEnabled"] is True
+    assert metadata["autoCompactEnabled"] is True
+    assert metadata["fastEnabled"] is True
+    assert metadata["verificationEnabled"] is False
+    assert metadata["searchVerificationEnabled"] is False
+    assert metadata["zdrEnabled"] is True
+
+
+def test_failed_resume_connection_does_not_poison_the_client(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    socket.connect_failure = OSError("offline")
+
+    with pytest.raises(ThinkConnectionError, match="live connection"):
+        client.resume("thread-unreachable")
+
+    socket.connect_failure = None
+    run = client.submit("A new workload")
+    assert run.id == "thread-1"
+
+
+def test_stale_run_cannot_refresh_the_socket_away_from_the_active_run(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    first = client.submit("First workload")
+    socket.trigger("task_end", {"threadId": first.id})
+    socket.trigger(
+        "new_message",
+        {
+            "id": "first-final",
+            "threadId": first.id,
+            "type": "assistant_message",
+            "output": "First answer",
+            "metadata": {"is_final_response": True},
+        },
+    )
+    second = client.submit("Second workload")
+    calls_before = len(socket.calls)
+
+    with pytest.raises(InputResponseError, match="no longer active"):
+        first.refresh()
+
+    assert len(socket.calls) == calls_before
+    assert second.status is RunStatus.QUEUED
+
+
 def test_resume_waits_for_transcript_before_returning_pause_prompt(
     auth_state: CachedAuth,
     transport: tuple[FakeSession, FakeSocket],
@@ -1547,6 +2497,333 @@ def test_rejected_follow_up_restores_completed_turn(
     restored_result = run.wait(timeout=0.1)
     assert isinstance(restored_result, RunResult)
     assert restored_result.output == "First answer"
+
+
+def test_run_result_lazily_exposes_structured_files_and_notebook_markdown(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit("Draw a duck")
+    socket.trigger(
+        "new_message",
+        {
+            "id": "final",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "## Duck\n\n![Duck](/api/user-files/thread-1/images/duck.png)",
+            "metadata": {"is_final_response": True},
+        },
+    )
+    socket.trigger("task_end", {"threadId": run.id})
+
+    result = run.wait(timeout=0.1)
+
+    assert isinstance(result, RunResult)
+    assert session.gets == []
+    session.output_responses.append(
+        FakeResponse(
+            200,
+            {
+                "files": [
+                    {
+                        "name": "duck.png",
+                        "path": "images/duck.png",
+                        "size": 1234,
+                        "modified": 10.0,
+                        "created": 9.0,
+                    }
+                ],
+                "hasMore": False,
+            },
+        )
+    )
+    assert result.files == (
+        OutputFile("duck.png", "images/duck.png", 1234, 10.0, 9.0),
+    )
+    assert result.artifacts is result.files
+    assert len(session.gets) == 1
+    assert result._repr_markdown_() == result.output
+    assert hash(result) == hash(RunResult(result.run_id, result.output))
+
+
+def test_interact_handles_clarification_callback_until_result(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit("Analyze")
+    socket.trigger(
+        "new_message",
+        {
+            "id": "question",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Which cohort?",
+            "metadata": {},
+        },
+    )
+    socket.trigger(
+        "status_overlay_update",
+        {
+            "threadId": run.id,
+            "visible": True,
+            "waitingForInput": True,
+            "humanApprovalStage": "clarifying_questions",
+            "checkpointId": "1f13d2a1-9893-603b-8000-000000000001",
+        },
+    )
+
+    def finish_after_response(
+        event: str,
+        data: object,
+        timeout: float | None,
+    ) -> None:
+        del data, timeout
+        if event != "client_message":
+            return
+        socket.trigger("task_start", {"threadId": run.id})
+        socket.trigger(
+            "new_message",
+            {
+                "id": "final",
+                "threadId": run.id,
+                "type": "assistant_message",
+                "output": "All cohorts analyzed",
+                "metadata": {"is_final_response": True},
+            },
+        )
+        socket.trigger("task_end", {"threadId": run.id})
+
+    socket.call_hook = finish_after_response
+    seen: list[NeedsInput] = []
+
+    def answer_clarification(request: NeedsInput) -> str:
+        seen.append(request)
+        return "all cohorts"
+
+    result = run.interact(
+        timeout=1.0,
+        on_clarification=answer_clarification,
+    )
+
+    assert isinstance(result, RunResult)
+    assert result.output == "All cohorts analyzed"
+    assert [request.prompt for request in seen] == ["Which cohort?"]
+
+
+def test_cancel_waits_for_durable_stop_release_and_detach_does_not_cancel(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    events: list[ThinkEvent] = []
+    client = make_client(auth_state, transport, on_event=events.append)
+    run = client.submit("Long analysis")
+    socket.trigger("task_start", {"threadId": run.id, "taskId": "task-1"})
+
+    def release_stop(event: str, data: object) -> None:
+        if event != "stop":
+            return
+        assert data == {
+            "threadId": run.id,
+            "clientObservedActive": True,
+            "taskId": "task-1",
+        }
+        socket.trigger("task_stopping", {"threadId": run.id, "taskId": "task-1"})
+        socket.trigger("task_end", {"threadId": run.id, "taskId": "task-1"})
+        socket.trigger(
+            "thread_stop_released",
+            {"threadId": run.id, "taskId": "task-1"},
+        )
+
+    socket.emit_hook = release_stop
+    run.cancel(timeout=0.5)
+
+    assert run.status is RunStatus.CANCELLED
+    assert EventKind.CANCELLING in {event.kind for event in events}
+    assert EventKind.CANCELLED in {event.kind for event in events}
+    with pytest.raises(RunCancelledError):
+        run.wait(timeout=0.1)
+
+    second_transport = (FakeSession(), FakeSocket())
+    _second_session, second_socket = second_transport
+    second_client = make_client(auth_state, second_transport)
+    second_run = second_client.submit("Keep running")
+    second_socket.trigger("task_start", {"threadId": second_run.id})
+    second_run.detach()
+    assert second_socket.connected is False
+    assert not any(event == "stop" for event, _data in second_socket.emits)
+
+
+def test_cancel_is_reissued_after_reconnect_until_stop_release(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit("Long analysis")
+    socket.trigger("task_start", {"threadId": run.id})
+
+    with pytest.raises(RunTimeoutError):
+        run.cancel(timeout=0.02)
+    assert sum(event == "stop" for event, _data in socket.emits) == 1
+
+    socket.connected = False
+    client.connect()
+    assert sum(event == "stop" for event, _data in socket.emits) == 2
+    socket.trigger("thread_stop_released", {"threadId": run.id})
+    assert run.status is RunStatus.CANCELLED
+    socket.trigger("task_start", {"threadId": run.id, "taskId": "late-task"})
+    socket.trigger("task_stopping", {"threadId": run.id, "taskId": "late-task"})
+    assert run.status is RunStatus.CANCELLED
+
+
+def test_stale_task_lifecycle_events_do_not_settle_the_active_turn(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit("Analyze")
+    socket.trigger("task_start", {"threadId": run.id, "taskId": "current-task"})
+
+    socket.trigger("task_end", {"threadId": run.id, "taskId": "old-task"})
+    socket.trigger("task_stopping", {"threadId": run.id, "taskId": "old-task"})
+    socket.trigger(
+        "thread_stop_released",
+        {"threadId": run.id, "taskId": "old-task"},
+    )
+    socket.trigger(
+        "thread_stop_released",
+        {"threadId": run.id, "taskId": "current-task"},
+    )
+
+    assert run.status is RunStatus.RUNNING
+    with pytest.raises(RunTimeoutError):
+        run.wait(timeout=0.01)
+
+
+def test_follow_up_cancel_before_task_start_does_not_reuse_the_prior_task_id(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit("First turn")
+    socket.trigger("task_start", {"threadId": run.id, "taskId": "first-task"})
+    socket.trigger(
+        "new_message",
+        {
+            "id": "first-final",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "First answer",
+            "metadata": {"is_final_response": True},
+        },
+    )
+    socket.trigger("task_end", {"threadId": run.id, "taskId": "first-task"})
+    assert isinstance(run.wait(timeout=0.1), RunResult)
+
+    run.follow_up("Second turn")
+    with pytest.raises(RunTimeoutError):
+        run.cancel(timeout=0.01)
+
+    stop_payloads = [data for event, data in socket.emits if event == "stop"]
+    assert stop_payloads[-1] == {
+        "threadId": run.id,
+        "clientObservedActive": True,
+    }
+    socket.trigger("task_start", {"threadId": run.id, "taskId": "second-task"})
+    assert run.status is RunStatus.CANCELLING
+    assert socket.emits[-1] == (
+        "stop",
+        {
+            "threadId": run.id,
+            "clientObservedActive": True,
+            "taskId": "second-task",
+        },
+    )
+
+
+@settings(max_examples=50, deadline=None, database=None)
+@given(
+    lifecycle_events=st.lists(
+        st.tuples(
+            st.sampled_from(
+                ["task_end", "task_stopping", "thread_stop_released"]
+            ),
+            st.sampled_from([None, "current-task", "stale-task"]),
+        ),
+        max_size=30,
+    )
+)
+def test_task_lifecycle_routing_fuzz_matches_the_active_task_only(
+    lifecycle_events: list[tuple[str, str | None]],
+) -> None:
+    auth_state = CachedAuth(
+        email="scientist@example.com",
+        access_token="dashboard-jwt",
+        url="https://bystro.cloud",
+    )
+    transport = (FakeSession(), FakeSocket())
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit("Analyze")
+    socket.trigger("task_start", {"threadId": run.id, "taskId": "current-task"})
+    expected_status = RunStatus.RUNNING
+    cancel_requested = False
+
+    for event, task_id in lifecycle_events:
+        payload: dict[str, object] = {"threadId": run.id}
+        if task_id is not None:
+            payload["taskId"] = task_id
+        task_matches = task_id in {None, "current-task"}
+        if expected_status is not RunStatus.CANCELLED:
+            if event == "task_stopping" and task_matches:
+                cancel_requested = True
+                expected_status = RunStatus.CANCELLING
+            elif (
+                event == "thread_stop_released"
+                and task_matches
+                and cancel_requested
+            ):
+                expected_status = RunStatus.CANCELLED
+        socket.trigger(event, payload)
+        assert run.status is expected_status
+
+
+def test_async_event_iterator_and_wait_return_the_terminal_result(
+    auth_state: CachedAuth,
+    transport: tuple[FakeSession, FakeSocket],
+) -> None:
+    _session, socket = transport
+    client = make_client(auth_state, transport)
+    run = client.submit("Analyze")
+    socket.trigger("task_start", {"threadId": run.id})
+    socket.trigger(
+        "new_message",
+        {
+            "id": "final",
+            "threadId": run.id,
+            "type": "assistant_message",
+            "output": "Done",
+            "metadata": {"is_final_response": True},
+        },
+    )
+    socket.trigger("task_end", {"threadId": run.id})
+
+    async def consume() -> tuple[list[ThinkEvent], RunResult]:
+        events = [event async for event in run.aevents(timeout=1.0)]
+        outcome = await run.await_result(timeout=1.0)
+        assert isinstance(outcome, RunResult)
+        return events, outcome
+
+    events, result = asyncio.run(consume())
+    assert EventKind.COMPLETED in {event.kind for event in events}
+    assert result.output == "Done"
 
 
 @settings(max_examples=50, deadline=None, database=None)


### PR DESCRIPTION
## What changed

- adds typed structured progress phases, visible stream deltas, elapsed heartbeats, and a canonical coalescing terminal renderer
- adds one-call interactive clarification/plan handling while preserving manual `NeedsInput` control
- adds durable `cancel()` versus local `detach()`, reconnect-safe stop handling, and async event/result APIs
- exposes lazy structured result files, conversation history/resume, single-file downloads, and all-results tar downloads
- documents cached authentication, modes, chunked file submission, composable genetic/artifact/conversation context, Cloudflare routes, and notebook usage
- bumps the public package to 2.1.2

## Why

The original SDK could submit and wait, but long agent turns looked stuck, clarification required a manual loop, reconnect/cancel semantics were implicit, and protected artifacts were not first-class. The backend already emits structured progress metadata; this change makes that protocol usable from the public SDK without duplicating backend state.

## Validation

- `321 passed` across the full public Python package suite
- `75 passed` from the exact built wheel in an isolated target
- Ruff, mypy, and `git diff --check` pass
- built CPython 3.12 wheel and source distribution for 2.1.2
- production, strict-WebSocket, public-TLS canaries:
  - interactive clarification resumed and completed with 315 stream frames
  - backend search/think progress metadata parsed end-to-end
  - 11 MiB upload crossed the 10 MiB chunk boundary, then reconnected and durably cancelled
  - protected single-file and 16-file tar downloads completed
  - exact final wheel completed a 14-frame production run with generic progress coalesced
- no custom CA variables were used in production

## Deployment note

Think routes are already live-tested through Cloudflare. Optional legacy genetic-job discovery via `bystro.api.annotation.get_jobs` also needs the narrowly matched `/api/jobs*` path on `bystro.cloud`; origin authentication and authorization remain active.
